### PR TITLE
Implement radians conversions for ByteAngle

### DIFF
--- a/src/protocol/byte_angle.rs
+++ b/src/protocol/byte_angle.rs
@@ -1,3 +1,4 @@
+use std::f32::consts::TAU;
 use std::io::Write;
 
 use crate::protocol::{Decode, Encode};
@@ -11,8 +12,16 @@ impl ByteAngle {
         ByteAngle((f.rem_euclid(360.0) / 360.0 * 256.0).round() as u8)
     }
 
+    pub fn from_radians(f: f32) -> ByteAngle {
+        ByteAngle((f.rem_euclid(TAU) / TAU * 256.0).round() as u8)
+    }
+
     pub fn to_degrees(self) -> f32 {
         self.0 as f32 / 256.0 * 360.0
+    }
+
+    pub fn to_radians(self) -> f32 {
+        self.0 as f32 / 256.0 * TAU
     }
 }
 


### PR DESCRIPTION
Adds `from_radians` function and `to_radians` method for `ByteAngle`.