### PR TITLE
Reduce boilerplate by making a default client event.

### DIFF
--- a/examples/combat.rs
+++ b/examples/combat.rs
@@ -3,11 +3,10 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use log::LevelFilter;
 use valence::block::{BlockPos, BlockState};
-use valence::client::{Client, ClientEvent, ClientId, GameMode, Hand, InteractWithEntityKind};
+use valence::client::{ClientEvent, ClientId, GameMode, InteractWithEntityKind, default_client_event};
 use valence::config::{Config, ServerListPing};
 use valence::dimension::DimensionId;
-use valence::entity::types::Pose;
-use valence::entity::{Entity, EntityEvent, EntityId, EntityKind, TrackedData};
+use valence::entity::{EntityEvent, EntityId, EntityKind};
 use valence::player_list::PlayerListId;
 use valence::server::{Server, SharedServer, ShutdownResult};
 use valence::text::{Color, TextFormat};
@@ -205,7 +204,7 @@ impl Config for Game {
                     .get_mut(client.state.player)
                     .expect("missing player entity");
 
-                match client_event_boilerplate(client, player) {
+                match default_client_event(client, player) {
                     Some(ClientEvent::StartSprinting) => {
                         client.state.extra_knockback = true;
                     }
@@ -271,120 +270,4 @@ impl Config for Game {
             }
         }
     }
-}
-
-fn client_event_boilerplate(
-    client: &mut Client<Game>,
-    entity: &mut Entity<Game>,
-) -> Option<ClientEvent> {
-    let event = client.pop_event()?;
-
-    match &event {
-        ClientEvent::ChatMessage { .. } => {}
-        ClientEvent::SettingsChanged {
-            view_distance,
-            main_hand,
-            displayed_skin_parts,
-            ..
-        } => {
-            client.set_view_distance(*view_distance);
-
-            let player = client.player_mut();
-
-            player.set_cape(displayed_skin_parts.cape());
-            player.set_jacket(displayed_skin_parts.jacket());
-            player.set_left_sleeve(displayed_skin_parts.left_sleeve());
-            player.set_right_sleeve(displayed_skin_parts.right_sleeve());
-            player.set_left_pants_leg(displayed_skin_parts.left_pants_leg());
-            player.set_right_pants_leg(displayed_skin_parts.right_pants_leg());
-            player.set_hat(displayed_skin_parts.hat());
-            player.set_main_arm(*main_hand as u8);
-
-            if let TrackedData::Player(player) = entity.data_mut() {
-                player.set_cape(displayed_skin_parts.cape());
-                player.set_jacket(displayed_skin_parts.jacket());
-                player.set_left_sleeve(displayed_skin_parts.left_sleeve());
-                player.set_right_sleeve(displayed_skin_parts.right_sleeve());
-                player.set_left_pants_leg(displayed_skin_parts.left_pants_leg());
-                player.set_right_pants_leg(displayed_skin_parts.right_pants_leg());
-                player.set_hat(displayed_skin_parts.hat());
-                player.set_main_arm(*main_hand as u8);
-            }
-        }
-        ClientEvent::MovePosition {
-            position,
-            on_ground,
-        } => {
-            entity.set_position(*position);
-            entity.set_on_ground(*on_ground);
-        }
-        ClientEvent::MovePositionAndRotation {
-            position,
-            yaw,
-            pitch,
-            on_ground,
-        } => {
-            entity.set_position(*position);
-            entity.set_yaw(*yaw);
-            entity.set_head_yaw(*yaw);
-            entity.set_pitch(*pitch);
-            entity.set_on_ground(*on_ground);
-        }
-        ClientEvent::MoveRotation {
-            yaw,
-            pitch,
-            on_ground,
-        } => {
-            entity.set_yaw(*yaw);
-            entity.set_head_yaw(*yaw);
-            entity.set_pitch(*pitch);
-            entity.set_on_ground(*on_ground);
-        }
-        ClientEvent::MoveOnGround { on_ground } => {
-            entity.set_on_ground(*on_ground);
-        }
-        ClientEvent::MoveVehicle { .. } => {}
-        ClientEvent::StartSneaking => {
-            if let TrackedData::Player(player) = entity.data_mut() {
-                if player.get_pose() == Pose::Standing {
-                    player.set_pose(Pose::Sneaking);
-                }
-            }
-        }
-        ClientEvent::StopSneaking => {
-            if let TrackedData::Player(player) = entity.data_mut() {
-                if player.get_pose() == Pose::Sneaking {
-                    player.set_pose(Pose::Standing);
-                }
-            }
-        }
-        ClientEvent::StartSprinting => {
-            if let TrackedData::Player(player) = entity.data_mut() {
-                player.set_sprinting(true);
-            }
-        }
-        ClientEvent::StopSprinting => {
-            if let TrackedData::Player(player) = entity.data_mut() {
-                player.set_sprinting(false);
-            }
-        }
-        ClientEvent::StartJumpWithHorse { .. } => {}
-        ClientEvent::StopJumpWithHorse => {}
-        ClientEvent::LeaveBed => {}
-        ClientEvent::OpenHorseInventory => {}
-        ClientEvent::StartFlyingWithElytra => {}
-        ClientEvent::ArmSwing(hand) => {
-            entity.push_event(match hand {
-                Hand::Main => EntityEvent::SwingMainHand,
-                Hand::Off => EntityEvent::SwingOffHand,
-            });
-        }
-        ClientEvent::InteractWithEntity { .. } => {}
-        ClientEvent::SteerBoat { .. } => {}
-        ClientEvent::Digging { .. } => {}
-    }
-
-    entity.set_world(client.world());
-
-    Some(event)
 }

--- a/examples/conway.rs
+++ b/examples/conway.rs
@@ -7,11 +7,11 @@ use num::Integer;
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
 use valence::biome::Biome;
 use valence::block::BlockState;
-use valence::client::{Client, ClientEvent, Hand};
+use valence::client::{ClientEvent, default_client_event};
 use valence::config::{Config, ServerListPing};
 use valence::dimension::{Dimension, DimensionId};
 use valence::entity::types::Pose;
-use valence::entity::{Entity, EntityEvent, EntityId, EntityKind, TrackedData};
+use valence::entity::{EntityId, EntityKind, TrackedData};
 use valence::player_list::PlayerListId;
 use valence::server::{Server, SharedServer, ShutdownResult};
 use valence::text::{Color, TextFormat};
@@ -49,8 +49,7 @@ struct ServerState {
 
 #[derive(Default)]
 struct ClientState {
-    entity_id: EntityId,
-    sneaking: bool,
+    entity_id: EntityId
 }
 
 const MAX_PLAYERS: usize = 10;
@@ -186,7 +185,7 @@ impl Config for Game {
                 server.state.board.fill(false);
             }
 
-            while let Some(event) = client_event_boilerplate(client, player) {
+            while let Some(event) = default_client_event(client, player) {
                 match event {
                     ClientEvent::Digging { position, .. } => {
                         if (0..SIZE_X as i32).contains(&position.x)
@@ -197,18 +196,12 @@ impl Config for Game {
                                 [position.x as usize + position.z as usize * SIZE_X] = true;
                         }
                     }
-                    ClientEvent::StartSneaking => {
-                        client.state.sneaking = true;
-                    }
-                    ClientEvent::StopSneaking => {
-                        client.state.sneaking = false;
-                    }
                     _ => {}
                 }
             }
 
-            if client.state.sneaking {
-                server.state.paused = true;
+            if let TrackedData::Player(data) = player.data() {
+                server.state.paused = data.get_pose() == Pose::Sneaking;
             }
 
             true
@@ -273,120 +266,4 @@ impl Config for Game {
             }
         }
     }
-}
-
-fn client_event_boilerplate(
-    client: &mut Client<Game>,
-    entity: &mut Entity<Game>,
-) -> Option<ClientEvent> {
-    let event = client.pop_event()?;
-
-    match &event {
-        ClientEvent::ChatMessage { .. } => {}
-        ClientEvent::SettingsChanged {
-            view_distance,
-            main_hand,
-            displayed_skin_parts,
-            ..
-        } => {
-            client.set_view_distance(*view_distance);
-
-            let player = client.player_mut();
-
-            player.set_cape(displayed_skin_parts.cape());
-            player.set_jacket(displayed_skin_parts.jacket());
-            player.set_left_sleeve(displayed_skin_parts.left_sleeve());
-            player.set_right_sleeve(displayed_skin_parts.right_sleeve());
-            player.set_left_pants_leg(displayed_skin_parts.left_pants_leg());
-            player.set_right_pants_leg(displayed_skin_parts.right_pants_leg());
-            player.set_hat(displayed_skin_parts.hat());
-            player.set_main_arm(*main_hand as u8);
-
-            if let TrackedData::Player(player) = entity.data_mut() {
-                player.set_cape(displayed_skin_parts.cape());
-                player.set_jacket(displayed_skin_parts.jacket());
-                player.set_left_sleeve(displayed_skin_parts.left_sleeve());
-                player.set_right_sleeve(displayed_skin_parts.right_sleeve());
-                player.set_left_pants_leg(displayed_skin_parts.left_pants_leg());
-                player.set_right_pants_leg(displayed_skin_parts.right_pants_leg());
-                player.set_hat(displayed_skin_parts.hat());
-                player.set_main_arm(*main_hand as u8);
-            }
-        }
-        ClientEvent::MovePosition {
-            position,
-            on_ground,
-        } => {
-            entity.set_position(*position);
-            entity.set_on_ground(*on_ground);
-        }
-        ClientEvent::MovePositionAndRotation {
-            position,
-            yaw,
-            pitch,
-            on_ground,
-        } => {
-            entity.set_position(*position);
-            entity.set_yaw(*yaw);
-            entity.set_head_yaw(*yaw);
-            entity.set_pitch(*pitch);
-            entity.set_on_ground(*on_ground);
-        }
-        ClientEvent::MoveRotation {
-            yaw,
-            pitch,
-            on_ground,
-        } => {
-            entity.set_yaw(*yaw);
-            entity.set_head_yaw(*yaw);
-            entity.set_pitch(*pitch);
-            entity.set_on_ground(*on_ground);
-        }
-        ClientEvent::MoveOnGround { on_ground } => {
-            entity.set_on_ground(*on_ground);
-        }
-        ClientEvent::MoveVehicle { .. } => {}
-        ClientEvent::StartSneaking => {
-            if let TrackedData::Player(player) = entity.data_mut() {
-                if player.get_pose() == Pose::Standing {
-                    player.set_pose(Pose::Sneaking);
-                }
-            }
-        }
-        ClientEvent::StopSneaking => {
-            if let TrackedData::Player(player) = entity.data_mut() {
-                if player.get_pose() == Pose::Sneaking {
-                    player.set_pose(Pose::Standing);
-                }
-            }
-        }
-        ClientEvent::StartSprinting => {
-            if let TrackedData::Player(player) = entity.data_mut() {
-                player.set_sprinting(true);
-            }
-        }
-        ClientEvent::StopSprinting => {
-            if let TrackedData::Player(player) = entity.data_mut() {
-                player.set_sprinting(false);
-            }
-        }
-        ClientEvent::StartJumpWithHorse { .. } => {}
-        ClientEvent::StopJumpWithHorse => {}
-        ClientEvent::LeaveBed => {}
-        ClientEvent::OpenHorseInventory => {}
-        ClientEvent::StartFlyingWithElytra => {}
-        ClientEvent::ArmSwing(hand) => {
-            entity.push_event(match hand {
-                Hand::Main => EntityEvent::SwingMainHand,
-                Hand::Off => EntityEvent::SwingOffHand,
-            });
-        }
-        ClientEvent::InteractWithEntity { .. } => {}
-        ClientEvent::SteerBoat { .. } => {}
-        ClientEvent::Digging { .. } => {}
-    }
-
-    entity.set_world(client.world());
-
-    Some(event)
 }

--- a/examples/cow_sphere.rs
+++ b/examples/cow_sphere.rs
@@ -5,11 +5,10 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use log::LevelFilter;
 use valence::async_trait;
 use valence::block::{BlockPos, BlockState};
-use valence::client::{Client, ClientEvent, GameMode, Hand};
+use valence::client::{GameMode, default_client_event};
 use valence::config::{Config, ServerListPing};
 use valence::dimension::DimensionId;
-use valence::entity::types::Pose;
-use valence::entity::{Entity, EntityEvent, EntityId, EntityKind, TrackedData};
+use valence::entity::{EntityId, EntityKind};
 use valence::player_list::PlayerListId;
 use valence::server::{Server, SharedServer, ShutdownResult};
 use valence::text::{Color, TextFormat};
@@ -162,7 +161,7 @@ impl Config for Game {
                 .get_mut(client.state)
                 .expect("missing player entity");
 
-            while client_event_boilerplate(client, entity).is_some() {}
+            while default_client_event(client, entity).is_some() {}
 
             true
         });
@@ -222,120 +221,4 @@ fn fibonacci_spiral(n: usize) -> impl Iterator<Item = Vec3<f64>> {
         let phi = (1.0 - 2.0 * y).acos();
         Vec3::new(theta.cos() * phi.sin(), theta.sin() * phi.sin(), phi.cos())
     })
-}
-
-fn client_event_boilerplate(
-    client: &mut Client<Game>,
-    entity: &mut Entity<Game>,
-) -> Option<ClientEvent> {
-    let event = client.pop_event()?;
-
-    match &event {
-        ClientEvent::ChatMessage { .. } => {}
-        ClientEvent::SettingsChanged {
-            view_distance,
-            main_hand,
-            displayed_skin_parts,
-            ..
-        } => {
-            client.set_view_distance(*view_distance);
-
-            let player = client.player_mut();
-
-            player.set_cape(displayed_skin_parts.cape());
-            player.set_jacket(displayed_skin_parts.jacket());
-            player.set_left_sleeve(displayed_skin_parts.left_sleeve());
-            player.set_right_sleeve(displayed_skin_parts.right_sleeve());
-            player.set_left_pants_leg(displayed_skin_parts.left_pants_leg());
-            player.set_right_pants_leg(displayed_skin_parts.right_pants_leg());
-            player.set_hat(displayed_skin_parts.hat());
-            player.set_main_arm(*main_hand as u8);
-
-            if let TrackedData::Player(player) = entity.data_mut() {
-                player.set_cape(displayed_skin_parts.cape());
-                player.set_jacket(displayed_skin_parts.jacket());
-                player.set_left_sleeve(displayed_skin_parts.left_sleeve());
-                player.set_right_sleeve(displayed_skin_parts.right_sleeve());
-                player.set_left_pants_leg(displayed_skin_parts.left_pants_leg());
-                player.set_right_pants_leg(displayed_skin_parts.right_pants_leg());
-                player.set_hat(displayed_skin_parts.hat());
-                player.set_main_arm(*main_hand as u8);
-            }
-        }
-        ClientEvent::MovePosition {
-            position,
-            on_ground,
-        } => {
-            entity.set_position(*position);
-            entity.set_on_ground(*on_ground);
-        }
-        ClientEvent::MovePositionAndRotation {
-            position,
-            yaw,
-            pitch,
-            on_ground,
-        } => {
-            entity.set_position(*position);
-            entity.set_yaw(*yaw);
-            entity.set_head_yaw(*yaw);
-            entity.set_pitch(*pitch);
-            entity.set_on_ground(*on_ground);
-        }
-        ClientEvent::MoveRotation {
-            yaw,
-            pitch,
-            on_ground,
-        } => {
-            entity.set_yaw(*yaw);
-            entity.set_head_yaw(*yaw);
-            entity.set_pitch(*pitch);
-            entity.set_on_ground(*on_ground);
-        }
-        ClientEvent::MoveOnGround { on_ground } => {
-            entity.set_on_ground(*on_ground);
-        }
-        ClientEvent::MoveVehicle { .. } => {}
-        ClientEvent::StartSneaking => {
-            if let TrackedData::Player(player) = entity.data_mut() {
-                if player.get_pose() == Pose::Standing {
-                    player.set_pose(Pose::Sneaking);
-                }
-            }
-        }
-        ClientEvent::StopSneaking => {
-            if let TrackedData::Player(player) = entity.data_mut() {
-                if player.get_pose() == Pose::Sneaking {
-                    player.set_pose(Pose::Standing);
-                }
-            }
-        }
-        ClientEvent::StartSprinting => {
-            if let TrackedData::Player(player) = entity.data_mut() {
-                player.set_sprinting(true);
-            }
-        }
-        ClientEvent::StopSprinting => {
-            if let TrackedData::Player(player) = entity.data_mut() {
-                player.set_sprinting(false);
-            }
-        }
-        ClientEvent::StartJumpWithHorse { .. } => {}
-        ClientEvent::StopJumpWithHorse => {}
-        ClientEvent::LeaveBed => {}
-        ClientEvent::OpenHorseInventory => {}
-        ClientEvent::StartFlyingWithElytra => {}
-        ClientEvent::ArmSwing(hand) => {
-            entity.push_event(match hand {
-                Hand::Main => EntityEvent::SwingMainHand,
-                Hand::Off => EntityEvent::SwingOffHand,
-            });
-        }
-        ClientEvent::InteractWithEntity { .. } => {}
-        ClientEvent::SteerBoat { .. } => {}
-        ClientEvent::Digging { .. } => {}
-    }
-
-    entity.set_world(client.world());
-
-    Some(event)
 }

--- a/examples/raycast.rs
+++ b/examples/raycast.rs
@@ -4,11 +4,10 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use log::LevelFilter;
 use valence::async_trait;
 use valence::block::{BlockPos, BlockState};
-use valence::client::{Client, ClientEvent, GameMode, Hand};
+use valence::client::{GameMode, default_client_event};
 use valence::config::{Config, ServerListPing};
 use valence::dimension::DimensionId;
-use valence::entity::types::Pose;
-use valence::entity::{Entity, EntityEvent, EntityId, EntityKind, TrackedData};
+use valence::entity::{EntityId, EntityKind, TrackedData};
 use valence::player_list::PlayerListId;
 use valence::server::{Server, SharedServer, ShutdownResult};
 use valence::spatial_index::RaycastHit;
@@ -38,7 +37,10 @@ const MAX_PLAYERS: usize = 10;
 
 const SPAWN_POS: BlockPos = BlockPos::new(0, 100, -5);
 
-const PLAYER_EYE_HEIGHT: f64 = 1.6;
+const PLAYER_EYE_HEIGHT: f64 = 1.62;
+
+// TODO
+// const PLAYER_SNEAKING_EYE_HEIGHT: f64 = 1.495;
 
 #[async_trait]
 impl Config for Game {
@@ -180,7 +182,7 @@ impl Config for Game {
                 }
             }
 
-            while client_event_boilerplate(client, server.entities.get_mut(client.state).unwrap())
+            while default_client_event(client, server.entities.get_mut(client.state).unwrap())
                 .is_some()
             {}
 
@@ -199,120 +201,4 @@ impl Config for Game {
             e.state = false;
         }
     }
-}
-
-fn client_event_boilerplate(
-    client: &mut Client<Game>,
-    entity: &mut Entity<Game>,
-) -> Option<ClientEvent> {
-    let event = client.pop_event()?;
-
-    match &event {
-        ClientEvent::ChatMessage { .. } => {}
-        ClientEvent::SettingsChanged {
-            view_distance,
-            main_hand,
-            displayed_skin_parts,
-            ..
-        } => {
-            client.set_view_distance(*view_distance);
-
-            let player = client.player_mut();
-
-            player.set_cape(displayed_skin_parts.cape());
-            player.set_jacket(displayed_skin_parts.jacket());
-            player.set_left_sleeve(displayed_skin_parts.left_sleeve());
-            player.set_right_sleeve(displayed_skin_parts.right_sleeve());
-            player.set_left_pants_leg(displayed_skin_parts.left_pants_leg());
-            player.set_right_pants_leg(displayed_skin_parts.right_pants_leg());
-            player.set_hat(displayed_skin_parts.hat());
-            player.set_main_arm(*main_hand as u8);
-
-            if let TrackedData::Player(player) = entity.data_mut() {
-                player.set_cape(displayed_skin_parts.cape());
-                player.set_jacket(displayed_skin_parts.jacket());
-                player.set_left_sleeve(displayed_skin_parts.left_sleeve());
-                player.set_right_sleeve(displayed_skin_parts.right_sleeve());
-                player.set_left_pants_leg(displayed_skin_parts.left_pants_leg());
-                player.set_right_pants_leg(displayed_skin_parts.right_pants_leg());
-                player.set_hat(displayed_skin_parts.hat());
-                player.set_main_arm(*main_hand as u8);
-            }
-        }
-        ClientEvent::MovePosition {
-            position,
-            on_ground,
-        } => {
-            entity.set_position(*position);
-            entity.set_on_ground(*on_ground);
-        }
-        ClientEvent::MovePositionAndRotation {
-            position,
-            yaw,
-            pitch,
-            on_ground,
-        } => {
-            entity.set_position(*position);
-            entity.set_yaw(*yaw);
-            entity.set_head_yaw(*yaw);
-            entity.set_pitch(*pitch);
-            entity.set_on_ground(*on_ground);
-        }
-        ClientEvent::MoveRotation {
-            yaw,
-            pitch,
-            on_ground,
-        } => {
-            entity.set_yaw(*yaw);
-            entity.set_head_yaw(*yaw);
-            entity.set_pitch(*pitch);
-            entity.set_on_ground(*on_ground);
-        }
-        ClientEvent::MoveOnGround { on_ground } => {
-            entity.set_on_ground(*on_ground);
-        }
-        ClientEvent::MoveVehicle { .. } => {}
-        ClientEvent::StartSneaking => {
-            if let TrackedData::Player(player) = entity.data_mut() {
-                if player.get_pose() == Pose::Standing {
-                    player.set_pose(Pose::Sneaking);
-                }
-            }
-        }
-        ClientEvent::StopSneaking => {
-            if let TrackedData::Player(player) = entity.data_mut() {
-                if player.get_pose() == Pose::Sneaking {
-                    player.set_pose(Pose::Standing);
-                }
-            }
-        }
-        ClientEvent::StartSprinting => {
-            if let TrackedData::Player(player) = entity.data_mut() {
-                player.set_sprinting(true);
-            }
-        }
-        ClientEvent::StopSprinting => {
-            if let TrackedData::Player(player) = entity.data_mut() {
-                player.set_sprinting(false);
-            }
-        }
-        ClientEvent::StartJumpWithHorse { .. } => {}
-        ClientEvent::StopJumpWithHorse => {}
-        ClientEvent::LeaveBed => {}
-        ClientEvent::OpenHorseInventory => {}
-        ClientEvent::StartFlyingWithElytra => {}
-        ClientEvent::ArmSwing(hand) => {
-            entity.push_event(match hand {
-                Hand::Main => EntityEvent::SwingMainHand,
-                Hand::Off => EntityEvent::SwingOffHand,
-            });
-        }
-        ClientEvent::InteractWithEntity { .. } => {}
-        ClientEvent::SteerBoat { .. } => {}
-        ClientEvent::Digging { .. } => {}
-    }
-
-    entity.set_world(client.world());
-
-    Some(event)
 }

--- a/examples/terrain.rs
+++ b/examples/terrain.rs
@@ -7,11 +7,10 @@ use rayon::iter::ParallelIterator;
 use valence::async_trait;
 use valence::block::{BlockState, PropName, PropValue};
 use valence::chunk::ChunkPos;
-use valence::client::{Client, ClientEvent, GameMode, Hand};
+use valence::client::{GameMode, default_client_event};
 use valence::config::{Config, ServerListPing};
 use valence::dimension::DimensionId;
-use valence::entity::types::Pose;
-use valence::entity::{Entity, EntityEvent, EntityId, EntityKind, TrackedData};
+use valence::entity::{EntityId, EntityKind};
 use valence::player_list::PlayerListId;
 use valence::server::{Server, SharedServer, ShutdownResult};
 use valence::text::{Color, TextFormat};
@@ -142,7 +141,7 @@ impl Config for Game {
             }
 
             if let Some(entity) = server.entities.get_mut(client.state) {
-                while client_event_boilerplate(client, entity).is_some() {}
+                while default_client_event(client, entity).is_some() {}
             }
 
             let dist = client.view_distance();
@@ -346,120 +345,4 @@ fn fbm(noise: &SuperSimplex, p: [f64; 3], octaves: u32, lacunarity: f64, persist
 
 fn noise01(noise: &SuperSimplex, xyz: [f64; 3]) -> f64 {
     (noise.get(xyz) + 1.0) / 2.0
-}
-
-fn client_event_boilerplate(
-    client: &mut Client<Game>,
-    entity: &mut Entity<Game>,
-) -> Option<ClientEvent> {
-    let event = client.pop_event()?;
-
-    match &event {
-        ClientEvent::ChatMessage { .. } => {}
-        ClientEvent::SettingsChanged {
-            view_distance,
-            main_hand,
-            displayed_skin_parts,
-            ..
-        } => {
-            client.set_view_distance(*view_distance);
-
-            let player = client.player_mut();
-
-            player.set_cape(displayed_skin_parts.cape());
-            player.set_jacket(displayed_skin_parts.jacket());
-            player.set_left_sleeve(displayed_skin_parts.left_sleeve());
-            player.set_right_sleeve(displayed_skin_parts.right_sleeve());
-            player.set_left_pants_leg(displayed_skin_parts.left_pants_leg());
-            player.set_right_pants_leg(displayed_skin_parts.right_pants_leg());
-            player.set_hat(displayed_skin_parts.hat());
-            player.set_main_arm(*main_hand as u8);
-
-            if let TrackedData::Player(player) = entity.data_mut() {
-                player.set_cape(displayed_skin_parts.cape());
-                player.set_jacket(displayed_skin_parts.jacket());
-                player.set_left_sleeve(displayed_skin_parts.left_sleeve());
-                player.set_right_sleeve(displayed_skin_parts.right_sleeve());
-                player.set_left_pants_leg(displayed_skin_parts.left_pants_leg());
-                player.set_right_pants_leg(displayed_skin_parts.right_pants_leg());
-                player.set_hat(displayed_skin_parts.hat());
-                player.set_main_arm(*main_hand as u8);
-            }
-        }
-        ClientEvent::MovePosition {
-            position,
-            on_ground,
-        } => {
-            entity.set_position(*position);
-            entity.set_on_ground(*on_ground);
-        }
-        ClientEvent::MovePositionAndRotation {
-            position,
-            yaw,
-            pitch,
-            on_ground,
-        } => {
-            entity.set_position(*position);
-            entity.set_yaw(*yaw);
-            entity.set_head_yaw(*yaw);
-            entity.set_pitch(*pitch);
-            entity.set_on_ground(*on_ground);
-        }
-        ClientEvent::MoveRotation {
-            yaw,
-            pitch,
-            on_ground,
-        } => {
-            entity.set_yaw(*yaw);
-            entity.set_head_yaw(*yaw);
-            entity.set_pitch(*pitch);
-            entity.set_on_ground(*on_ground);
-        }
-        ClientEvent::MoveOnGround { on_ground } => {
-            entity.set_on_ground(*on_ground);
-        }
-        ClientEvent::MoveVehicle { .. } => {}
-        ClientEvent::StartSneaking => {
-            if let TrackedData::Player(player) = entity.data_mut() {
-                if player.get_pose() == Pose::Standing {
-                    player.set_pose(Pose::Sneaking);
-                }
-            }
-        }
-        ClientEvent::StopSneaking => {
-            if let TrackedData::Player(player) = entity.data_mut() {
-                if player.get_pose() == Pose::Sneaking {
-                    player.set_pose(Pose::Standing);
-                }
-            }
-        }
-        ClientEvent::StartSprinting => {
-            if let TrackedData::Player(player) = entity.data_mut() {
-                player.set_sprinting(true);
-            }
-        }
-        ClientEvent::StopSprinting => {
-            if let TrackedData::Player(player) = entity.data_mut() {
-                player.set_sprinting(false);
-            }
-        }
-        ClientEvent::StartJumpWithHorse { .. } => {}
-        ClientEvent::StopJumpWithHorse => {}
-        ClientEvent::LeaveBed => {}
-        ClientEvent::OpenHorseInventory => {}
-        ClientEvent::StartFlyingWithElytra => {}
-        ClientEvent::ArmSwing(hand) => {
-            entity.push_event(match hand {
-                Hand::Main => EntityEvent::SwingMainHand,
-                Hand::Off => EntityEvent::SwingOffHand,
-            });
-        }
-        ClientEvent::InteractWithEntity { .. } => {}
-        ClientEvent::SteerBoat { .. } => {}
-        ClientEvent::Digging { .. } => {}
-    }
-
-    entity.set_world(client.world());
-
-    Some(event)
 }


### PR DESCRIPTION
This adds an (encouraged) default client event from the examples to reduce confusion for examples.