### PR TITLE
Update valence_nbt to version 0.3.0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,14 +79,14 @@
     trivial_casts,
     trivial_numeric_casts,
     unused_lifetimes,
-    unused_import_braces
+    unused_import_braces,
+    clippy::dbg_macro
 )]
 #![allow(
     clippy::derive_partial_eq_without_eq,
     clippy::unusual_byte_groupings,
     clippy::comparison_chain
 )]
-#![deny(clippy::dbg_macro)]
 
 /// Used on [`Config`](config::Config) to allow for async methods in traits.
 ///

--- a/valence_nbt/Cargo.toml
+++ b/valence_nbt/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/valence-rs/valence/tree/main/valence_nbt"
 readme = "README.md"
 license = "MIT"
 keywords = ["nbt", "minecraft", "serialization"]
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Ryan Johnson <ryanj00a@gmail.com>"]
 edition = "2021"
 

--- a/valence_nbt/src/compound.rs
+++ b/valence_nbt/src/compound.rs
@@ -28,7 +28,7 @@ impl Compound {
     /// If the result is `Err`, then the reported count will be greater than or
     /// equal to the number of bytes that have actually been written.
     ///
-    /// [`to_binary_writer`]: crate::to_binary_writer
+    /// [`to_binary_writer`]: crate::to_binary_writer()
     pub fn binary_encoded_len(&self, root_name: &str) -> usize {
         encoded_len(self, root_name)
     }

--- a/valence_nbt/src/compound.rs
+++ b/valence_nbt/src/compound.rs
@@ -3,6 +3,7 @@ use std::hash::Hash;
 use std::iter::FusedIterator;
 use std::ops::{Index, IndexMut};
 
+use crate::to_binary_writer::encoded_len;
 use crate::Value;
 
 /// A map type with [`String`] keys and [`Value`] values.
@@ -16,6 +17,22 @@ type Map = std::collections::BTreeMap<String, Value>;
 
 #[cfg(feature = "preserve_order")]
 type Map = indexmap::IndexMap<String, Value>;
+
+impl Compound {
+    /// Returns the number of bytes that will be written with
+    /// [`to_binary_writer`] when called with this compound and root name.
+    ///
+    /// If [`to_binary_writer`] results in `Ok`, the exact number of bytes
+    /// reported by this function will have been written.
+    ///
+    /// If the result is `Err`, then the reported count will be greater than or
+    /// equal to the number of bytes that have actually been written.
+    ///
+    /// [`to_binary_writer`]: crate::to_binary_writer
+    pub fn binary_encoded_len(&self, root_name: &str) -> usize {
+        encoded_len(self, root_name)
+    }
+}
 
 impl Compound {
     pub fn new() -> Self {

--- a/valence_nbt/src/from_binary_slice.rs
+++ b/valence_nbt/src/from_binary_slice.rs
@@ -4,7 +4,7 @@ use byteorder::{BigEndian, ReadBytesExt};
 use cesu8::Cesu8DecodingError;
 
 use crate::tag::Tag;
-use crate::{Compound, Error, List, Result, Value, MAX_DEPTH};
+use crate::{Compound, Error, List, Result, Value};
 
 /// Decodes uncompressed NBT binary data from the provided slice.
 ///
@@ -26,6 +26,9 @@ pub fn from_binary_slice(slice: &mut &[u8]) -> Result<(Compound, String)> {
 
     Ok((root, root_name))
 }
+
+/// Maximum recursion depth to prevent overflowing the call stack.
+const MAX_DEPTH: usize = 512;
 
 struct DecodeState<'a, 'b> {
     slice: &'a mut &'b [u8],

--- a/valence_nbt/src/lib.rs
+++ b/valence_nbt/src/lib.rs
@@ -49,7 +49,22 @@
 //! preserved during insertion and deletion at a slight cost to performance.
 //! The iterators on `Compound` can then implement [`DoubleEndedIterator`].
 
-#![deny(unsafe_code)]
+#![deny(
+    rustdoc::broken_intra_doc_links,
+    rustdoc::private_intra_doc_links,
+    rustdoc::missing_crate_level_docs,
+    rustdoc::invalid_codeblock_attributes,
+    rustdoc::invalid_rust_codeblocks,
+    rustdoc::bare_urls
+)]
+#![warn(
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_lifetimes,
+    unused_import_braces,
+    clippy::dbg_macro
+)]
+#![allow(clippy::unusual_byte_groupings)]
 
 pub use compound::Compound;
 pub use error::Error;
@@ -60,15 +75,13 @@ pub use value::{List, Value};
 pub mod compound;
 mod error;
 mod from_binary_slice;
+mod modified_utf8;
 mod to_binary_writer;
 pub mod value;
 
 mod tag;
 #[cfg(test)]
 mod tests;
-
-/// Maximum recursion depth to prevent overflowing the call stack.
-const MAX_DEPTH: usize = 512;
 
 type Result<T> = std::result::Result<T, Error>;
 

--- a/valence_nbt/src/modified_utf8.rs
+++ b/valence_nbt/src/modified_utf8.rs
@@ -1,8 +1,9 @@
-/// Utilities for working with Java's "Modified UTF-8" character encoding.
-///
-/// For more information, refer to [Wikipedia].
-///
-/// [Wikipedia]: https://en.wikipedia.org/wiki/UTF-8#Modified_UTF-8
+//! Utilities for working with Java's "Modified UTF-8" character encoding.
+//!
+//! For more information, refer to [Wikipedia].
+//!
+//! [Wikipedia]: https://en.wikipedia.org/wiki/UTF-8#Modified_UTF-8
+
 use std::io;
 use std::io::Write;
 use std::str::from_utf8_unchecked;

--- a/valence_nbt/src/modified_utf8.rs
+++ b/valence_nbt/src/modified_utf8.rs
@@ -1,0 +1,127 @@
+/// Utilities for working with Java's "Modified UTF-8" character encoding.
+///
+/// For more information, refer to [Wikipedia].
+///
+/// [Wikipedia]: https://en.wikipedia.org/wiki/UTF-8#Modified_UTF-8
+use std::io;
+use std::io::Write;
+use std::str::from_utf8_unchecked;
+
+use byteorder::{BigEndian, WriteBytesExt};
+
+pub fn write_modified_utf8(mut writer: impl Write, text: &str) -> io::Result<()> {
+    let bytes = text.as_bytes();
+    let mut i = 0;
+
+    while i < bytes.len() {
+        match bytes[i] {
+            0 => {
+                writer.write_u16::<BigEndian>(0xc080)?;
+                i += 1;
+            }
+            b @ 1..=127 => {
+                writer.write_u8(b)?;
+                i += 1;
+            }
+            b => {
+                let w = utf8_char_width(b);
+                debug_assert!(w <= 4);
+                debug_assert!(i + w <= bytes.len());
+
+                if w != 4 {
+                    writer.write_all(&bytes[i..i + w])?;
+                } else {
+                    let s = unsafe { from_utf8_unchecked(&bytes[i..i + w]) };
+                    let c = s.chars().next().unwrap() as u32 - 0x10000;
+
+                    let s0 = ((c >> 10) as u16) | 0xd800;
+                    let s1 = ((c & 0x3ff) as u16) | 0xdc00;
+
+                    writer.write_all(encode_surrogate(s0).as_slice())?;
+                    writer.write_all(encode_surrogate(s1).as_slice())?;
+                }
+                i += w;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+const fn utf8_char_width(first_byte: u8) -> usize {
+    const UTF8_CHAR_WIDTH: [u8; 256] = [
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+        4, 4, 4, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ];
+
+    UTF8_CHAR_WIDTH[first_byte as usize] as _
+}
+
+fn encode_surrogate(surrogate: u16) -> [u8; 3] {
+    debug_assert!((0xd800..=0xdfff).contains(&surrogate));
+
+    const TAG_CONT_U8: u8 = 0b1000_0000u8;
+    [
+        0b11100000 | ((surrogate & 0b11110000_00000000) >> 12) as u8,
+        TAG_CONT_U8 | ((surrogate & 0b00001111_11000000) >> 6) as u8,
+        TAG_CONT_U8 | (surrogate & 0b00000000_00111111) as u8,
+    ]
+}
+
+pub fn encoded_len(text: &str) -> usize {
+    let mut n = 0;
+    let mut i = 0;
+    let bytes = text.as_bytes();
+
+    while i < bytes.len() {
+        match bytes[i] {
+            0 => {
+                n += 2;
+                i += 1;
+            }
+            // Fast path for ASCII here makes a huge difference in benchmarks.
+            1..=127 => {
+                n += 1;
+                i += 1;
+            }
+            b => {
+                let w = utf8_char_width(b);
+
+                if w == 4 {
+                    n += 6;
+                } else {
+                    n += w;
+                }
+
+                i += w;
+            }
+        }
+    }
+
+    n
+}
+
+#[cfg(test)]
+#[test]
+fn equivalence() {
+    fn check(s: &str) {
+        let mut ours = Vec::new();
+
+        let theirs = cesu8::to_java_cesu8(s);
+        write_modified_utf8(&mut ours, s).unwrap();
+
+        assert_eq!(theirs, ours);
+        assert_eq!(theirs.len(), encoded_len(s));
+    }
+
+    check("Mary had a little lamb\0");
+    check("🤡💩👻💀☠👽👾🤖🎃😺😸😹😻😼😽🙀😿😾");
+    check("ÅÆÇÈØõ÷£¥ý");
+}


### PR DESCRIPTION
Improves write performance and adds `encoded_len` to compounds.