### PR TITLE
Fix order of chunk creation in conway's example

### DIFF
--- a/examples/conway.rs
+++ b/examples/conway.rs
@@ -107,8 +107,8 @@ impl Config for Game {
         let world = server.worlds.insert(DimensionId::default(), ()).1;
         server.state.player_list = Some(server.player_lists.insert(()).0);
 
-        for chunk_z in -2..Integer::div_ceil(&(SIZE_X as i32), &16) + 2 {
-            for chunk_x in -2..Integer::div_ceil(&(SIZE_Z as i32), &16) + 2 {
+        for chunk_z in -2..Integer::div_ceil(&(SIZE_Z as i32), &16) + 2 {
+            for chunk_x in -2..Integer::div_ceil(&(SIZE_X as i32), &16) + 2 {
                 world.chunks.insert((chunk_x as i32, chunk_z as i32), ());
             }
         }


### PR DESCRIPTION
This would typically go unnoticed, but upon expanding the and making meaningful use of both directions, this being an issue arises.