### PR TITLE
Add sample players when client requests ping list

### DIFF
--- a/examples/combat.rs
+++ b/examples/combat.rs
@@ -77,6 +77,7 @@ impl Config for Game {
         ServerListPing::Respond {
             online_players: self.player_count.load(Ordering::SeqCst) as i32,
             max_players: MAX_PLAYERS as i32,
+            sample_players: None,
             description: "Hello Valence!".color(Color::AQUA),
             favicon_png: Some(include_bytes!("../assets/favicon.png")),
         }

--- a/examples/conway.rs
+++ b/examples/conway.rs
@@ -98,6 +98,7 @@ impl Config for Game {
         ServerListPing::Respond {
             online_players: self.player_count.load(Ordering::SeqCst) as i32,
             max_players: MAX_PLAYERS as i32,
+            sample_players: None,
             description: "Hello Valence!".color(Color::AQUA),
             favicon_png: Some(include_bytes!("../assets/favicon.png")),
         }

--- a/examples/cow_sphere.rs
+++ b/examples/cow_sphere.rs
@@ -6,7 +6,7 @@ use log::LevelFilter;
 use valence::async_trait;
 use valence::block::{BlockPos, BlockState};
 use valence::client::{default_client_event, GameMode};
-use valence::config::{Config, ServerListPing};
+use valence::config::{Config, SampleListPing, ServerListPing};
 use valence::dimension::DimensionId;
 use valence::entity::{EntityId, EntityKind};
 use valence::player_list::PlayerListId;
@@ -65,9 +65,15 @@ impl Config for Game {
         _remote_addr: SocketAddr,
         _protocol_version: i32,
     ) -> ServerListPing {
+        let sample = vec![
+            "\u{00A7}6Hello",
+            "\u{00A7}6\u{00A7}oWelcome where Cows make a... Sphere",
+        ];
+
         ServerListPing::Respond {
             online_players: self.player_count.load(Ordering::SeqCst) as i32,
             max_players: MAX_PLAYERS as i32,
+            sample_players: Some(sample.into_iter().map(SampleListPing::from).collect()),
             description: "Hello Valence!".color(Color::AQUA),
             favicon_png: Some(include_bytes!("../assets/favicon.png")),
         }

--- a/examples/raycast.rs
+++ b/examples/raycast.rs
@@ -66,6 +66,7 @@ impl Config for Game {
         ServerListPing::Respond {
             online_players: self.player_count.load(Ordering::SeqCst) as i32,
             max_players: MAX_PLAYERS as i32,
+            sample_players: None,
             description: "Hello Valence!".color(Color::AQUA),
             favicon_png: Some(include_bytes!("../assets/favicon.png")),
         }

--- a/examples/terrain.rs
+++ b/examples/terrain.rs
@@ -73,6 +73,7 @@ impl Config for Game {
         ServerListPing::Respond {
             online_players: self.player_count.load(Ordering::SeqCst) as i32,
             max_players: MAX_PLAYERS as i32,
+            sample_players: None,
             description: "Hello Valence!".color(Color::AQUA),
             favicon_png: Some(include_bytes!("../assets/favicon.png")),
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -584,6 +584,7 @@ async fn handle_status<C: Config>(
         ServerListPing::Respond {
             online_players,
             max_players,
+            sample_players,
             description,
             favicon_png,
         } => {
@@ -595,7 +596,10 @@ async fn handle_status<C: Config>(
                 "players": {
                     "online": online_players,
                     "max": max_players,
-                    // TODO: player sample?
+                    "sample": match sample_players {
+                        Some(sample_list) => json!(sample_list),
+                        None => Value::String(String::new()),
+                    },
                 },
                 "description": description,
             });


### PR DESCRIPTION
This will allow to set any sample players with
custom names and ids, also it is possible to set
\u00A7 character to have colorful text

By the way, I'm kinda new to Rust, so any suggestion in this code would be amazing to keep improving