### PR TITLE
Fix Inventory `consume_one`

### DIFF
--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -26,10 +26,10 @@ pub trait Inventory {
     fn consume_one(&mut self, slot_id: SlotId) {
         let mut slot = self.slot(slot_id).cloned();
         if let Some(stack) = slot.as_mut() {
-            stack.set_count(stack.count() - 1);
-            let slot = if stack.count() == 0 {
+            let slot = if stack.count() <= 1 {
                 None
             } else {
+                stack.set_count(stack.count() - 1);
                 Some(stack)
             };
             self.set_slot(slot_id, slot.cloned());


### PR DESCRIPTION
Since `ItemStack::set_count()` is bound to 1-127 inclusive it is impossible to set the count to 0. Previously consuming one from a stack of one would do nothing. Now the count is only set if there are more than one item in the stack.