### PR TITLE
Split `Chunk` into loaded and unloaded types

### DIFF
--- a/examples/conway.rs
+++ b/examples/conway.rs
@@ -7,6 +7,7 @@ use num::Integer;
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
 use valence::biome::Biome;
 use valence::block::BlockState;
+use valence::chunk::{Chunk, UnloadedChunk};
 use valence::client::{default_client_event, ClientEvent, Hand};
 use valence::config::{Config, ServerListPing};
 use valence::dimension::{Dimension, DimensionId};
@@ -109,7 +110,11 @@ impl Config for Game {
 
         for chunk_z in -2..Integer::div_ceil(&(SIZE_Z as i32), &16) + 2 {
             for chunk_x in -2..Integer::div_ceil(&(SIZE_X as i32), &16) + 2 {
-                world.chunks.insert((chunk_x as i32, chunk_z as i32), ());
+                world.chunks.insert(
+                    [chunk_x as i32, chunk_z as i32],
+                    UnloadedChunk::default(),
+                    (),
+                );
             }
         }
     }

--- a/examples/cow_sphere.rs
+++ b/examples/cow_sphere.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use log::LevelFilter;
 use valence::async_trait;
 use valence::block::{BlockPos, BlockState};
+use valence::chunk::UnloadedChunk;
 use valence::client::{default_client_event, GameMode};
 use valence::config::{Config, ServerListPing};
 use valence::dimension::DimensionId;
@@ -80,7 +81,7 @@ impl Config for Game {
         let size = 5;
         for z in -size..size {
             for x in -size..size {
-                world.chunks.insert([x, z], ());
+                world.chunks.insert([x, z], UnloadedChunk::default(), ());
             }
         }
 

--- a/examples/raycast.rs
+++ b/examples/raycast.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use log::LevelFilter;
 use valence::async_trait;
 use valence::block::{BlockPos, BlockState};
+use valence::chunk::UnloadedChunk;
 use valence::client::{default_client_event, GameMode};
 use valence::config::{Config, ServerListPing};
 use valence::dimension::DimensionId;
@@ -78,7 +79,7 @@ impl Config for Game {
         let size = 5;
         for z in -size..size {
             for x in -size..size {
-                world.chunks.insert([x, z], ());
+                world.chunks.insert([x, z], UnloadedChunk::default(), ());
             }
         }
 

--- a/examples/terrain.rs
+++ b/examples/terrain.rs
@@ -6,7 +6,7 @@ use noise::{NoiseFn, Seedable, SuperSimplex};
 use rayon::iter::ParallelIterator;
 use valence::async_trait;
 use valence::block::{BlockState, PropName, PropValue};
-use valence::chunk::ChunkPos;
+use valence::chunk::{Chunk, ChunkPos, UnloadedChunk};
 use valence::client::{default_client_event, GameMode};
 use valence::config::{Config, ServerListPing};
 use valence::dimension::DimensionId;
@@ -151,7 +151,7 @@ impl Config for Game {
                 if let Some(chunk) = world.chunks.get_mut(pos) {
                     chunk.state = true;
                 } else {
-                    world.chunks.insert(pos, true);
+                    world.chunks.insert(pos, UnloadedChunk::default(), true);
                 }
             }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,7 +30,8 @@ pub trait Config: Sized + Send + Sync + UnwindSafe + RefUnwindSafe + 'static {
     type EntityState: Send + Sync;
     /// Custom state to store with every [`World`](crate::world::World).
     type WorldState: Send + Sync;
-    /// Custom state to store with every [`Chunk`](crate::chunk::Chunk).
+    /// Custom state to store with every
+    /// [`LoadedChunk`](crate::chunk::LoadedChunk).
     type ChunkState: Send + Sync;
     /// Custom state to store with every
     /// [`PlayerList`](crate::player_list::PlayerList).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //!
 //! In Valence, many types are owned by the library but given out as mutable
 //! references for the user to modify. Examples of such types include [`World`],
-//! [`Chunk`], [`Entity`], and [`Client`].
+//! [`LoadedChunk`], [`Entity`], and [`Client`].
 //!
 //! **You must not call [`mem::swap`] on these references (or any other
 //! function that would move their location in memory).** Doing so breaks
@@ -57,7 +57,7 @@
 //! [`Worlds`]: crate::world::Worlds
 //! [`World`]: crate::world::World
 //! [`Chunks`]: crate::chunk::Chunks
-//! [`Chunk`]: crate::chunk::Chunk
+//! [`LoadedChunk`]: crate::chunk::LoadedChunk
 //! [`Entity`]: crate::entity::Entity
 //! [`Client`]: crate::client::Client
 


### PR DESCRIPTION
These changes will pave the way for nonblocking terrain generation in `terrain.rs`.

Need to give it another look while I'm not so tired.