### PR TITLE
Add prelude module to valence.

### DIFF
--- a/examples/biomes.rs
+++ b/examples/biomes.rs
@@ -3,17 +3,7 @@ use std::net::SocketAddr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use log::LevelFilter;
-use valence::biome::Biome;
-use valence::block::BlockState;
-use valence::chunk::{Chunk, UnloadedChunk};
-use valence::client::GameMode;
-use valence::config::{Config, ServerListPing};
-use valence::dimension::{Dimension, DimensionId};
-use valence::entity::{EntityId, EntityKind};
-use valence::player_list::PlayerListId;
-use valence::server::{Server, SharedServer, ShutdownResult};
-use valence::text::{Color, TextFormat};
-use valence::{async_trait, ident};
+use valence::prelude::*;
 
 pub fn main() -> ShutdownResult {
     env_logger::Builder::new()
@@ -43,9 +33,7 @@ struct ClientState {
 }
 
 const MAX_PLAYERS: usize = 10;
-
 const BIOME_COUNT: usize = 10;
-
 const MIN_Y: i32 = -64;
 
 #[async_trait]

--- a/examples/building.rs
+++ b/examples/building.rs
@@ -3,16 +3,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use log::LevelFilter;
 use num::Integer;
-use valence::async_trait;
-use valence::block::BlockState;
-use valence::chunk::{Chunk, UnloadedChunk};
-use valence::client::{handle_event_default, ClientEvent, DiggingStatus, GameMode, Hand};
-use valence::config::{Config, ServerListPing};
-use valence::dimension::{Dimension, DimensionId};
-use valence::entity::{EntityId, EntityKind};
-use valence::player_list::PlayerListId;
-use valence::server::{Server, SharedServer, ShutdownResult};
-use valence::text::{Color, TextFormat};
+use valence::client::{DiggingStatus, Hand};
+use valence::prelude::*;
 
 pub fn main() -> ShutdownResult {
     env_logger::Builder::new()

--- a/examples/chest.rs
+++ b/examples/chest.rs
@@ -3,19 +3,9 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use log::LevelFilter;
 use num::Integer;
-use valence::async_trait;
-use valence::block::BlockState;
-use valence::chunk::UnloadedChunk;
-use valence::client::{handle_event_default, ClientEvent, Hand};
-use valence::config::{Config, ServerListPing};
-use valence::dimension::{Dimension, DimensionId};
-use valence::entity::{EntityId, EntityKind};
-use valence::inventory::{ConfigurableInventory, Inventory, InventoryId, PlayerInventory};
-use valence::item::{ItemKind, ItemStack};
-use valence::player_list::PlayerListId;
+use valence::client::Hand;
+use valence::prelude::*;
 use valence::protocol::{SlotId, VarInt};
-use valence::server::{Server, SharedServer, ShutdownResult};
-use valence::text::{Color, TextFormat};
 
 pub fn main() -> ShutdownResult {
     env_logger::Builder::new()

--- a/examples/combat.rs
+++ b/examples/combat.rs
@@ -2,19 +2,8 @@ use std::net::SocketAddr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use log::LevelFilter;
-use valence::block::{BlockPos, BlockState};
-use valence::chunk::{Chunk, UnloadedChunk};
-use valence::client::{
-    handle_event_default, ClientEvent, ClientId, GameMode, InteractWithEntityKind,
-};
-use valence::config::{Config, ServerListPing};
-use valence::dimension::DimensionId;
-use valence::entity::{EntityEvent, EntityId, EntityKind};
-use valence::player_list::PlayerListId;
-use valence::server::{Server, SharedServer, ShutdownResult};
-use valence::text::{Color, TextFormat};
-use valence::{async_trait, Ticks};
-use vek::{Vec2, Vec3};
+use valence::client::InteractWithEntityKind;
+use valence::prelude::*;
 
 pub fn main() -> ShutdownResult {
     env_logger::Builder::new()

--- a/examples/conway.rs
+++ b/examples/conway.rs
@@ -4,21 +4,12 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use log::LevelFilter;
 use num::Integer;
-use rayon::iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
-use valence::biome::Biome;
-use valence::block::BlockState;
-use valence::chunk::{Chunk, UnloadedChunk};
-use valence::client::{handle_event_default, ClientEvent, Hand};
-use valence::config::{Config, ServerListPing};
-use valence::dimension::{Dimension, DimensionId};
+use rayon::prelude::*;
+use valence::client::Hand;
 use valence::entity::types::Pose;
-use valence::entity::{EntityId, EntityKind, TrackedData};
-use valence::player_list::PlayerListId;
+use valence::prelude::*;
+// TODO: re-export this somewhere in valence.
 use valence::protocol::packets::s2c::play::SoundCategory;
-use valence::server::{Server, SharedServer, ShutdownResult};
-use valence::text::{Color, TextFormat};
-use valence::{async_trait, ident};
-use vek::Vec3;
 
 pub fn main() -> ShutdownResult {
     env_logger::Builder::new()

--- a/examples/cow_sphere.rs
+++ b/examples/cow_sphere.rs
@@ -5,18 +5,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use log::LevelFilter;
 use uuid::Uuid;
-use valence::async_trait;
-use valence::block::{BlockPos, BlockState};
-use valence::chunk::UnloadedChunk;
-use valence::client::{handle_event_default, GameMode};
-use valence::config::{Config, PlayerSampleEntry, ServerListPing};
-use valence::dimension::DimensionId;
-use valence::entity::{EntityId, EntityKind};
-use valence::player_list::PlayerListId;
-use valence::server::{Server, SharedServer, ShutdownResult};
-use valence::text::{Color, TextFormat};
-use valence::util::to_yaw_and_pitch;
-use vek::{Mat3, Vec3};
+use valence::prelude::*;
 
 pub fn main() -> ShutdownResult {
     env_logger::Builder::new()

--- a/examples/death.rs
+++ b/examples/death.rs
@@ -2,18 +2,7 @@ use std::net::SocketAddr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use log::LevelFilter;
-use valence::async_trait;
-use valence::block::{BlockPos, BlockState};
-use valence::chunk::UnloadedChunk;
-use valence::client::{handle_event_default, ClientEvent};
-use valence::config::{Config, ServerListPing};
-use valence::dimension::Dimension;
-use valence::entity::{EntityId, EntityKind};
-use valence::player_list::PlayerListId;
-use valence::server::{Server, SharedServer, ShutdownResult};
-use valence::text::{Color, TextFormat};
-use valence::world::WorldId;
-use vek::Vec3;
+use valence::prelude::*;
 
 pub fn main() -> ShutdownResult {
     env_logger::Builder::new()
@@ -89,10 +78,6 @@ impl Config for Game {
     type WorldState = WorldState;
     type ChunkState = ();
     type PlayerListState = ();
-
-    fn online_mode(&self) -> bool {
-        false
-    }
 
     fn max_connections(&self) -> usize {
         // We want status pings to be successful even if the server is full.

--- a/examples/entity_raycast.rs
+++ b/examples/entity_raycast.rs
@@ -2,21 +2,8 @@ use std::net::SocketAddr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use log::LevelFilter;
-use uuid::Uuid;
-use valence::async_trait;
-use valence::block::{BlockPos, BlockState};
-use valence::chunk::UnloadedChunk;
-use valence::client::{handle_event_default, GameMode};
-use valence::config::{Config, ServerListPing};
-use valence::dimension::DimensionId;
 use valence::entity::types::{Facing, PaintingKind, Pose};
-use valence::entity::{EntityId, EntityKind, TrackedData};
-use valence::player_list::PlayerListId;
-use valence::server::{Server, SharedServer, ShutdownResult};
-use valence::spatial_index::RaycastHit;
-use valence::text::{Color, TextFormat};
-use valence::util::from_yaw_and_pitch;
-use vek::Vec3;
+use valence::prelude::*;
 
 pub fn main() -> ShutdownResult {
     env_logger::Builder::new()

--- a/examples/inventory_piano.rs
+++ b/examples/inventory_piano.rs
@@ -3,19 +3,11 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use log::LevelFilter;
 use num::Integer;
-use valence::block::BlockState;
-use valence::chunk::{Chunk, UnloadedChunk};
-use valence::client::{handle_event_default, Client, ClientEvent, GameMode};
-use valence::config::{Config, ServerListPing};
-use valence::dimension::{Dimension, DimensionId};
-use valence::entity::{Entity, EntityId, EntityKind};
-use valence::player_list::PlayerListId;
+pub use valence::prelude::*;
+// TODO: remove protocol imports.
 use valence::protocol::packets::c2s::play::ClickContainerMode;
 use valence::protocol::packets::s2c::play::SoundCategory;
 use valence::protocol::SlotId;
-use valence::server::{Server, SharedServer, ShutdownResult};
-use valence::text::{Color, TextFormat};
-use valence::{async_trait, ident};
 
 pub fn main() -> ShutdownResult {
     env_logger::Builder::new()

--- a/examples/parkour.rs
+++ b/examples/parkour.rs
@@ -6,19 +6,10 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use log::LevelFilter;
 use rand::seq::SliceRandom;
 use rand::Rng;
-use valence::block::{BlockPos, BlockState};
-use valence::chunk::{ChunkPos, UnloadedChunk};
-use valence::client::{handle_event_default, Client, GameMode, SetTitleAnimationTimes};
-use valence::config::{Config, ServerListPing};
-use valence::dimension::DimensionId;
-use valence::entity::{EntityId, EntityKind};
-use valence::player_list::PlayerListId;
+use valence::client::SetTitleAnimationTimes;
+use valence::prelude::*;
+// TODO: remove protocol imports.
 use valence::protocol::packets::s2c::play::SoundCategory;
-use valence::server::{Server, SharedServer, ShutdownResult};
-use valence::text::{Color, TextFormat};
-use valence::util::chunks_in_view_distance;
-use valence::world::{World, WorldId};
-use valence::{async_trait, ident};
 
 pub fn main() -> ShutdownResult {
     env_logger::Builder::new()

--- a/examples/resource_pack.rs
+++ b/examples/resource_pack.rs
@@ -2,18 +2,8 @@ use std::net::SocketAddr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use log::LevelFilter;
-use valence::async_trait;
-use valence::block::{BlockPos, BlockState};
-use valence::chunk::UnloadedChunk;
-use valence::client::{
-    handle_event_default, Client, ClientEvent, GameMode, InteractWithEntityKind, ResourcePackStatus,
-};
-use valence::config::{Config, ServerListPing};
-use valence::dimension::DimensionId;
-use valence::entity::{EntityId, EntityKind, TrackedData};
-use valence::player_list::PlayerListId;
-use valence::server::{Server, SharedServer, ShutdownResult};
-use valence::text::{Color, TextFormat};
+use valence::client::{InteractWithEntityKind, ResourcePackStatus};
+use valence::prelude::*;
 
 pub fn main() -> ShutdownResult {
     env_logger::Builder::new()

--- a/examples/terrain.rs
+++ b/examples/terrain.rs
@@ -5,17 +5,7 @@ use std::time::SystemTime;
 use log::LevelFilter;
 use noise::{NoiseFn, Seedable, SuperSimplex};
 use rayon::iter::ParallelIterator;
-use valence::async_trait;
-use valence::block::{BlockState, PropName, PropValue};
-use valence::chunk::{Chunk, ChunkPos, UnloadedChunk};
-use valence::client::{handle_event_default, GameMode};
-use valence::config::{Config, ServerListPing};
-use valence::dimension::DimensionId;
-use valence::entity::{EntityId, EntityKind};
-use valence::player_list::PlayerListId;
-use valence::server::{Server, SharedServer, ShutdownResult};
-use valence::text::{Color, TextFormat};
-use valence::util::chunks_in_view_distance;
+pub use valence::prelude::*;
 use vek::Lerp;
 
 pub fn main() -> ShutdownResult {

--- a/performance_tests/players/src/main.rs
+++ b/performance_tests/players/src/main.rs
@@ -2,15 +2,7 @@ use std::net::SocketAddr;
 use std::time::Instant;
 
 use log::LevelFilter;
-use valence::async_trait;
-use valence::block::BlockState;
-use valence::chunk::{Chunk, UnloadedChunk};
-use valence::client::{handle_event_default, ClientEvent};
-use valence::config::{Config, ServerListPing};
-use valence::dimension::{Dimension, DimensionId};
-use valence::entity::{EntityId, EntityKind};
-use valence::player_list::PlayerListId;
-use valence::server::{Server, SharedServer, ShutdownResult};
+use valence::prelude::*;
 
 pub fn main() -> ShutdownResult {
     env_logger::Builder::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,8 +126,43 @@ pub mod text;
 pub mod util;
 pub mod world;
 
+/// Use `valence::prelude::*` to import the most commonly used items from the
+/// library.
+pub mod prelude {
+    pub use biome::{Biome, BiomeId};
+    pub use block::{BlockKind, BlockPos, BlockState, PropName, PropValue};
+    pub use chunk::{Chunk, ChunkPos, Chunks, LoadedChunk, UnloadedChunk};
+    pub use client::{handle_event_default, Client, ClientEvent, ClientId, Clients, GameMode};
+    pub use config::{Config, PlayerSampleEntry, ServerListPing};
+    pub use dimension::{Dimension, DimensionId};
+    pub use entity::{Entities, Entity, EntityEvent, EntityId, EntityKind, TrackedData};
+    pub use ident::{Ident, IdentError};
+    pub use inventory::{
+        ConfigurableInventory, Inventories, Inventory, InventoryId, PlayerInventory,
+    };
+    pub use item::{ItemKind, ItemStack};
+    pub use player_list::{PlayerList, PlayerListEntry, PlayerListId, PlayerLists};
+    pub use server::{NewClientData, Server, SharedServer, ShutdownResult};
+    pub use spatial_index::{RaycastHit, SpatialIndex};
+    pub use text::{Color, Text, TextFormat};
+    pub use util::{
+        chunks_in_view_distance, from_yaw_and_pitch, is_chunk_in_view_distance, to_yaw_and_pitch,
+    };
+    pub use uuid::Uuid;
+    pub use valence_nbt::Compound;
+    pub use vek::{Aabb, Mat2, Mat3, Mat4, Vec2, Vec3, Vec4};
+    pub use world::{World, WorldId, WorldMeta, Worlds};
+
+    use super::*;
+    pub use crate::{
+        async_trait, ident, nbt, vek, Ticks, LIBRARY_NAMESPACE, PROTOCOL_VERSION, STANDARD_TPS,
+        VERSION_NAME,
+    };
+}
+
 /// The Minecraft protocol version this library currently targets.
 pub const PROTOCOL_VERSION: i32 = 760;
+
 /// The name of the Minecraft version this library currently targets, e.g.
 /// "1.8.2"
 pub const VERSION_NAME: &str = "1.19.2";


### PR DESCRIPTION
This removes boilerplate code in the examples and reduces friction when getting started.