### PR TITLE
Avoid calling to_kind() in is_air()

### DIFF
--- a/build/block.rs
+++ b/build/block.rs
@@ -511,8 +511,8 @@ pub fn build() -> anyhow::Result<TokenStream> {
             /// If this block is `air`, `cave_air` or `void_air`.
             pub const fn is_air(self) -> bool {
                 matches!(
-                    self.to_kind(),
-                    BlockKind::Air | BlockKind::CaveAir | BlockKind::VoidAir
+                    self,
+                    BlockState::AIR | BlockState::CAVE_AIR | BlockState::VOID_AIR
                 )
             }
 


### PR DESCRIPTION
This PR changes is_air() to not call to_kind() to increase performance.

Example flamegraphs of real usecase of parsing java chunks to UnloadedChunk:

Before this change:
![flamegraph](https://user-images.githubusercontent.com/13693773/198851700-f455d055-a18d-495c-9989-110e3f569ad9.svg)



After this change:
![flamegraph](https://user-images.githubusercontent.com/13693773/198851673-01f2a6d8-1cb0-4ae7-b57b-6e47a38d9cee.svg)
