### PR TITLE
upgrade aes and cfb8 crates from 0.7 to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ build = "build/main.rs"
 authors = ["Ryan Johnson <ryanj00a@gmail.com>"]
 
 [dependencies]
-aes = "0.7"
+aes = "0.8"
 anyhow = "1"
 approx = "0.5.1"
 arrayvec = "0.7"
@@ -23,7 +23,7 @@ bitfield-struct = "0.1"
 bitvec = "1"
 byteorder = "1"
 cesu8 = "1.1.0"
-cfb8 = "0.7"
+cfb8 = "0.8"
 flate2 = "1"
 flume = "0.10"
 futures = "0.3"


### PR DESCRIPTION
Right now, the unit tests for this will fail. Do not merge this as is, it will break clients being able to connect.

There are some breaking changes moving from 0.7 to 0.8. Namely, the cfb8 crate now provides 2 types `Encryptor<T>` and `Decryptor<T>` and the `encrypt()` and `decrypt()` methods now **consume the `cipher` instead of just borrowing it.** (eg. `fn encrypt(self, ...)` rather than `fn encrypt(&self, ...)`)

I'm putting this up as a draft so somebody else can pick it up if I don't get back around to it.