### PR TITLE
packet_inspector: fix UnexpectedEof errors deep inside packet decoding causing perfectly good connections to be aborted. fixes #64

### DIFF
--- a/packet_inspector/src/main.rs
+++ b/packet_inspector/src/main.rs
@@ -172,7 +172,7 @@ async fn handle_connection(client: TcpStream, cli: Cli) -> anyhow::Result<()> {
                         .await
                     {
                         if let Some(e) = e.downcast_ref::<io::Error>() {
-                            if e.kind() == ErrorKind::UnexpectedEof {
+                            if e.kind() == ErrorKind::BrokenPipe {
                                 return Ok(());
                             }
                         }
@@ -188,7 +188,7 @@ async fn handle_connection(client: TcpStream, cli: Cli) -> anyhow::Result<()> {
                         .await
                     {
                         if let Some(e) = e.downcast_ref::<io::Error>() {
-                            if e.kind() == ErrorKind::UnexpectedEof {
+                            if e.kind() == ErrorKind::BrokenPipe {
                                 return Ok(());
                             }
                         }


### PR DESCRIPTION
fixes #64

### Test plan

start a vanilla mc server
```
docker run -e EULA=TRUE -e ONLINE_MODE=false -d -p 25565:25565 --name mc itzg/minecraft-server
```

run packet inspector
```
cargo r -r -p packet_inspector -- 127.0.0.1:25566 127.0.0.1:25565
```

Open mc and connect to `localhost:25566`
See that you can load into the world and play as normal.