### PR TITLE
Make replaceable blocks place correctly in the building example.

### DIFF
--- a/examples/building.rs
+++ b/examples/building.rs
@@ -208,13 +208,22 @@ impl Config for Game {
                         ..
                     } => {
                         if hand == Hand::Main {
-                            let place_at = location.get_in_direction(face);
                             if let Some(stack) = client.held_item() {
-                                if let Some(block_kind) = stack.item.to_block_kind() {
-                                    world.chunks.set_block_state(
-                                        place_at,
-                                        BlockState::from_kind(block_kind),
-                                    );
+                                if let Some(held_block_kind) = stack.item.to_block_kind() {
+                                    let block_to_place = BlockState::from_kind(held_block_kind);
+
+                                    if world
+                                        .chunks
+                                        .block_state(location)
+                                        .map(|s| s.is_replaceable())
+                                        .unwrap_or(false)
+                                    {
+                                        world.chunks.set_block_state(location, block_to_place);
+                                    } else {
+                                        let place_at = location.get_in_direction(face);
+                                        world.chunks.set_block_state(place_at, block_to_place);
+                                    }
+
                                     if client.game_mode() != GameMode::Creative {
                                         client.consume_one_held_item();
                                     }


### PR DESCRIPTION
Closes #114

Note that this is a band-aid solution to a more general problem. In the future, there should be a function in the `block` module to handle all these placement rules.