### PR TITLE
Add basic enchantment extraction

### DIFF
--- a/extracted/enchants.json
+++ b/extracted/enchants.json
@@ -8,10 +8,11 @@
       "max_level": 4,
       "rarity_weight": 10,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 1,
@@ -21,10 +22,11 @@
       "max_level": 4,
       "rarity_weight": 5,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 2,
@@ -34,10 +36,11 @@
       "max_level": 4,
       "rarity_weight": 5,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 3,
@@ -47,10 +50,11 @@
       "max_level": 4,
       "rarity_weight": 2,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 4,
@@ -60,10 +64,11 @@
       "max_level": 4,
       "rarity_weight": 5,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 5,
@@ -73,10 +78,11 @@
       "max_level": 3,
       "rarity_weight": 2,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 6,
@@ -86,10 +92,11 @@
       "max_level": 1,
       "rarity_weight": 2,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 7,
@@ -99,10 +106,11 @@
       "max_level": 3,
       "rarity_weight": 1,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 8,
@@ -112,10 +120,11 @@
       "max_level": 3,
       "rarity_weight": 2,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 9,
@@ -125,11 +134,11 @@
       "max_level": 2,
       "rarity_weight": 2,
       "cursed": false,
-      "sources": [
-        "treasure",
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": true,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 10,
@@ -139,11 +148,11 @@
       "max_level": 1,
       "rarity_weight": 1,
       "cursed": true,
-      "sources": [
-        "treasure",
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": true,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 11,
@@ -153,9 +162,11 @@
       "max_level": 3,
       "rarity_weight": 1,
       "cursed": false,
-      "sources": [
-        "treasure"
-      ]
+      "sources": {
+        "treasure": true,
+        "enchantment_table": false,
+        "random_selection": false
+      }
     },
     {
       "id": 12,
@@ -165,9 +176,11 @@
       "max_level": 3,
       "rarity_weight": 1,
       "cursed": false,
-      "sources": [
-        "treasure"
-      ]
+      "sources": {
+        "treasure": true,
+        "enchantment_table": false,
+        "random_selection": false
+      }
     },
     {
       "id": 13,
@@ -177,10 +190,11 @@
       "max_level": 5,
       "rarity_weight": 10,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 14,
@@ -190,10 +204,11 @@
       "max_level": 5,
       "rarity_weight": 5,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 15,
@@ -203,10 +218,11 @@
       "max_level": 5,
       "rarity_weight": 5,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 16,
@@ -216,10 +232,11 @@
       "max_level": 2,
       "rarity_weight": 5,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 17,
@@ -229,10 +246,11 @@
       "max_level": 2,
       "rarity_weight": 2,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 18,
@@ -242,10 +260,11 @@
       "max_level": 3,
       "rarity_weight": 2,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 19,
@@ -255,10 +274,11 @@
       "max_level": 3,
       "rarity_weight": 2,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 20,
@@ -268,10 +288,11 @@
       "max_level": 5,
       "rarity_weight": 10,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 21,
@@ -281,10 +302,11 @@
       "max_level": 1,
       "rarity_weight": 1,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 22,
@@ -294,10 +316,11 @@
       "max_level": 3,
       "rarity_weight": 5,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 23,
@@ -307,10 +330,11 @@
       "max_level": 3,
       "rarity_weight": 2,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 24,
@@ -320,10 +344,11 @@
       "max_level": 5,
       "rarity_weight": 10,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 25,
@@ -333,10 +358,11 @@
       "max_level": 2,
       "rarity_weight": 2,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 26,
@@ -346,10 +372,11 @@
       "max_level": 1,
       "rarity_weight": 2,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 27,
@@ -359,10 +386,11 @@
       "max_level": 1,
       "rarity_weight": 1,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 28,
@@ -372,10 +400,11 @@
       "max_level": 3,
       "rarity_weight": 2,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 29,
@@ -385,10 +414,11 @@
       "max_level": 3,
       "rarity_weight": 2,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 30,
@@ -398,10 +428,11 @@
       "max_level": 3,
       "rarity_weight": 5,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 31,
@@ -411,10 +442,11 @@
       "max_level": 5,
       "rarity_weight": 2,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 32,
@@ -424,10 +456,11 @@
       "max_level": 3,
       "rarity_weight": 2,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 33,
@@ -437,10 +470,11 @@
       "max_level": 1,
       "rarity_weight": 1,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 34,
@@ -450,10 +484,11 @@
       "max_level": 1,
       "rarity_weight": 2,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 35,
@@ -463,10 +498,11 @@
       "max_level": 3,
       "rarity_weight": 5,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 36,
@@ -476,10 +512,11 @@
       "max_level": 4,
       "rarity_weight": 10,
       "cursed": false,
-      "sources": [
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": false,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 37,
@@ -489,11 +526,11 @@
       "max_level": 1,
       "rarity_weight": 2,
       "cursed": false,
-      "sources": [
-        "treasure",
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": true,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     },
     {
       "id": 38,
@@ -503,11 +540,11 @@
       "max_level": 1,
       "rarity_weight": 1,
       "cursed": true,
-      "sources": [
-        "treasure",
-        "enchantment_table",
-        "random_selection"
-      ]
+      "sources": {
+        "treasure": true,
+        "enchantment_table": true,
+        "random_selection": true
+      }
     }
   ]
 }

--- a/extracted/enchants.json
+++ b/extracted/enchants.json
@@ -1,0 +1,513 @@
+{
+  "enchants": [
+    {
+      "id": 0,
+      "name": "protection",
+      "translation_key": "enchantment.minecraft.protection",
+      "min_level": 1,
+      "max_level": 4,
+      "rarity_weight": 10,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 1,
+      "name": "fire_protection",
+      "translation_key": "enchantment.minecraft.fire_protection",
+      "min_level": 1,
+      "max_level": 4,
+      "rarity_weight": 5,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "feather_falling",
+      "translation_key": "enchantment.minecraft.feather_falling",
+      "min_level": 1,
+      "max_level": 4,
+      "rarity_weight": 5,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "blast_protection",
+      "translation_key": "enchantment.minecraft.blast_protection",
+      "min_level": 1,
+      "max_level": 4,
+      "rarity_weight": 2,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "projectile_protection",
+      "translation_key": "enchantment.minecraft.projectile_protection",
+      "min_level": 1,
+      "max_level": 4,
+      "rarity_weight": 5,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "respiration",
+      "translation_key": "enchantment.minecraft.respiration",
+      "min_level": 1,
+      "max_level": 3,
+      "rarity_weight": 2,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 6,
+      "name": "aqua_affinity",
+      "translation_key": "enchantment.minecraft.aqua_affinity",
+      "min_level": 1,
+      "max_level": 1,
+      "rarity_weight": 2,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 7,
+      "name": "thorns",
+      "translation_key": "enchantment.minecraft.thorns",
+      "min_level": 1,
+      "max_level": 3,
+      "rarity_weight": 1,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 8,
+      "name": "depth_strider",
+      "translation_key": "enchantment.minecraft.depth_strider",
+      "min_level": 1,
+      "max_level": 3,
+      "rarity_weight": 2,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 9,
+      "name": "frost_walker",
+      "translation_key": "enchantment.minecraft.frost_walker",
+      "min_level": 1,
+      "max_level": 2,
+      "rarity_weight": 2,
+      "cursed": false,
+      "sources": [
+        "treasure",
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 10,
+      "name": "binding_curse",
+      "translation_key": "enchantment.minecraft.binding_curse",
+      "min_level": 1,
+      "max_level": 1,
+      "rarity_weight": 1,
+      "cursed": true,
+      "sources": [
+        "treasure",
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 11,
+      "name": "soul_speed",
+      "translation_key": "enchantment.minecraft.soul_speed",
+      "min_level": 1,
+      "max_level": 3,
+      "rarity_weight": 1,
+      "cursed": false,
+      "sources": [
+        "treasure"
+      ]
+    },
+    {
+      "id": 12,
+      "name": "swift_sneak",
+      "translation_key": "enchantment.minecraft.swift_sneak",
+      "min_level": 1,
+      "max_level": 3,
+      "rarity_weight": 1,
+      "cursed": false,
+      "sources": [
+        "treasure"
+      ]
+    },
+    {
+      "id": 13,
+      "name": "sharpness",
+      "translation_key": "enchantment.minecraft.sharpness",
+      "min_level": 1,
+      "max_level": 5,
+      "rarity_weight": 10,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 14,
+      "name": "smite",
+      "translation_key": "enchantment.minecraft.smite",
+      "min_level": 1,
+      "max_level": 5,
+      "rarity_weight": 5,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 15,
+      "name": "bane_of_arthropods",
+      "translation_key": "enchantment.minecraft.bane_of_arthropods",
+      "min_level": 1,
+      "max_level": 5,
+      "rarity_weight": 5,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 16,
+      "name": "knockback",
+      "translation_key": "enchantment.minecraft.knockback",
+      "min_level": 1,
+      "max_level": 2,
+      "rarity_weight": 5,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 17,
+      "name": "fire_aspect",
+      "translation_key": "enchantment.minecraft.fire_aspect",
+      "min_level": 1,
+      "max_level": 2,
+      "rarity_weight": 2,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 18,
+      "name": "looting",
+      "translation_key": "enchantment.minecraft.looting",
+      "min_level": 1,
+      "max_level": 3,
+      "rarity_weight": 2,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 19,
+      "name": "sweeping",
+      "translation_key": "enchantment.minecraft.sweeping",
+      "min_level": 1,
+      "max_level": 3,
+      "rarity_weight": 2,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 20,
+      "name": "efficiency",
+      "translation_key": "enchantment.minecraft.efficiency",
+      "min_level": 1,
+      "max_level": 5,
+      "rarity_weight": 10,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 21,
+      "name": "silk_touch",
+      "translation_key": "enchantment.minecraft.silk_touch",
+      "min_level": 1,
+      "max_level": 1,
+      "rarity_weight": 1,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 22,
+      "name": "unbreaking",
+      "translation_key": "enchantment.minecraft.unbreaking",
+      "min_level": 1,
+      "max_level": 3,
+      "rarity_weight": 5,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 23,
+      "name": "fortune",
+      "translation_key": "enchantment.minecraft.fortune",
+      "min_level": 1,
+      "max_level": 3,
+      "rarity_weight": 2,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 24,
+      "name": "power",
+      "translation_key": "enchantment.minecraft.power",
+      "min_level": 1,
+      "max_level": 5,
+      "rarity_weight": 10,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 25,
+      "name": "punch",
+      "translation_key": "enchantment.minecraft.punch",
+      "min_level": 1,
+      "max_level": 2,
+      "rarity_weight": 2,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 26,
+      "name": "flame",
+      "translation_key": "enchantment.minecraft.flame",
+      "min_level": 1,
+      "max_level": 1,
+      "rarity_weight": 2,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 27,
+      "name": "infinity",
+      "translation_key": "enchantment.minecraft.infinity",
+      "min_level": 1,
+      "max_level": 1,
+      "rarity_weight": 1,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 28,
+      "name": "luck_of_the_sea",
+      "translation_key": "enchantment.minecraft.luck_of_the_sea",
+      "min_level": 1,
+      "max_level": 3,
+      "rarity_weight": 2,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 29,
+      "name": "lure",
+      "translation_key": "enchantment.minecraft.lure",
+      "min_level": 1,
+      "max_level": 3,
+      "rarity_weight": 2,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 30,
+      "name": "loyalty",
+      "translation_key": "enchantment.minecraft.loyalty",
+      "min_level": 1,
+      "max_level": 3,
+      "rarity_weight": 5,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 31,
+      "name": "impaling",
+      "translation_key": "enchantment.minecraft.impaling",
+      "min_level": 1,
+      "max_level": 5,
+      "rarity_weight": 2,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 32,
+      "name": "riptide",
+      "translation_key": "enchantment.minecraft.riptide",
+      "min_level": 1,
+      "max_level": 3,
+      "rarity_weight": 2,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 33,
+      "name": "channeling",
+      "translation_key": "enchantment.minecraft.channeling",
+      "min_level": 1,
+      "max_level": 1,
+      "rarity_weight": 1,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 34,
+      "name": "multishot",
+      "translation_key": "enchantment.minecraft.multishot",
+      "min_level": 1,
+      "max_level": 1,
+      "rarity_weight": 2,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 35,
+      "name": "quick_charge",
+      "translation_key": "enchantment.minecraft.quick_charge",
+      "min_level": 1,
+      "max_level": 3,
+      "rarity_weight": 5,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 36,
+      "name": "piercing",
+      "translation_key": "enchantment.minecraft.piercing",
+      "min_level": 1,
+      "max_level": 4,
+      "rarity_weight": 10,
+      "cursed": false,
+      "sources": [
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 37,
+      "name": "mending",
+      "translation_key": "enchantment.minecraft.mending",
+      "min_level": 1,
+      "max_level": 1,
+      "rarity_weight": 2,
+      "cursed": false,
+      "sources": [
+        "treasure",
+        "enchantment_table",
+        "random_selection"
+      ]
+    },
+    {
+      "id": 38,
+      "name": "vanishing_curse",
+      "translation_key": "enchantment.minecraft.vanishing_curse",
+      "min_level": 1,
+      "max_level": 1,
+      "rarity_weight": 1,
+      "cursed": true,
+      "sources": [
+        "treasure",
+        "enchantment_table",
+        "random_selection"
+      ]
+    }
+  ]
+}

--- a/extractor/src/main/java/dev/_00a/valence_extractor/Main.java
+++ b/extractor/src/main/java/dev/_00a/valence_extractor/Main.java
@@ -6,6 +6,7 @@ import dev._00a.valence_extractor.extractors.Blocks;
 import dev._00a.valence_extractor.extractors.Entities;
 import dev._00a.valence_extractor.extractors.EntityData;
 import dev._00a.valence_extractor.extractors.Packets;
+import dev._00a.valence_extractor.extractors.Enchants;
 import net.fabricmc.api.ModInitializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,7 +41,7 @@ public class Main implements ModInitializer {
     public void onInitialize() {
         LOGGER.info("Starting extractors...");
 
-        var extractors = new Extractor[]{new Blocks(), new Entities(), new EntityData(), new Packets()};
+        var extractors = new Extractor[]{new Blocks(), new Entities(), new EntityData(), new Packets(), new Enchants()};
 
         Path outputDirectory;
         try {

--- a/extractor/src/main/java/dev/_00a/valence_extractor/extractors/Enchants.java
+++ b/extractor/src/main/java/dev/_00a/valence_extractor/extractors/Enchants.java
@@ -32,17 +32,12 @@ public class Enchants implements Main.Extractor {
             enchantJson.addProperty("rarity_weight", enchant.getRarity().getWeight());
             enchantJson.addProperty("cursed", enchant.isCursed());
 
-            var enchantmentSources = new JsonArray();
-            if(enchant.isTreasure()){
-                enchantmentSources.add("treasure");
-            }
-            if(enchant.isAvailableForEnchantedBookOffer()){
-                enchantmentSources.add("enchantment_table");
-            }
+            var enchantmentSources = new JsonObject();
+            enchantmentSources.addProperty("treasure", enchant.isTreasure());
+            enchantmentSources.addProperty("enchantment_table", enchant.isAvailableForEnchantedBookOffer());
             //All enchants except for 'Soul speed' and 'Swift sneak' are available for random selection and are only obtainable from loot chests.
-            if(enchant.isAvailableForRandomSelection()){
-                enchantmentSources.add("random_selection");
-            }
+            enchantmentSources.addProperty("random_selection", enchant.isAvailableForRandomSelection());
+
             enchantJson.add("sources", enchantmentSources);
 
             enchantsJson.add(enchantJson);

--- a/extractor/src/main/java/dev/_00a/valence_extractor/extractors/Enchants.java
+++ b/extractor/src/main/java/dev/_00a/valence_extractor/extractors/Enchants.java
@@ -1,0 +1,54 @@
+package dev._00a.valence_extractor.extractors;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import dev._00a.valence_extractor.Main;
+import net.minecraft.util.registry.Registry;
+
+public class Enchants implements Main.Extractor {
+    public Enchants() {
+    }
+
+    @Override
+    public String fileName() {
+        return "enchants.json";
+    }
+
+    @Override
+    public JsonElement extract() {
+        var topLevelJson = new JsonObject();
+        var enchantsJson = new JsonArray();
+
+        for (var enchant : Registry.ENCHANTMENT) {
+            var enchantJson = new JsonObject();
+
+            enchantJson.addProperty("id", Registry.ENCHANTMENT.getRawId(enchant));
+            enchantJson.addProperty("name", Registry.ENCHANTMENT.getId(enchant).getPath());
+            enchantJson.addProperty("translation_key", enchant.getTranslationKey());
+
+            enchantJson.addProperty("min_level", enchant.getMinLevel());
+            enchantJson.addProperty("max_level", enchant.getMaxLevel());
+            enchantJson.addProperty("rarity_weight", enchant.getRarity().getWeight());
+            enchantJson.addProperty("cursed", enchant.isCursed());
+
+            var enchantmentSources = new JsonArray();
+            if(enchant.isTreasure()){
+                enchantmentSources.add("treasure");
+            }
+            if(enchant.isAvailableForEnchantedBookOffer()){
+                enchantmentSources.add("enchantment_table");
+            }
+            //All enchants except for 'Soul speed' and 'Swift sneak' are available for random selection and are only obtainable from loot chests.
+            if(enchant.isAvailableForRandomSelection()){
+                enchantmentSources.add("random_selection");
+            }
+            enchantJson.add("sources", enchantmentSources);
+
+            enchantsJson.add(enchantJson);
+        }
+
+        topLevelJson.add("enchants", enchantsJson);
+        return topLevelJson;
+    }
+}


### PR DESCRIPTION
This adds basic enchantment extraction into the JSON file. Note: No rust parser has yet been written.

Do we want the top level to be an array or an object as currently defined in [enchants.json](https://github.com/valence-rs/valence/compare/main...TerminatorNL:valence:enchant-extract?expand=1#diff-bdab9517c426197356200e180fd7375d4598b135622b05cc63efbcdb62378c99)? I used the other extracted files as reference and they use objects.