### PR TITLE
Replace HashMap with BTreeMap in valence_nbt

### DIFF
--- a/valence_nbt/Cargo.toml
+++ b/valence_nbt/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/valence-rs/valence_nbt"
 readme = "README.md"
 license = "MIT"
 keywords = ["nbt", "minecraft", "serialization"]
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Ryan Johnson <ryanj00a@gmail.com>"]
 edition = "2021"
 


### PR DESCRIPTION
Turns out that `BTreeMap`s are a bit faster when the element count is low.

This change also makes debugging compounds easier since the elements are displayed in sorted order.