### PR TITLE
Replace the bool in the retain functions with a retain decision

### DIFF
--- a/examples/building.rs
+++ b/examples/building.rs
@@ -11,6 +11,7 @@ use valence::config::{Config, ServerListPing};
 use valence::dimension::{Dimension, DimensionId};
 use valence::entity::{EntityId, EntityKind};
 use valence::player_list::PlayerListId;
+use valence::retain::RetainDecision;
 use valence::server::{Server, SharedServer, ShutdownResult};
 use valence::text::{Color, TextFormat};
 use valence::{async_trait, ident};
@@ -142,7 +143,7 @@ impl Config for Game {
                     .is_err()
                 {
                     client.disconnect("The server is full!".color(Color::RED));
-                    return false;
+                    return RetainDecision::Remove;
                 }
 
                 match server
@@ -152,7 +153,7 @@ impl Config for Game {
                     Some((id, _)) => client.state.entity_id = id,
                     None => {
                         client.disconnect("Conflicting UUID");
-                        return false;
+                        return RetainDecision::Remove;
                     }
                 }
 
@@ -182,7 +183,7 @@ impl Config for Game {
                 if let Some(id) = &server.state.player_list {
                     server.player_lists.get_mut(id).remove(client.uuid());
                 }
-                return false;
+                return RetainDecision::Remove;
             }
 
             let player = server.entities.get_mut(client.state.entity_id).unwrap();
@@ -226,7 +227,7 @@ impl Config for Game {
                 }
             }
 
-            true
+            RetainDecision::Keep
         });
     }
 }

--- a/examples/combat.rs
+++ b/examples/combat.rs
@@ -11,6 +11,7 @@ use valence::config::{Config, ServerListPing};
 use valence::dimension::DimensionId;
 use valence::entity::{EntityEvent, EntityId, EntityKind};
 use valence::player_list::PlayerListId;
+use valence::retain::RetainDecision;
 use valence::server::{Server, SharedServer, ShutdownResult};
 use valence::text::{Color, TextFormat};
 use valence::{async_trait, Ticks};
@@ -135,7 +136,7 @@ impl Config for Game {
                     .is_err()
                 {
                     client.disconnect("The server is full!".color(Color::RED));
-                    return false;
+                    return RetainDecision::Remove;
                 }
 
                 let (player_id, player) = match server.entities.insert_with_uuid(
@@ -146,7 +147,7 @@ impl Config for Game {
                     Some(e) => e,
                     None => {
                         client.disconnect("Conflicting UUID");
-                        return false;
+                        return RetainDecision::Remove;
                     }
                 };
 
@@ -192,7 +193,7 @@ impl Config for Game {
                 if let Some(id) = &server.state {
                     server.player_lists.get_mut(id).remove(client.uuid());
                 }
-                return false;
+                return RetainDecision::Remove;
             }
 
             if client.position().y <= 0.0 {
@@ -244,7 +245,7 @@ impl Config for Game {
                 }
             }
 
-            true
+            RetainDecision::Keep
         });
 
         for (_, entity) in server.entities.iter_mut() {

--- a/examples/conway.rs
+++ b/examples/conway.rs
@@ -15,6 +15,7 @@ use valence::entity::types::Pose;
 use valence::entity::{EntityId, EntityKind, TrackedData};
 use valence::player_list::PlayerListId;
 use valence::protocol::packets::s2c::play::SoundCategory;
+use valence::retain::RetainDecision;
 use valence::server::{Server, SharedServer, ShutdownResult};
 use valence::text::{Color, TextFormat};
 use valence::{async_trait, ident};
@@ -139,7 +140,7 @@ impl Config for Game {
                     .is_err()
                 {
                     client.disconnect("The server is full!".color(Color::RED));
-                    return false;
+                    return RetainDecision::Remove;
                 }
 
                 match server
@@ -149,7 +150,7 @@ impl Config for Game {
                     Some((id, _)) => client.state.entity_id = id,
                     None => {
                         client.disconnect("Conflicting UUID");
-                        return false;
+                        return RetainDecision::Remove;
                     }
                 }
 
@@ -181,7 +182,7 @@ impl Config for Game {
                 if let Some(id) = &server.state.player_list {
                     server.player_lists.get_mut(id).remove(client.uuid());
                 }
-                return false;
+                return RetainDecision::Remove;
             }
 
             let player = server.entities.get_mut(client.state.entity_id).unwrap();
@@ -243,7 +244,7 @@ impl Config for Game {
                 "Playing".color(Color::GREEN)
             });
 
-            true
+            RetainDecision::Keep
         });
 
         if !server.state.paused && server.shared.current_tick() % 2 == 0 {

--- a/examples/cow_sphere.rs
+++ b/examples/cow_sphere.rs
@@ -13,6 +13,7 @@ use valence::config::{Config, PlayerSampleEntry, ServerListPing};
 use valence::dimension::DimensionId;
 use valence::entity::{EntityId, EntityKind};
 use valence::player_list::PlayerListId;
+use valence::retain::RetainDecision;
 use valence::server::{Server, SharedServer, ShutdownResult};
 use valence::text::{Color, TextFormat};
 use valence::util::to_yaw_and_pitch;
@@ -121,7 +122,7 @@ impl Config for Game {
                     .is_err()
                 {
                     client.disconnect("The server is full!".color(Color::RED));
-                    return false;
+                    return RetainDecision::Remove;
                 }
 
                 match server
@@ -131,7 +132,7 @@ impl Config for Game {
                     Some((id, _)) => client.state = id,
                     None => {
                         client.disconnect("Conflicting UUID");
-                        return false;
+                        return RetainDecision::Remove;
                     }
                 }
 
@@ -168,7 +169,7 @@ impl Config for Game {
                 }
                 server.entities.remove(client.state);
 
-                return false;
+                return RetainDecision::Remove;
             }
 
             let entity = server
@@ -178,7 +179,7 @@ impl Config for Game {
 
             while handle_event_default(client, entity).is_some() {}
 
-            true
+            RetainDecision::Keep
         });
 
         let time = server.shared.current_tick() as f64 / server.shared.tick_rate() as f64;

--- a/examples/entity_raycast.rs
+++ b/examples/entity_raycast.rs
@@ -12,6 +12,7 @@ use valence::dimension::DimensionId;
 use valence::entity::types::{Facing, PaintingKind, Pose};
 use valence::entity::{EntityId, EntityKind, TrackedData};
 use valence::player_list::PlayerListId;
+use valence::retain::RetainDecision;
 use valence::server::{Server, SharedServer, ShutdownResult};
 use valence::spatial_index::RaycastHit;
 use valence::text::{Color, TextFormat};
@@ -320,7 +321,7 @@ impl Config for Game {
                     .is_err()
                 {
                     client.disconnect("The server is full!".color(Color::RED));
-                    return false;
+                    return RetainDecision::Remove;
                 }
 
                 match server
@@ -330,7 +331,7 @@ impl Config for Game {
                     Some((id, _)) => client.state.player = id,
                     None => {
                         client.disconnect("Conflicting UUID");
-                        return false;
+                        return RetainDecision::Remove;
                     }
                 }
 
@@ -373,7 +374,7 @@ impl Config for Game {
                 }
                 server.entities.remove(client.state.player);
 
-                return false;
+                return RetainDecision::Remove;
             }
 
             let client_pos = client.position();
@@ -418,7 +419,7 @@ impl Config for Game {
             .is_some()
             {}
 
-            true
+            RetainDecision::Keep
         });
     }
 }

--- a/examples/resource_pack.rs
+++ b/examples/resource_pack.rs
@@ -12,6 +12,7 @@ use valence::config::{Config, ServerListPing};
 use valence::dimension::DimensionId;
 use valence::entity::{EntityId, EntityKind, TrackedData};
 use valence::player_list::PlayerListId;
+use valence::retain::RetainDecision;
 use valence::server::{Server, SharedServer, ShutdownResult};
 use valence::text::{Color, TextFormat};
 
@@ -119,7 +120,7 @@ impl Config for Game {
                     .is_err()
                 {
                     client.disconnect("The server is full!".color(Color::RED));
-                    return false;
+                    return RetainDecision::Remove;
                 }
 
                 match server
@@ -129,7 +130,7 @@ impl Config for Game {
                     Some((id, _)) => client.state.entity_id = id,
                     None => {
                         client.disconnect("Conflicting UUID");
-                        return false;
+                        return RetainDecision::Remove;
                     }
                 }
 
@@ -168,7 +169,7 @@ impl Config for Game {
                 }
                 server.entities.remove(client.state.entity_id);
 
-                return false;
+                return RetainDecision::Remove;
             }
 
             let player = server.entities.get_mut(client.state.entity_id).unwrap();
@@ -207,7 +208,7 @@ impl Config for Game {
                 }
             }
 
-            true
+            RetainDecision::Keep
         });
     }
 }

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -27,6 +27,7 @@ use crate::protocol::packets::s2c::play::{
     BlockUpdate, ChunkDataAndUpdateLight, ChunkDataHeightmaps, S2cPlayPacket, UpdateSectionBlocks,
 };
 use crate::protocol::{Encode, NbtBridge, VarInt, VarLong};
+use crate::retain::RetainDecision;
 use crate::server::SharedServer;
 
 /// A container for all [`LoadedChunk`]s in a [`World`](crate::world::World).
@@ -117,8 +118,9 @@ impl<C: Config> Chunks<C> {
     /// Removes all chunks for which `f` returns `true`.
     ///
     /// All chunks are visited in an unspecified order.
-    pub fn retain(&mut self, mut f: impl FnMut(ChunkPos, &mut LoadedChunk<C>) -> bool) {
-        self.chunks.retain(|&pos, chunk| f(pos, chunk))
+    pub fn retain(&mut self, mut f: impl FnMut(ChunkPos, &mut LoadedChunk<C>) -> RetainDecision) {
+        self.chunks
+            .retain(|&pos, chunk| f(pos, chunk).should_keep())
     }
 
     /// Deletes all chunks.

--- a/src/client.rs
+++ b/src/client.rs
@@ -38,6 +38,7 @@ use crate::protocol::packets::s2c::play::{
     UpdateEntityPositionAndRotation, UpdateEntityRotation,
 };
 use crate::protocol::{BoundedInt, BoundedString, ByteAngle, NbtBridge, RawBytes, VarInt};
+use crate::retain::RetainDecision;
 use crate::server::{C2sPacketChannels, NewClientData, S2cPlayMessage, SharedServer};
 use crate::slab_versioned::{Key, VersionedSlab};
 use crate::text::Text;
@@ -81,7 +82,7 @@ impl<C: Config> Clients<C> {
     /// Deletes all clients from the server for which `f` returns `false`.
     ///
     /// All clients are visited in an unspecified order.
-    pub fn retain(&mut self, mut f: impl FnMut(ClientId, &mut Client<C>) -> bool) {
+    pub fn retain(&mut self, mut f: impl FnMut(ClientId, &mut Client<C>) -> RetainDecision) {
         self.slab.retain(|k, v| f(ClientId(k), v))
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -78,7 +78,7 @@ impl<C: Config> Clients<C> {
         self.slab.remove(client.0).map(|c| c.state)
     }
 
-    /// Deletes all clients from the server for which `f` returns `true`.
+    /// Deletes all clients from the server for which `f` returns `false`.
     ///
     /// All clients are visited in an unspecified order.
     pub fn retain(&mut self, mut f: impl FnMut(ClientId, &mut Client<C>) -> bool) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 //! Configuration for the server.
 
 use std::borrow::Cow;
-use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::panic::{RefUnwindSafe, UnwindSafe};
 
 use async_trait::async_trait;
@@ -206,6 +206,50 @@ pub trait Config: Sized + Send + Sync + UnwindSafe + RefUnwindSafe + 'static {
     /// [`Clients`]: crate::client::Clients
     async fn login(&self, shared: &SharedServer<Self>, ncd: &NewClientData) -> Result<(), Text> {
         Ok(())
+    }
+
+    /// Called upon client connect (if online mode is enabled) to obtain
+    /// the host address of the session server. Defaults to the official
+    /// mojang session server.
+    ///
+    /// This method is called from within the default implementation of
+    /// [`Self::session_server_url`]. If that method is overridden, this
+    /// method will not be called.
+    ///
+    /// # Default Implementation
+    ///
+    /// The official mojang session server (`sessionserver.mojang.com`)
+    /// is used.
+    fn session_server_host(&self, server: &SharedServer<Self>) -> Cow<'_, str> {
+        Cow::from("sessionserver.mojang.com")
+    }
+
+    /// Called upon (every) client connect (if online mode is enabled) to obtain
+    /// the full URL to use for session server requests. Defaults to
+    /// `https://<host>/session/minecraft/hasJoined?username=<username>&serverId=<auth-digest>&ip=<player-ip>`.
+    ///
+    /// If you just want to change the server host, you can override
+    /// [`Self::session_server_host`] instead.
+    ///
+    /// It is assumed, that upon successful request, a structure matching the
+    /// description in the [wiki](https://wiki.vg/Protocol_Encryption#Server) was obtained.
+    /// Providing a URL that does not return such a structure will result in a
+    /// disconnect for every client that connects.
+    ///
+    /// The arguments are described in the linked wiki article.
+    fn format_session_server_url(
+        &self,
+        server: &SharedServer<Self>,
+        username: &str,
+        auth_digest: &str,
+        server_ip: &IpAddr,
+    ) -> Cow<'_, str> {
+        let host = self.session_server_host(server);
+        let path_and_args = format!(
+            "session/minecraft/hasJoined?username={}&serverId={}&ip={}",
+            username, auth_digest, server_ip
+        );
+        Cow::from(format!("https://{}/{}", host, path_and_args))
     }
 
     /// Called after the server is created, but prior to accepting connections

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,8 @@
     clippy::unusual_byte_groupings,
     clippy::comparison_chain
 )]
+#![feature(try_trait_v2)]
+#![feature(assert_matches)]
 
 /// Used on [`Config`](config::Config) to allow for async methods in traits.
 ///
@@ -105,6 +107,7 @@ pub mod player_textures;
 #[allow(dead_code)]
 #[doc(hidden)]
 pub mod protocol;
+pub mod retain;
 pub mod server;
 mod slab;
 mod slab_rc;

--- a/src/player_list.rs
+++ b/src/player_list.rs
@@ -14,6 +14,7 @@ use crate::protocol::packets::s2c::play::{
 };
 use crate::protocol::packets::Property;
 use crate::protocol::VarInt;
+use crate::retain::RetainDecision;
 use crate::slab_rc::{Key, SlabRc};
 use crate::text::Text;
 
@@ -178,9 +179,9 @@ impl<C: Config> PlayerList<C> {
     /// Removes all entries from the player list for which `f` returns `true`.
     ///
     /// All entries are visited in an unspecified order.
-    pub fn retain(&mut self, mut f: impl FnMut(Uuid, &mut PlayerListEntry) -> bool) {
+    pub fn retain(&mut self, mut f: impl FnMut(Uuid, &mut PlayerListEntry) -> RetainDecision) {
         self.entries.retain(|&uuid, entry| {
-            if !f(uuid, entry) {
+            if RetainDecision::should_remove(f(uuid, entry)) {
                 self.removed.insert(uuid);
                 false
             } else {

--- a/src/retain.rs
+++ b/src/retain.rs
@@ -1,0 +1,133 @@
+use std::ops::{ControlFlow, FromResidual, Try};
+
+/// The result of a decision on whether to remove or keep an element.
+///
+/// The [`From`] trait is implemented for this trait with the type `bool`,
+/// where `true` is [`Retain::Keep`] and `false` is [`Retain::Remove`].
+///
+/// The [`Try`] trait is implemented for this type, allowing it to be used
+/// with the `?` operator. [`RetainDecision::Remove`] is the value that
+/// will lead to a short-circuiting early return from the function when
+/// used with the `?` operator.
+///
+/// [`From`]: std::convert::From
+/// [`Try`]: https://doc.rust-lang.org/std/ops/trait.Try.html
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum RetainDecision {
+    Keep,
+    Remove,
+}
+
+impl RetainDecision {
+    /// Returns `true` if the decision is to keep the value.
+    pub fn should_keep(self) -> bool {
+        matches!(self, RetainDecision::Keep)
+    }
+
+    /// Returns `true` if the decision is to remove the value.
+    pub fn should_remove(self) -> bool {
+        matches!(self, RetainDecision::Remove)
+    }
+}
+
+impl From<bool> for RetainDecision {
+    fn from(b: bool) -> Self {
+        if b {
+            Self::Keep
+        } else {
+            Self::Remove
+        }
+    }
+}
+
+impl FromResidual for RetainDecision {
+    fn from_residual(_: <Self as Try>::Residual) -> Self {
+        RetainDecision::Remove
+    }
+}
+
+impl Try for RetainDecision {
+    type Output = ();
+    type Residual = ();
+
+    fn from_output(_: Self::Output) -> Self {
+        RetainDecision::Keep
+    }
+
+    fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {
+        match self {
+            RetainDecision::Keep => ControlFlow::Continue(()),
+            RetainDecision::Remove => ControlFlow::Break(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::assert_matches::assert_matches;
+    use std::sync::atomic::AtomicUsize;
+
+    use super::*;
+
+    #[test]
+    fn test_from() {
+        assert_matches!(RetainDecision::from(true), RetainDecision::Keep);
+        assert_matches!(RetainDecision::from(false), RetainDecision::Remove);
+        assert_matches!(Into::<RetainDecision>::into(true), RetainDecision::Keep);
+        assert_matches!(Into::<RetainDecision>::into(false), RetainDecision::Remove);
+    }
+
+    #[test]
+    fn test_other() {
+        assert!(RetainDecision::Keep.should_keep());
+        assert!(RetainDecision::Remove.should_remove());
+        assert_ne!(RetainDecision::Keep, RetainDecision::Remove);
+
+        assert_matches!(RetainDecision::from_output(()), RetainDecision::Keep);
+        assert_matches!(RetainDecision::from_residual(()), RetainDecision::Remove);
+    }
+
+    #[test]
+    fn test_try() {
+        /*
+        This is about the constellation we have with the plain 'retain-loop' in
+        server implementations. Within the server implementation, we have a few
+        checks, and if any of them fail, we want to remove the (for example) client,
+        and do an early exit. This is, why for the RetainDecision, we can short circuit
+        with the '?'-operator.
+
+        In this test, we test, that the operator actually short circuits before the
+        seventh element, and touches the first six.
+
+        To map this test to one of the constellations described above:
+        `check` is any server implementor's check, for example, if UUIDs collide.
+        `exec` is the enclosing `clients.retain(...)` loop, from which we want to
+        early exit, if `check` fails.
+         */
+
+        let reached_count = AtomicUsize::new(0);
+        let check = |n: i32| -> RetainDecision {
+            if n >= 6 {
+                // 5 can still be checked, but 6 can't
+                panic!("should short circuit after 5");
+            }
+
+            let _ = &reached_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+            if n < 5 {
+                RetainDecision::Keep
+            } else {
+                RetainDecision::Remove
+            }
+        };
+        fn exec(check: impl Fn(i32) -> RetainDecision) -> RetainDecision {
+            let data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+            for i in data {
+                check(i)?;
+            }
+            RetainDecision::Keep
+        }
+        assert_matches!(exec(check), RetainDecision::Remove);
+        assert_eq!(6, reached_count.load(std::sync::atomic::Ordering::SeqCst));
+    }
+}

--- a/src/slab_rc.rs
+++ b/src/slab_rc.rs
@@ -120,6 +120,6 @@ impl<T> SlabRc<T> {
 
     pub fn collect_garbage(&mut self) {
         self.slab
-            .retain(|_, slot| Arc::strong_count(&slot.key.0) > 1);
+            .retain(|_, slot| (Arc::strong_count(&slot.key.0) > 1).into());
     }
 }

--- a/src/world.rs
+++ b/src/world.rs
@@ -7,6 +7,7 @@ use rayon::iter::ParallelIterator;
 use crate::chunk::Chunks;
 use crate::config::Config;
 use crate::dimension::DimensionId;
+use crate::retain::RetainDecision;
 use crate::server::SharedServer;
 use crate::slab_versioned::{Key, VersionedSlab};
 use crate::spatial_index::SpatialIndex;
@@ -70,7 +71,7 @@ impl<C: Config> Worlds<C> {
     /// Removes all worlds from the server for which `f` returns `true`.
     ///
     /// All worlds are visited in an unspecified order.
-    pub fn retain(&mut self, mut f: impl FnMut(WorldId, &mut World<C>) -> bool) {
+    pub fn retain(&mut self, mut f: impl FnMut(WorldId, &mut World<C>) -> RetainDecision) {
         self.slab.retain(|k, v| f(WorldId(k), v))
     }
 


### PR DESCRIPTION
The functions for retain calls are now expected to return
a more explicit RetainDecision.
The RetainDecision implements Try, so that server implementors can use the ?-operator to short-circuit their implementation of those functions.

Helped me a lot in my little server project, especially because the retain functions can grow quite a bit, and this helped me splitting it up better.
Also improves readability IMO, since I don't have to figure out, what exactly the `return true;` in that place means.