### PR TITLE
Implemented Weather

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -5,7 +5,6 @@ use std::iter::FusedIterator;
 use std::mem;
 use std::time::Duration;
 
-use anyhow::ensure;
 pub use bitfield_struct::bitfield;
 pub use event::*;
 use flume::{Receiver, Sender, TrySendError};

--- a/src/client.rs
+++ b/src/client.rs
@@ -1164,7 +1164,11 @@ impl<C: Config> Client<C> {
             if self.old_raining != self.new_raining {
                 self.old_raining = self.new_raining;
                 self.send_packet(GameEvent {
-                    reason: if self.old_raining {GameStateChangeReason::BeginRaining} else {GameStateChangeReason::EndRaining},
+                    reason: if self.old_raining {
+                        GameStateChangeReason::BeginRaining
+                    } else {
+                        GameStateChangeReason::EndRaining
+                    },
                     value: 0 as f32,
                 })
             }
@@ -1173,7 +1177,7 @@ impl<C: Config> Client<C> {
                 self.old_rain_level = self.new_rain_level;
                 self.send_packet(GameEvent {
                     reason: GameStateChangeReason::RainLevelChange,
-                    value: self.old_rain_level as f32,
+                    value: self.old_rain_level,
                 });
             }
 
@@ -1181,7 +1185,7 @@ impl<C: Config> Client<C> {
                 self.old_thunder_level = self.new_thunder_level;
                 self.send_packet(GameEvent {
                     reason: GameStateChangeReason::ThunderLevelChange,
-                    value: self.old_thunder_level as f32,
+                    value: self.old_thunder_level,
                 });
             }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -465,7 +465,7 @@ impl<C: Config> Client<C> {
         self.new_game_mode = game_mode;
     }
 
-    /// Sets sets whether it rains
+    /// Sets whether or not the client sees rain.
     pub fn set_raining(&mut self, raining: bool) {
         self.send_packet(GameEvent {
             reason: if raining {
@@ -477,35 +477,30 @@ impl<C: Config> Client<C> {
         })
     }
 
-    /// Sets the client's rain level
-    /// The rain level must be a float between 0.0 and 1.0.
-    /// This changes the skycolor and lightning on the client.
-    pub fn set_rain_level(&mut self, rain_level: f32) -> anyhow::Result<()> {
-        ensure!(
-            (0.0..=1.0).contains(&rain_level),
-            "the rain level must be between 0 and 1"
-        );
+    /// Sets the client's rain level. This changes the sky color and lightning
+    /// on the client.
+    ///
+    /// The rain level is clamped between `0.0.` and `1.0`.
+    pub fn set_rain_level(&mut self, rain_level: f32) {
         self.send_packet(GameEvent {
             reason: GameStateChangeReason::RainLevelChange,
-            value: rain_level,
+            value: rain_level.clamp(0.0, 1.0),
         });
-        Ok(())
     }
 
-    /// Sets the client's thunder level
-    /// Requires either to start a rain with `set_raining` or set the rain level
-    /// with `set_rain_level`. The thunder level must be a float between 0.0
-    /// and 1.0. This changes the skycolor and lightning on the client.
-    pub fn set_thunder_level(&mut self, thunder_level: f32) -> anyhow::Result<()> {
-        ensure!(
-            (0.0..=1.0).contains(&thunder_level),
-            "the thunder level must be between 0 and 1"
-        );
+    /// Sets the client's thunder level. This changes the sky color and
+    /// lightning on the client.
+    ///
+    /// For this to take effect, it must already be raining via
+    /// [`set_raining`](Self::set_raining) or
+    /// [`set_rain_level`](Self::set_rain_level).
+    ///
+    /// The thunder level is clamped between `0.0` and `1.0`.
+    pub fn set_thunder_level(&mut self, thunder_level: f32) {
         self.send_packet(GameEvent {
             reason: GameStateChangeReason::ThunderLevelChange,
-            value: thunder_level,
+            value: thunder_level.clamp(0.0, 1.0),
         });
-        Ok(())
     }
 
     /// Plays a sound to the client at a given position.


### PR DESCRIPTION
This PR implements Weather.
# Issue
Closes #105

Im currently not sure how design the api for weather.
**Current State** (by Game Event)
```rust
client.set_raining(true);
client.set_rain_level(0.5); // does not depend on set_raining
client.set_thunder_level(0.3); // does depend on set_raining (or set_rain_level)
```
**Idea 2** (without set_raining)
```rust
client.set_rain_level(0.5);
client.set_thunder_level(0.3); // does depend on set_rain_level
```
**Idea 3**
```rust
client.set_rain(0.5);
client.set_thunder(0.3); // does depend on set_rain_level
client.set_thunder(0.5/*rain level*/, 0.3/*thunder level*/); // does depend on set_rain_level
```

**Idea 4**
```rust
client.set_weather(Weather::Rain);
client.set_weather(Weather::Rain, 0.5);
client.set_weather(Weather::Thunder); // depends on enabling the rain first
client.set_weather(Weather::Thunder, 0.3); // depends on enabling the rain first
```
I would be happy if someone would give their opinion on this.