### PR TITLE
Fix yaw not matching client yaw

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -46,7 +46,7 @@ use crate::server::{C2sPacketChannels, NewClientData, S2cPlayMessage, SharedServ
 use crate::slab_versioned::{Key, VersionedSlab};
 use crate::text::Text;
 use crate::username::Username;
-use crate::util::{chunks_in_view_distance, is_chunk_in_view_distance};
+use crate::util::{chunks_in_view_distance, is_chunk_in_view_distance, wrap_yaw};
 use crate::world::{WorldId, Worlds};
 use crate::{ident, LIBRARY_NAMESPACE};
 
@@ -413,7 +413,7 @@ impl<C: Config> Client<C> {
     /// If you want to change the client's world, use [`Self::spawn`].
     pub fn teleport(&mut self, pos: impl Into<Vec3<f64>>, yaw: f32, pitch: f32) {
         self.position = pos.into();
-        self.yaw = yaw;
+        self.yaw = wrap_yaw(yaw);
         self.pitch = pitch;
 
         self.bits.set_teleported_this_tick(true);
@@ -990,7 +990,7 @@ impl<C: Config> Client<C> {
             C2sPlayPacket::SetPlayerPositionAndRotation(p) => {
                 if self.pending_teleports == 0 {
                     self.position = p.position;
-                    self.yaw = p.yaw;
+                    self.yaw = wrap_yaw(p.yaw);
                     self.pitch = p.pitch;
 
                     self.events.push_back(ClientEvent::MovePositionAndRotation {
@@ -1003,7 +1003,7 @@ impl<C: Config> Client<C> {
             }
             C2sPlayPacket::SetPlayerRotation(p) => {
                 if self.pending_teleports == 0 {
-                    self.yaw = p.yaw;
+                    self.yaw = wrap_yaw(p.yaw);
                     self.pitch = p.pitch;
 
                     self.events.push_back(ClientEvent::MoveRotation {

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -18,7 +18,7 @@ use crate::protocol::packets::s2c::play::{
 };
 use crate::protocol::{ByteAngle, RawBytes, VarInt};
 use crate::slab_versioned::{Key, VersionedSlab};
-use crate::util::aabb_from_bottom_and_size;
+use crate::util::{aabb_from_bottom_and_size, wrap_yaw};
 use crate::world::WorldId;
 use crate::STANDARD_TPS;
 

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -352,7 +352,7 @@ impl<C: Config> Entity<C> {
     /// Sets the yaw of this entity in degrees.
     pub fn set_yaw(&mut self, yaw: f32) {
         if self.yaw != yaw {
-            self.yaw = yaw;
+            self.yaw = wrap_yaw(yaw);
             self.bits.set_yaw_or_pitch_modified(true);
         }
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -111,7 +111,7 @@ pub fn wrap_yaw(yaw: f32) -> f32 {
     let abs_yaw = yaw.abs();
     let steps = (abs_yaw / 180.0).floor();
     let step_offset = steps % 2.0;
-    return abs_yaw - (steps + step_offset) * 180.0;
+    abs_yaw - (steps + step_offset) * 180.0
 }
 
 /// Calculates the minimum number of bits needed to represent the integer `n`.

--- a/src/util.rs
+++ b/src/util.rs
@@ -105,6 +105,15 @@ pub fn ray_box_intersect(ro: Vec3<f64>, rd: Vec3<f64>, bb: Aabb<f64>) -> Option<
     }
 }
 
+/// Takes a float and wraps it around -180..180 in a way that matches the
+/// client's interpretation of yaw values
+pub fn wrap_yaw(yaw: f32) -> f32 {
+    let abs_yaw = yaw.abs();
+    let steps = (abs_yaw / 180.0).floor();
+    let step_offset = steps % 2.0;
+    return abs_yaw - (steps + step_offset) * 180.0;
+}
+
 /// Calculates the minimum number of bits needed to represent the integer `n`.
 /// Also known as `floor(log2(n)) + 1`.
 ///


### PR DESCRIPTION
Saw this bug ( #121 ) and thought it might be a good first issue.

I'm new to rust and contributing in general, so please guide me.

This seemed to fix the issue, but it might not apply to all cases, only for C2S packets regarding pos & yaw and entities

I'm also not sure what the best way of applying the wrap to when you set the yaw, though.