### PR TITLE
Update definition for ChatMessage and CommandExecution

### DIFF
--- a/src/protocol/codec.rs
+++ b/src/protocol/codec.rs
@@ -200,7 +200,10 @@ impl<R: AsyncRead + Unpin> Decoder<R> {
                     .context("decoding packet after decompressing")?;
                 ensure!(
                     decompressed.is_empty(),
-                    "packet contents were not read completely"
+                    format!(
+                        "packet contents were not read completely, {} remaining bytes",
+                        decompressed.len()
+                    )
                 );
                 packet
             } else {

--- a/src/protocol/packets/c2s.rs
+++ b/src/protocol/packets/c2s.rs
@@ -123,8 +123,15 @@ pub mod play {
     }
 
     def_struct! {
+        MessageAcknowledgmentList {
+            entries: Vec<MessageAcknowledgmentEntry>,
+        }
+    }
+
+    def_struct! {
         MessageAcknowledgment {
-            entry: Option<MessageAcknowledgmentEntry>,
+            last_seen: MessageAcknowledgmentList,
+            last_received: Option<MessageAcknowledgmentEntry>,
         }
     }
 
@@ -150,6 +157,7 @@ pub mod play {
             salt: u64,
             signature: Vec<u8>,
             signed_preview: bool,
+            acknowledgement: MessageAcknowledgment,
         }
     }
 

--- a/src/protocol/packets/c2s.rs
+++ b/src/protocol/packets/c2s.rs
@@ -143,10 +143,20 @@ pub mod play {
     }
 
     def_struct! {
+        ArgumentSignatureEntry {
+            name: BoundedString<0, 16>,
+            signature: Vec<u8>,
+        }
+    }
+
+    def_struct! {
         CommandExecution {
-            command: String, // TODO: bounded?
-            // TODO: timestamp, arg signatures
+            command: BoundedString<0, 256>,
+            timestamp: u64,
+            salt: u64,
+            arg_sig: Vec<ArgumentSignatureEntry>,
             signed_preview: bool,
+            acknowledgement: MessageAcknowledgment,
         }
     }
 


### PR DESCRIPTION
fixes #24

I went ahead and updated `CommandExecution` too since these 2 packets are similar.

# Test plan

1. run `cargo r -r --example terrain`
2. run mc and join localhost
3. type any non command in chat
4. type `/help` in chat
5. see that you don't get kicked
