### PR TITLE
prevent typing in chat from kicking players

### DIFF
--- a/src/protocol/codec.rs
+++ b/src/protocol/codec.rs
@@ -196,12 +196,12 @@ impl<R: AsyncRead + Unpin> Decoder<R> {
                     .context("decompressing packet body")?;
 
                 let mut decompressed = self.decompress_buf.as_slice();
-                let packet = P::decode_packet(&mut decompressed)
-                    .context("decoding packet after decompressing")?;
                 ensure!(
                     decompressed.is_empty(),
                     "packet contents were not read completely"
                 );
+                let packet = P::decode_packet(&mut decompressed)
+                    .context("decoding packet after decompressing")?;
                 packet
             } else {
                 P::decode_packet(&mut packet_contents).context("decoding packet")?


### PR DESCRIPTION
Simply move the assertion for decompressed packet contents, because `P::decode_packet` consumes the packet it is given. It might be a good idea to consider just passing ownership of `decompressed` rather than `&mut decompressed` to make this behavior more clear. Not allowing `P::decode_packet` to modify the packet would also be a good solution.

fixes #24

# Test plan

run
```
cargo r -r --example conway
```

- connect to server on localhost
- type in chat
- see that you don't get kicked
- the chat message does not appear in chat (out of scope for this PR)
