### PR TITLE
Add/Update some packet definitions

### DIFF
--- a/src/protocol/packets.rs
+++ b/src/protocol/packets.rs
@@ -328,7 +328,7 @@ macro_rules! def_packet_group {
                             Ok(Self::$packet(pkt))
                         }
                     )*
-                    id => bail!(concat!("unknown ", stringify!($group_name), " packet ID {}"), id),
+                    id => bail!(concat!("unknown ", stringify!($group_name), " packet ID {} ({:#x})"), id, id),
                 }
             }
         }

--- a/src/protocol/packets/s2c.rs
+++ b/src/protocol/packets/s2c.rs
@@ -206,7 +206,7 @@ pub mod play {
     }
 
     def_struct! {
-        SetDifficulty {
+        ChangeDifficulty {
             difficulty: Difficulty,
             locked: bool,
         }
@@ -840,6 +840,7 @@ pub mod play {
             BlockEvent = 8,
             BlockUpdate = 9,
             BossBar = 10,
+            ChangeDifficulty = 11,
             ClearTitles = 13,
             PluginMessage = 22,
             PlaySoundId = 23,

--- a/src/protocol/packets/s2c.rs
+++ b/src/protocol/packets/s2c.rs
@@ -628,6 +628,30 @@ pub mod play {
     }
 
     def_struct! {
+        UpdateRecipeBook {
+            action: UpdateRecipeBookAction,
+            crafting_recipe_book_open: bool,
+            crafting_recipe_book_filter_active: bool,
+            smelting_recipe_book_open: bool,
+            smelting_recipe_book_filter_active: bool,
+            blast_furnace_recipe_book_open: bool,
+            blast_furnace_recipe_book_filter_active: bool,
+            smoker_recipe_book_open: bool,
+            smoker_recipe_book_filter_active: bool,
+            recipe_ids: Vec<Ident>,
+            recipe_ids2: Option<Vec<Ident>>, // only present if action == init
+        }
+    }
+
+    def_enum! {
+        UpdateRecipeBookAction: VarInt {
+            Init = 0,
+            Add = 1,
+            Remove = 2,
+        }
+    }
+
+    def_struct! {
         EntitiesDestroy {
             entities: Vec<VarInt>,
         }
@@ -857,6 +881,7 @@ pub mod play {
             ChatMessage = 51,
             UpdatePlayerList = 55,
             PlayerPositionLook = 57,
+            UpdateRecipeBook = 58,
             EntitiesDestroy = 59,
             PlayerRespawn = 62,
             EntitySetHeadYaw = 63,

--- a/src/protocol/packets/s2c.rs
+++ b/src/protocol/packets/s2c.rs
@@ -227,6 +227,13 @@ pub mod play {
         }
     }
 
+    def_struct! {
+        PluginMessage {
+            channel: Ident,
+            data: Vec<u8>,
+        }
+    }
+
     def_enum! {
         SoundCategory: VarInt {
             Master = 0,
@@ -834,6 +841,7 @@ pub mod play {
             BlockUpdate = 9,
             BossBar = 10,
             ClearTitles = 13,
+            PluginMessage = 22,
             PlaySoundId = 23,
             Disconnect = 25,
             EntityStatus = 26,


### PR DESCRIPTION
- add the packet id in hex to unknown packet error message make it easier to look up on wiki.vg
- add packet definition for PluginMessage
- rename SetDifficulty to ChangeDifficulty to match wiki.vg, add to S2cPlayPacket enum
- add packet definition for UpdateRecipeBook
