### PR TITLE
Added SetExperience and SetHealth packets

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -32,11 +32,11 @@ use crate::protocol::packets::s2c::play::{
     BiomeRegistry, ChatTypeRegistry, ChunkLoadDistance, ChunkRenderDistanceCenter, ClearTitles,
     DimensionTypeRegistry, DimensionTypeRegistryEntry, Disconnect, EntitiesDestroy,
     EntityAnimation, EntityAttributes, EntityAttributesProperty, EntityPosition, EntitySetHeadYaw,
-    EntityStatus, EntityTrackerUpdate, EntityVelocityUpdate, GameJoin, GameMessage,
-    GameStateChange, GameStateChangeReason, KeepAlive, MoveRelative, OverlayMessage, PlaySoundId,
-    PlayerActionResponse, PlayerPositionLook, PlayerPositionLookFlags, PlayerRespawn,
-    PlayerSpawnPosition, RegistryCodec, Rotate, RotateAndMoveRelative, S2cPlayPacket,
-    SoundCategory, UnloadChunk, UpdateSubtitle, UpdateTitle,
+    EntityStatus, EntityTrackerUpdate, EntityVelocityUpdate, ExperienceBarUpdate, GameJoin,
+    GameMessage, GameStateChange, GameStateChangeReason, HealthUpdate, KeepAlive, MoveRelative,
+    OverlayMessage, PlaySoundId, PlayerActionResponse, PlayerPositionLook, PlayerPositionLookFlags,
+    PlayerRespawn, PlayerSpawnPosition, RegistryCodec, Rotate, RotateAndMoveRelative,
+    S2cPlayPacket, SoundCategory, UnloadChunk, UpdateSubtitle, UpdateTitle,
 };
 use crate::protocol::{BoundedInt, ByteAngle, NbtBridge, RawBytes, VarInt};
 use crate::server::{C2sPacketChannels, NewClientData, S2cPlayMessage, SharedServer};
@@ -542,6 +542,35 @@ impl<C: Config> Client<C> {
     /// Removes the current title from the client's screen.
     pub fn clear_title(&mut self) {
         self.send_packet(ClearTitles { reset: true });
+    }
+
+    /// Sets the XP bar visible above hotbar and total experience.
+    ///
+    /// # Arguments
+    /// * `bar` - Floating value in the range `0.0..=1.0` indicating progress on the XP bar.
+    /// * `level` - Number above the XP bar.
+    /// * `total_xp` - TODO.
+    pub fn set_level(&mut self, bar: f32, level: i32, total_xp: i32) {
+        self.send_packet(ExperienceBarUpdate {
+            bar,
+            level: level.into(),
+            total_xp: total_xp.into(),
+        })
+    }
+
+    /// Sets the health and food of the player.
+    /// You can read more about hunger and saturation [here](https://minecraft.fandom.com/wiki/Food#Hunger_vs._Saturation).
+    ///
+    /// # Arguments
+    /// * `health` - Float in range `0.0..=20.0`. Value `<=0` is legal and will kill the player.
+    /// * `food` - Integer in range `0..=20`.
+    /// * `food_saturation` - Float in range `0.0..=5.0`.
+    pub fn set_health_and_food(&mut self, health: f32, food: i32, food_saturation: f32) {
+        self.send_packet(HealthUpdate {
+            health,
+            food: food.into(),
+            food_saturation,
+        })
     }
 
     /// Gets whether or not the client is connected to the server.

--- a/src/protocol/packets/s2c.rs
+++ b/src/protocol/packets/s2c.rs
@@ -702,7 +702,7 @@ pub mod play {
     }
 
     def_struct! {
-        SetExperience {
+        ExperienceBarUpdate {
             bar: f32,
             level: VarInt,
             total_xp: VarInt,
@@ -710,7 +710,7 @@ pub mod play {
     }
 
     def_struct! {
-        SetHealth {
+        HealthUpdate {
             health: f32,
             food: VarInt,
             food_saturation: f32,
@@ -859,8 +859,8 @@ pub mod play {
             PlayerSpawnPosition = 77,
             EntityTrackerUpdate = 80,
             EntityVelocityUpdate = 82,
-            SetExperience = 84,
-            SetHealth = 85,
+            ExperienceBarUpdate = 84,
+            HealthUpdate = 85,
             UpdateSubtitle = 91,
             WorldTimeUpdate = 92,
             UpdateTitle = 93,

--- a/src/protocol/packets/s2c.rs
+++ b/src/protocol/packets/s2c.rs
@@ -702,6 +702,22 @@ pub mod play {
     }
 
     def_struct! {
+        SetExperience {
+            bar: f32,
+            level: VarInt,
+            total_xp: VarInt,
+        }
+    }
+
+    def_struct! {
+        SetHealth {
+            health: f32,
+            food: VarInt,
+            food_saturation: f32,
+        }
+    }
+
+    def_struct! {
         UpdateSubtitle {
             subtitle_text: Text,
         }
@@ -843,6 +859,8 @@ pub mod play {
             PlayerSpawnPosition = 77,
             EntityTrackerUpdate = 80,
             EntityVelocityUpdate = 82,
+            SetExperience = 84,
+            SetHealth = 85,
             UpdateSubtitle = 91,
             WorldTimeUpdate = 92,
             UpdateTitle = 93,


### PR DESCRIPTION
[edit]
This PR implements [ExperienceBarUpdate](https://wiki.vg/Protocol#Set_Experience) and [HealthUpdate](https://wiki.vg/Protocol#Set_Health) packets.

I decided not to introduce a new field for Total Experience, health or hunger on `Client`, storing that data and conversion between Total Experience and level with xp bar would be handled downstream.

There are two new functions on `Client`, `set_level` and `set_health_and_food`.
Their docs describe ranges of the arguments.
It is ok to send these packets on the same tick player connected, that is why I chose not to defer sending them.

Setting total_xp has no effect on the score on death screen, so I have no idea what it does. There is a todo in `set_level` docs.

## Tests
### `HealthUpdate`
* Send packet on the same tick player connected
    * Outcome: packet **can** be sent on the same tick player connected (right after `GameJoin` packet)
* Send packet to player in creative mode
    * Outcome: works as expected, after changing gamemode back to survival, health bar was changed
* Send packet with health `<= 0`
    * Outcome: player dies. (Player is stuck now because respawn button does not work).
* Send packet with food `<= 0`, or food_saturation `<= 0`
    * Outcome: client does not crash, we can test and document this later when eating works.

### `ExperienceBarUpdate`
* Send packet on the same tick player connected
    * Outcome: packet **can** be sent on the same tick player connected (right after `GameJoin` packet)
* Send packet to player in creative mode
    * Outcome: works as expected, after changing gamemode back to survival, xp bar was changed
* Send packet with negative `total_xp`
    * Outcome: client did not crash

### Docs
* Documentation for the new helpers `set_level` and `set_health_and_food` rendered correctly.
---
Old:

Packets were tested manually.

API-wise, should these packets have a method on `Client`? If so, I will append this PR.

Also, it seems [Set Experience](https://wiki.vg/Protocol#Set_Experience) allows to set fields inconsistently (for example as `Total Experience = 0` and `Level = 5`). I couldn't find, if that could cause issues.