### PR TITLE
Add reverse From<Value> for Option<T>

### DIFF
--- a/valence_nbt/src/value.rs
+++ b/valence_nbt/src/value.rs
@@ -234,3 +234,123 @@ impl From<Vec<Vec<i64>>> for List {
         List::LongArray(v)
     }
 }
+
+impl From<Value> for Option<i8> {
+    fn from(value: Value) -> Self {
+        if let Value::Byte(b) = value {
+            Some(b)
+        } else {
+            None
+        }
+    }
+}
+
+impl From<Value> for Option<i16> {
+    fn from(value: Value) -> Self {
+        if let Value::Short(val) = value {
+            Some(val)
+        } else {
+            None
+        }
+    }
+}
+
+impl From<Value> for Option<i32> {
+    fn from(value: Value) -> Self {
+        if let Value::Int(val) = value {
+            Some(val)
+        } else {
+            None
+        }
+    }
+}
+
+impl From<Value> for Option<i64> {
+    fn from(value: Value) -> Self {
+        if let Value::Long(val) = value {
+            Some(val)
+        } else {
+            None
+        }
+    }
+}
+
+impl From<Value> for Option<f32> {
+    fn from(value: Value) -> Self {
+        if let Value::Float(val) = value {
+            Some(val)
+        } else {
+            None
+        }
+    }
+}
+
+impl From<Value> for Option<f64> {
+    fn from(value: Value) -> Self {
+        if let Value::Double(val) = value {
+            Some(val)
+        } else {
+            None
+        }
+    }
+}
+
+impl From<Value> for Option<Vec<i8>> {
+    fn from(value: Value) -> Self {
+        if let Value::ByteArray(val) = value {
+            Some(val)
+        } else {
+            None
+        }
+    }
+}
+
+impl From<Value> for Option<String> {
+    fn from(value: Value) -> Self {
+        if let Value::String(val) = value {
+            Some(val)
+        } else {
+            None
+        }
+    }
+}
+
+impl From<Value> for Option<List> {
+    fn from(value: Value) -> Self {
+        if let Value::List(val) = value {
+            Some(val)
+        } else {
+            None
+        }
+    }
+}
+
+impl From<Value> for Option<Compound> {
+    fn from(value: Value) -> Self {
+        if let Value::Compound(val) = value {
+            Some(val)
+        } else {
+            None
+        }
+    }
+}
+
+impl From<Value> for Option<Vec<i32>> {
+    fn from(value: Value) -> Self {
+        if let Value::IntArray(val) = value {
+            Some(val)
+        } else {
+            None
+        }
+    }
+}
+
+impl From<Value> for Option<Vec<i64>> {
+    fn from(value: Value) -> Self {
+        if let Value::LongArray(val) = value {
+            Some(val)
+        } else {
+            None
+        }
+    }
+}


### PR DESCRIPTION
This PR only adds implementations for `From<Value>` for `Option<T>`
This allows the use of generic bounds to specify the return type and get `None` if the value does not match the type.

Example use case (absent from this PR):
```rust
fn take_assume<R>(compound: &mut Compound, key: &'static str) -> Result<R, Error>
where
    Option<R>: From<Value>,
{
    match compound.remove(key) {
        None => Err(Error::missing_nbt_value(key)),
        Some(value) => {
            if let Some(value) = Option::<R>::from(value) {
                Ok(value)
            } else {
                Err(Error::invalid_nbt(key))
            }
        }
    }
}
```

Which would allow using the following:
```rust
let x: i32 = take_assume(&mut nbt, "xPos")?;
let y: i32 = take_assume(&mut nbt, "zPos")?;
let z: i32 = take_assume(&mut nbt, "yPos")?;

let status: String = take_assume(&mut nbt, "Status")?;
let last_update: i64 = take_assume(&mut nbt, "LastUpdate")?;
```

This creates an easier way to fail-fast while parsing NBT using custom `Error`s as shown in the first block.