### PR TITLE
Set length range for `verify_token` to (4, 16)

### DIFF
--- a/src/protocol/packets/s2c.rs
+++ b/src/protocol/packets/s2c.rs
@@ -41,7 +41,7 @@ pub mod login {
             server_id: BoundedString<0, 20>,
             /// The RSA public key
             public_key: Vec<u8>,
-            verify_token: BoundedArray<u8, 16, 16>,
+            verify_token: BoundedArray<u8, 4, 16>,
         }
     }
 


### PR DESCRIPTION
Notchian servers [ALWAYS](https://wiki.vg/Protocol#Encryption_Request) have a `verify_token` length of 4.
This PR updates the range of the `BoundedArray` to support this.