### PR TITLE
Add methods to Config to use a custom session server

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -78,7 +78,7 @@ impl<C: Config> Clients<C> {
         self.slab.remove(client.0).map(|c| c.state)
     }
 
-    /// Deletes all clients from the server for which `f` returns `true`.
+    /// Deletes all clients from the server for which `f` returns `false`.
     ///
     /// All clients are visited in an unspecified order.
     pub fn retain(&mut self, mut f: impl FnMut(ClientId, &mut Client<C>) -> bool) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 //! Configuration for the server.
 
 use std::borrow::Cow;
-use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::panic::{RefUnwindSafe, UnwindSafe};
 
 use async_trait::async_trait;
@@ -206,6 +206,50 @@ pub trait Config: Sized + Send + Sync + UnwindSafe + RefUnwindSafe + 'static {
     /// [`Clients`]: crate::client::Clients
     async fn login(&self, shared: &SharedServer<Self>, ncd: &NewClientData) -> Result<(), Text> {
         Ok(())
+    }
+
+    /// Called upon client connect (if online mode is enabled) to obtain
+    /// the host address of the session server. Defaults to the official
+    /// mojang session server.
+    ///
+    /// This method is called from within the default implementation of
+    /// [`Self::session_server_url`]. If that method is overridden, this
+    /// method will not be called.
+    ///
+    /// # Default Implementation
+    ///
+    /// The official mojang session server (`sessionserver.mojang.com`)
+    /// is used.
+    fn session_server_host(&self, server: &SharedServer<Self>) -> Cow<'_, str> {
+        Cow::from("sessionserver.mojang.com")
+    }
+
+    /// Called upon (every) client connect (if online mode is enabled) to obtain
+    /// the full URL to use for session server requests. Defaults to
+    /// `https://<host>/session/minecraft/hasJoined?username=<username>&serverId=<auth-digest>&ip=<player-ip>`.
+    ///
+    /// If you just want to change the server host, you can override
+    /// [`Self::session_server_host`] instead.
+    ///
+    /// It is assumed, that upon successful request, a structure matching the
+    /// description in the [wiki](https://wiki.vg/Protocol_Encryption#Server) was obtained.
+    /// Providing a URL that does not return such a structure will result in a
+    /// disconnect for every client that connects.
+    ///
+    /// The arguments are described in the linked wiki article.
+    fn format_session_server_url(
+        &self,
+        server: &SharedServer<Self>,
+        username: &str,
+        auth_digest: &str,
+        server_ip: &IpAddr,
+    ) -> Cow<'_, str> {
+        let host = self.session_server_host(server);
+        let path_and_args = format!(
+            "session/minecraft/hasJoined?username={}&serverId={}&ip={}",
+            username, auth_digest, server_ip
+        );
+        Cow::from(format!("https://{}/{}", host, path_and_args))
     }
 
     /// Called after the server is created, but prior to accepting connections

--- a/src/config.rs
+++ b/src/config.rs
@@ -208,28 +208,9 @@ pub trait Config: Sized + Send + Sync + UnwindSafe + RefUnwindSafe + 'static {
         Ok(())
     }
 
-    /// Called upon client connect (if online mode is enabled) to obtain
-    /// the host address of the session server. Defaults to the official
-    /// mojang session server.
-    ///
-    /// This method is called from within the default implementation of
-    /// [`Self::session_server_url`]. If that method is overridden, this
-    /// method will not be called.
-    ///
-    /// # Default Implementation
-    ///
-    /// The official mojang session server (`sessionserver.mojang.com`)
-    /// is used.
-    fn session_server_host(&self, server: &SharedServer<Self>) -> Cow<'_, str> {
-        Cow::from("sessionserver.mojang.com")
-    }
-
     /// Called upon (every) client connect (if online mode is enabled) to obtain
     /// the full URL to use for session server requests. Defaults to
-    /// `https://<host>/session/minecraft/hasJoined?username=<username>&serverId=<auth-digest>&ip=<player-ip>`.
-    ///
-    /// If you just want to change the server host, you can override
-    /// [`Self::session_server_host`] instead.
+    /// `https://sessionserver.mojang.com/session/minecraft/hasJoined?username=<username>&serverId=<auth-digest>&ip=<player-ip>`.
     ///
     /// It is assumed, that upon successful request, a structure matching the
     /// description in the [wiki](https://wiki.vg/Protocol_Encryption#Server) was obtained.
@@ -242,14 +223,9 @@ pub trait Config: Sized + Send + Sync + UnwindSafe + RefUnwindSafe + 'static {
         server: &SharedServer<Self>,
         username: &str,
         auth_digest: &str,
-        server_ip: &IpAddr,
-    ) -> Cow<'_, str> {
-        let host = self.session_server_host(server);
-        let path_and_args = format!(
-            "session/minecraft/hasJoined?username={}&serverId={}&ip={}",
-            username, auth_digest, server_ip
-        );
-        Cow::from(format!("https://{}/{}", host, path_and_args))
+        player_ip: &IpAddr,
+    ) -> String {
+        format!("https://sessionserver.mojang.com/session/minecraft/hasJoined?username={username}&serverId={auth_digest}&ip={player_ip}")
     }
 
     /// Called after the server is created, but prior to accepting connections

--- a/src/server.rs
+++ b/src/server.rs
@@ -712,8 +712,7 @@ async fn handle_login<C: Config>(
             &username,
             &hex_hash,
             &remote_addr.ip(),
-        )
-        .to_string();
+        );
         let resp = server.0.http_client.get(url).send().await?;
 
         let status = resp.status();


### PR DESCRIPTION
Added new methods to the Config trait, that enables implementors to use a fully custom URL.

Closes #40 