### PR TITLE
Translation key extractor and code generator

### DIFF
--- a/examples/text.rs
+++ b/examples/text.rs
@@ -106,13 +106,20 @@ impl Config for Game {
                 client.send_message("\nTranslated Text");
                 client.send_message(
                     " - 'chat.type.advancement.task': ".into_text()
-                        + Text::translate("chat.type.advancement.task", []),
+                        + Text::translate(TranslationKey::ChatTypeAdvancementTask, []),
                 );
                 client.send_message(
                     " - 'chat.type.advancement.task' with slots: ".into_text()
                         + Text::translate(
-                            "chat.type.advancement.task",
+                            TranslationKey::ChatTypeAdvancementTask,
                             ["arg1".into(), "arg2".into()],
+                        ),
+                );
+                client.send_message(
+                    " - 'custom.translation_key': ".into_text()
+                        + Text::translate(
+                            TranslationKey::Custom("custom.translation_key".to_owned()),
+                            [],
                         ),
                 );
 

--- a/extracted/translation_keys.json
+++ b/extracted/translation_keys.json
@@ -1,0 +1,21734 @@
+[
+  {
+    "key": "language.name",
+    "english_translation": "English"
+  },
+  {
+    "key": "language.region",
+    "english_translation": "United States"
+  },
+  {
+    "key": "language.code",
+    "english_translation": "en_us"
+  },
+  {
+    "key": "narrator.button.accessibility",
+    "english_translation": "Accessibility"
+  },
+  {
+    "key": "narrator.button.language",
+    "english_translation": "Language"
+  },
+  {
+    "key": "narrator.button.difficulty_lock",
+    "english_translation": "Difficulty lock"
+  },
+  {
+    "key": "narrator.button.difficulty_lock.unlocked",
+    "english_translation": "Unlocked"
+  },
+  {
+    "key": "narrator.button.difficulty_lock.locked",
+    "english_translation": "Locked"
+  },
+  {
+    "key": "narrator.screen.title",
+    "english_translation": "Title Screen"
+  },
+  {
+    "key": "narrator.controls.reset",
+    "english_translation": "Reset %s button"
+  },
+  {
+    "key": "narrator.controls.bound",
+    "english_translation": "%s is bound to %s"
+  },
+  {
+    "key": "narrator.controls.unbound",
+    "english_translation": "%s is not bound"
+  },
+  {
+    "key": "narrator.select",
+    "english_translation": "Selected: %s"
+  },
+  {
+    "key": "narrator.select.world",
+    "english_translation": "Selected %s, last played: %s, %s, %s, version: %s"
+  },
+  {
+    "key": "narrator.loading",
+    "english_translation": "Loading: %s"
+  },
+  {
+    "key": "narrator.loading.done",
+    "english_translation": "Done"
+  },
+  {
+    "key": "narrator.joining",
+    "english_translation": "Joining"
+  },
+  {
+    "key": "narrator.position.screen",
+    "english_translation": "Screen element %s out of %s"
+  },
+  {
+    "key": "narrator.screen.usage",
+    "english_translation": "Use mouse cursor or Tab button to select element"
+  },
+  {
+    "key": "narrator.position.list",
+    "english_translation": "Selected list row %s out of %s"
+  },
+  {
+    "key": "narrator.position.object_list",
+    "english_translation": "Selected row element %s out of %s"
+  },
+  {
+    "key": "narration.suggestion.tooltip",
+    "english_translation": "Selected suggestion %s out of %s: %s (%s)"
+  },
+  {
+    "key": "narration.suggestion",
+    "english_translation": "Selected suggestion %s out of %s: %s"
+  },
+  {
+    "key": "narration.button",
+    "english_translation": "Button: %s"
+  },
+  {
+    "key": "narration.button.usage.focused",
+    "english_translation": "Press Enter to activate"
+  },
+  {
+    "key": "narration.button.usage.hovered",
+    "english_translation": "Left click to activate"
+  },
+  {
+    "key": "narration.cycle_button.usage.focused",
+    "english_translation": "Press Enter to switch to %s"
+  },
+  {
+    "key": "narration.cycle_button.usage.hovered",
+    "english_translation": "Left click to switch to %s"
+  },
+  {
+    "key": "narration.checkbox",
+    "english_translation": "Checkbox: %s"
+  },
+  {
+    "key": "narration.checkbox.usage.focused",
+    "english_translation": "Press Enter to toggle"
+  },
+  {
+    "key": "narration.checkbox.usage.hovered",
+    "english_translation": "Left click to toggle"
+  },
+  {
+    "key": "narration.recipe",
+    "english_translation": "Recipe for %s"
+  },
+  {
+    "key": "narration.recipe.usage",
+    "english_translation": "Left click to select"
+  },
+  {
+    "key": "narration.recipe.usage.more",
+    "english_translation": "Right click to show more recipes"
+  },
+  {
+    "key": "narration.selection.usage",
+    "english_translation": "Press up and down buttons to move to another entry"
+  },
+  {
+    "key": "narration.component_list.usage",
+    "english_translation": "Press Tab to navigate to next element"
+  },
+  {
+    "key": "narration.slider.usage.focused",
+    "english_translation": "Press left or right keyboard buttons to change value"
+  },
+  {
+    "key": "narration.slider.usage.hovered",
+    "english_translation": "Drag slider to change value"
+  },
+  {
+    "key": "narration.edit_box",
+    "english_translation": "Edit box: %s"
+  },
+  {
+    "key": "chat_screen.title",
+    "english_translation": "Chat screen"
+  },
+  {
+    "key": "chat_screen.usage",
+    "english_translation": "Input message and press Enter to send"
+  },
+  {
+    "key": "chat_screen.message",
+    "english_translation": "Message to send: %s"
+  },
+  {
+    "key": "gui.done",
+    "english_translation": "Done"
+  },
+  {
+    "key": "gui.cancel",
+    "english_translation": "Cancel"
+  },
+  {
+    "key": "gui.back",
+    "english_translation": "Back"
+  },
+  {
+    "key": "gui.toTitle",
+    "english_translation": "Back to Title Screen"
+  },
+  {
+    "key": "gui.toMenu",
+    "english_translation": "Back to Server List"
+  },
+  {
+    "key": "gui.up",
+    "english_translation": "Up"
+  },
+  {
+    "key": "gui.down",
+    "english_translation": "Down"
+  },
+  {
+    "key": "gui.yes",
+    "english_translation": "Yes"
+  },
+  {
+    "key": "gui.no",
+    "english_translation": "No"
+  },
+  {
+    "key": "gui.none",
+    "english_translation": "None"
+  },
+  {
+    "key": "gui.all",
+    "english_translation": "All"
+  },
+  {
+    "key": "gui.ok",
+    "english_translation": "Ok"
+  },
+  {
+    "key": "gui.proceed",
+    "english_translation": "Proceed"
+  },
+  {
+    "key": "gui.acknowledge",
+    "english_translation": "Acknowledge"
+  },
+  {
+    "key": "gui.recipebook.moreRecipes",
+    "english_translation": "Right Click for More"
+  },
+  {
+    "key": "gui.recipebook.search_hint",
+    "english_translation": "Search..."
+  },
+  {
+    "key": "gui.recipebook.toggleRecipes.all",
+    "english_translation": "Showing All"
+  },
+  {
+    "key": "gui.recipebook.toggleRecipes.craftable",
+    "english_translation": "Showing Craftable"
+  },
+  {
+    "key": "gui.recipebook.toggleRecipes.smeltable",
+    "english_translation": "Showing Smeltable"
+  },
+  {
+    "key": "gui.recipebook.toggleRecipes.blastable",
+    "english_translation": "Showing Blastable"
+  },
+  {
+    "key": "gui.recipebook.toggleRecipes.smokable",
+    "english_translation": "Showing Smokable"
+  },
+  {
+    "key": "gui.socialInteractions.title",
+    "english_translation": "Social Interactions"
+  },
+  {
+    "key": "gui.socialInteractions.tab_all",
+    "english_translation": "All"
+  },
+  {
+    "key": "gui.socialInteractions.tab_hidden",
+    "english_translation": "Hidden"
+  },
+  {
+    "key": "gui.socialInteractions.tab_blocked",
+    "english_translation": "Blocked"
+  },
+  {
+    "key": "gui.socialInteractions.blocking_hint",
+    "english_translation": "Manage with Microsoft account"
+  },
+  {
+    "key": "gui.socialInteractions.status_hidden",
+    "english_translation": "Hidden"
+  },
+  {
+    "key": "gui.socialInteractions.status_blocked",
+    "english_translation": "Blocked"
+  },
+  {
+    "key": "gui.socialInteractions.status_offline",
+    "english_translation": "Offline"
+  },
+  {
+    "key": "gui.socialInteractions.status_hidden_offline",
+    "english_translation": "Hidden - Offline"
+  },
+  {
+    "key": "gui.socialInteractions.status_blocked_offline",
+    "english_translation": "Blocked - Offline"
+  },
+  {
+    "key": "gui.socialInteractions.server_label.single",
+    "english_translation": "%s - %s player"
+  },
+  {
+    "key": "gui.socialInteractions.server_label.multiple",
+    "english_translation": "%s - %s players"
+  },
+  {
+    "key": "gui.socialInteractions.search_hint",
+    "english_translation": "Search..."
+  },
+  {
+    "key": "gui.socialInteractions.search_empty",
+    "english_translation": "Couldn't find any players with that name"
+  },
+  {
+    "key": "gui.socialInteractions.empty_hidden",
+    "english_translation": "No players hidden in chat"
+  },
+  {
+    "key": "gui.socialInteractions.empty_blocked",
+    "english_translation": "No blocked players in chat"
+  },
+  {
+    "key": "gui.socialInteractions.hide",
+    "english_translation": "Hide in Chat"
+  },
+  {
+    "key": "gui.socialInteractions.show",
+    "english_translation": "Show in Chat"
+  },
+  {
+    "key": "gui.socialInteractions.report",
+    "english_translation": "Report"
+  },
+  {
+    "key": "gui.socialInteractions.hidden_in_chat",
+    "english_translation": "Chat messages from %s will be hidden"
+  },
+  {
+    "key": "gui.socialInteractions.shown_in_chat",
+    "english_translation": "Chat messages from %s will be shown"
+  },
+  {
+    "key": "gui.socialInteractions.tooltip.hide",
+    "english_translation": "Hide messages"
+  },
+  {
+    "key": "gui.socialInteractions.tooltip.show",
+    "english_translation": "Show messages"
+  },
+  {
+    "key": "gui.socialInteractions.tooltip.report",
+    "english_translation": "Report player"
+  },
+  {
+    "key": "gui.socialInteractions.tooltip.report.disabled",
+    "english_translation": "The reporting service is unavailable"
+  },
+  {
+    "key": "gui.socialInteractions.tooltip.report.no_messages",
+    "english_translation": "No reportable messages from player %s"
+  },
+  {
+    "key": "gui.socialInteractions.tooltip.report.not_reportable",
+    "english_translation": "This player can't be reported, because their chat messages can't be verified on this server"
+  },
+  {
+    "key": "gui.socialInteractions.narration.hide",
+    "english_translation": "Hide messages from %s"
+  },
+  {
+    "key": "gui.socialInteractions.narration.show",
+    "english_translation": "Show messages from %s"
+  },
+  {
+    "key": "gui.socialInteractions.narration.report",
+    "english_translation": "Report player %s"
+  },
+  {
+    "key": "gui.narrate.button",
+    "english_translation": "%s button"
+  },
+  {
+    "key": "gui.narrate.slider",
+    "english_translation": "%s slider"
+  },
+  {
+    "key": "gui.narrate.editBox",
+    "english_translation": "%s edit box: %s"
+  },
+  {
+    "key": "gui.chatReport.title",
+    "english_translation": "Report Player"
+  },
+  {
+    "key": "gui.chatReport.send",
+    "english_translation": "Send Report"
+  },
+  {
+    "key": "gui.chatReport.send.comments_too_long",
+    "english_translation": "Please shorten the comment"
+  },
+  {
+    "key": "gui.chatReport.send.no_reason",
+    "english_translation": "Please select a report category"
+  },
+  {
+    "key": "gui.chatReport.send.no_reported_messages",
+    "english_translation": "Please select at least one chat message to report"
+  },
+  {
+    "key": "gui.chatReport.send.too_many_messages",
+    "english_translation": "Trying to include too many messages in the report"
+  },
+  {
+    "key": "gui.chatReport.observed_what",
+    "english_translation": "Why are you reporting this?"
+  },
+  {
+    "key": "gui.chatReport.select_reason",
+    "english_translation": "Select Report Category"
+  },
+  {
+    "key": "gui.chatReport.more_comments",
+    "english_translation": "Please describe what happened:"
+  },
+  {
+    "key": "gui.chatReport.describe",
+    "english_translation": "Sharing details will help us make a well-informed decision."
+  },
+  {
+    "key": "gui.chatReport.comments",
+    "english_translation": "Comments edit box"
+  },
+  {
+    "key": "gui.chatReport.read_info",
+    "english_translation": "Learn About Reporting"
+  },
+  {
+    "key": "gui.chatReport.select_chat",
+    "english_translation": "Select Chat Messages to Report"
+  },
+  {
+    "key": "gui.chatReport.selected_chat",
+    "english_translation": "%s Chat Message(s) Selected to Report"
+  },
+  {
+    "key": "gui.chatReport.report_sent_msg",
+    "english_translation": "We’ve successfully received your report. Thank you!\n\nOur team will review it as soon as possible."
+  },
+  {
+    "key": "gui.chatReport.discard.title",
+    "english_translation": "Discard report and comments?"
+  },
+  {
+    "key": "gui.chatReport.discard.content",
+    "english_translation": "If you leave, you'll lose this report and your comments.\nAre you sure you want to leave?"
+  },
+  {
+    "key": "gui.chatReport.discard.discard",
+    "english_translation": "Leave and Discard Report"
+  },
+  {
+    "key": "gui.chatReport.discard.return",
+    "english_translation": "Continue Editing"
+  },
+  {
+    "key": "gui.abuseReport.reason.title",
+    "english_translation": "Select Report Category"
+  },
+  {
+    "key": "gui.abuseReport.reason.description",
+    "english_translation": "Description:"
+  },
+  {
+    "key": "gui.abuseReport.reason.narration",
+    "english_translation": "%s: %s"
+  },
+  {
+    "key": "gui.abuseReport.reason.false_reporting",
+    "english_translation": "False Reporting"
+  },
+  {
+    "key": "gui.abuseReport.reason.child_sexual_exploitation_or_abuse",
+    "english_translation": "Child sexual exploitation or abuse"
+  },
+  {
+    "key": "gui.abuseReport.reason.child_sexual_exploitation_or_abuse.description",
+    "english_translation": "Someone is talking about or otherwise promoting indecent behavior involving children."
+  },
+  {
+    "key": "gui.abuseReport.reason.terrorism_or_violent_extremism",
+    "english_translation": "Terrorism or violent extremism"
+  },
+  {
+    "key": "gui.abuseReport.reason.terrorism_or_violent_extremism.description",
+    "english_translation": "Someone is talking about, promoting, or threatening to commit acts of terrorism or violent extremism for political, religious, ideological, or other reasons."
+  },
+  {
+    "key": "gui.abuseReport.reason.hate_speech",
+    "english_translation": "Hate speech"
+  },
+  {
+    "key": "gui.abuseReport.reason.hate_speech.description",
+    "english_translation": "Someone is attacking you or another player based on characteristics of their identity, like religion, race, or sexuality."
+  },
+  {
+    "key": "gui.abuseReport.reason.harassment_or_bullying",
+    "english_translation": "Harassment or bullying"
+  },
+  {
+    "key": "gui.abuseReport.reason.harassment_or_bullying.description",
+    "english_translation": "Someone is shaming, attacking, or bullying you or someone else. This includes when someone is repeatedly trying to contact you or someone else without consent or posting private personal information about you or someone else without consent (\"doxing\")."
+  },
+  {
+    "key": "gui.abuseReport.reason.imminent_harm",
+    "english_translation": "Imminent harm - Threat to harm others"
+  },
+  {
+    "key": "gui.abuseReport.reason.imminent_harm.description",
+    "english_translation": "Someone is threatening to harm you or someone else in real life."
+  },
+  {
+    "key": "gui.abuseReport.reason.defamation_impersonation_false_information",
+    "english_translation": "Defamation, impersonation, or false information"
+  },
+  {
+    "key": "gui.abuseReport.reason.defamation_impersonation_false_information.description",
+    "english_translation": "Someone is damaging someone else's reputation, pretending to be someone they're not, or sharing false information with the aim to exploit or mislead others."
+  },
+  {
+    "key": "gui.abuseReport.reason.self_harm_or_suicide",
+    "english_translation": "Imminent harm - Self-harm or suicide"
+  },
+  {
+    "key": "gui.abuseReport.reason.self_harm_or_suicide.description",
+    "english_translation": "Someone is threatening to harm themselves in real life or talking about harming themselves in real life."
+  },
+  {
+    "key": "gui.abuseReport.reason.alcohol_tobacco_drugs",
+    "english_translation": "Drugs or alcohol"
+  },
+  {
+    "key": "gui.abuseReport.reason.alcohol_tobacco_drugs.description",
+    "english_translation": "Someone is encouraging others to partake in illegal drug related activities or encouraging underage drinking."
+  },
+  {
+    "key": "gui.abuseReport.reason.non_consensual_intimate_imagery",
+    "english_translation": "Non-consensual intimate imagery"
+  },
+  {
+    "key": "gui.abuseReport.reason.non_consensual_intimate_imagery.description",
+    "english_translation": "Someone is talking about, sharing, or otherwise promoting private and intimate images."
+  },
+  {
+    "key": "gui.abuseReport.sending.title",
+    "english_translation": "Sending your report..."
+  },
+  {
+    "key": "gui.abuseReport.sent.title",
+    "english_translation": "Report sent"
+  },
+  {
+    "key": "gui.abuseReport.error.title",
+    "english_translation": "Problem sending your report"
+  },
+  {
+    "key": "gui.abuseReport.send.generic_error",
+    "english_translation": "Encountered an unexpected error while sending your report."
+  },
+  {
+    "key": "gui.abuseReport.send.error_message",
+    "english_translation": "An error was returned while sending your report:\n'%s'"
+  },
+  {
+    "key": "gui.abuseReport.send.service_unavailable",
+    "english_translation": "Unable to reach the Abuse Reporting service. Please make sure you are connected to the internet and try again."
+  },
+  {
+    "key": "gui.abuseReport.send.http_error",
+    "english_translation": "An unexpected HTTP error occurred while sending your report."
+  },
+  {
+    "key": "gui.abuseReport.send.json_error",
+    "english_translation": "Encountered malformed payload while sending your report."
+  },
+  {
+    "key": "gui.chatSelection.title",
+    "english_translation": "Select Chat Messages to Report"
+  },
+  {
+    "key": "gui.chatSelection.context",
+    "english_translation": "Messages surrounding this selection will be included to provide additional context"
+  },
+  {
+    "key": "gui.chatSelection.selected",
+    "english_translation": "%s/%s message(s) selected"
+  },
+  {
+    "key": "gui.chatSelection.heading",
+    "english_translation": "%s %s"
+  },
+  {
+    "key": "gui.chatSelection.message.narrate",
+    "english_translation": "%s said: %s at %s"
+  },
+  {
+    "key": "gui.chatSelection.fold",
+    "english_translation": "%s unrelated messages hidden"
+  },
+  {
+    "key": "gui.multiLineEditBox.character_limit",
+    "english_translation": "%s/%s"
+  },
+  {
+    "key": "gui.banned.title.temporary",
+    "english_translation": "Account temporarily suspended"
+  },
+  {
+    "key": "gui.banned.title.permanent",
+    "english_translation": "Account permanently banned"
+  },
+  {
+    "key": "gui.banned.description",
+    "english_translation": "%s\n\n%s\n\nLearn more at the following link: %s"
+  },
+  {
+    "key": "gui.banned.description.reason",
+    "english_translation": "We recently received a report for bad behavior by your account. Our moderators have now reviewed your case and identified it as %s, which goes against the Minecraft Community Standards."
+  },
+  {
+    "key": "gui.banned.description.reason_id",
+    "english_translation": "Code: %s"
+  },
+  {
+    "key": "gui.banned.description.reason_id_message",
+    "english_translation": "Code: %s - %s"
+  },
+  {
+    "key": "gui.banned.description.unknownreason",
+    "english_translation": "We recently received a report for bad behavior by your account. Our moderators have now reviewed your case and identified that it goes against the Minecraft Community Standards."
+  },
+  {
+    "key": "gui.banned.description.temporary.duration",
+    "english_translation": "Your account is temporarily suspended and will be reactivated in %s."
+  },
+  {
+    "key": "gui.banned.description.temporary",
+    "english_translation": "%s Until then, you can’t play online or join Realms."
+  },
+  {
+    "key": "gui.banned.description.permanent",
+    "english_translation": "Your account is permanently banned, which means you can’t play online or join Realms."
+  },
+  {
+    "key": "translation.test.none",
+    "english_translation": "Hello, world!"
+  },
+  {
+    "key": "translation.test.complex",
+    "english_translation": "Prefix, %s%2$s again %s and %1$s lastly %s and also %1$s again!"
+  },
+  {
+    "key": "translation.test.escape",
+    "english_translation": "%%s %%%s %%%%s %%%%%s"
+  },
+  {
+    "key": "translation.test.invalid",
+    "english_translation": "hi %"
+  },
+  {
+    "key": "translation.test.invalid2",
+    "english_translation": "hi %  s"
+  },
+  {
+    "key": "translation.test.args",
+    "english_translation": "%s %s"
+  },
+  {
+    "key": "translation.test.world",
+    "english_translation": "world"
+  },
+  {
+    "key": "menu.game",
+    "english_translation": "Game Menu"
+  },
+  {
+    "key": "menu.singleplayer",
+    "english_translation": "Singleplayer"
+  },
+  {
+    "key": "menu.multiplayer",
+    "english_translation": "Multiplayer"
+  },
+  {
+    "key": "menu.online",
+    "english_translation": "Minecraft Realms"
+  },
+  {
+    "key": "menu.options",
+    "english_translation": "Options..."
+  },
+  {
+    "key": "menu.quit",
+    "english_translation": "Quit Game"
+  },
+  {
+    "key": "menu.returnToMenu",
+    "english_translation": "Save and Quit to Title"
+  },
+  {
+    "key": "menu.disconnect",
+    "english_translation": "Disconnect"
+  },
+  {
+    "key": "menu.returnToGame",
+    "english_translation": "Back to Game"
+  },
+  {
+    "key": "menu.generatingLevel",
+    "english_translation": "Generating world"
+  },
+  {
+    "key": "menu.loadingLevel",
+    "english_translation": "Loading world"
+  },
+  {
+    "key": "menu.savingLevel",
+    "english_translation": "Saving world"
+  },
+  {
+    "key": "menu.working",
+    "english_translation": "Working..."
+  },
+  {
+    "key": "menu.savingChunks",
+    "english_translation": "Saving chunks"
+  },
+  {
+    "key": "menu.preparingSpawn",
+    "english_translation": "Preparing spawn area: %s%%"
+  },
+  {
+    "key": "menu.loadingForcedChunks",
+    "english_translation": "Loading forced chunks for dimension %s"
+  },
+  {
+    "key": "menu.generatingTerrain",
+    "english_translation": "Building terrain"
+  },
+  {
+    "key": "menu.convertingLevel",
+    "english_translation": "Converting world"
+  },
+  {
+    "key": "menu.respawning",
+    "english_translation": "Respawning"
+  },
+  {
+    "key": "menu.shareToLan",
+    "english_translation": "Open to LAN"
+  },
+  {
+    "key": "menu.sendFeedback",
+    "english_translation": "Give Feedback"
+  },
+  {
+    "key": "menu.reportBugs",
+    "english_translation": "Report Bugs"
+  },
+  {
+    "key": "menu.playerReporting",
+    "english_translation": "Player Reporting"
+  },
+  {
+    "key": "menu.paused",
+    "english_translation": "Game Paused"
+  },
+  {
+    "key": "menu.modded",
+    "english_translation": " (Modded)"
+  },
+  {
+    "key": "optimizeWorld.confirm.title",
+    "english_translation": "Optimize World"
+  },
+  {
+    "key": "optimizeWorld.confirm.description",
+    "english_translation": "This will attempt to optimize your world by making sure all data is stored in the most recent game format. This can take a very long time, depending on your world. Once done, your world may play faster but will no longer be compatible with older versions of the game. Are you sure you wish to proceed?"
+  },
+  {
+    "key": "optimizeWorld.title",
+    "english_translation": "Optimizing World '%s'"
+  },
+  {
+    "key": "optimizeWorld.stage.counting",
+    "english_translation": "Counting chunks..."
+  },
+  {
+    "key": "optimizeWorld.stage.upgrading",
+    "english_translation": "Upgrading all chunks..."
+  },
+  {
+    "key": "optimizeWorld.stage.finished",
+    "english_translation": "Finishing up..."
+  },
+  {
+    "key": "optimizeWorld.stage.failed",
+    "english_translation": "Failed! :("
+  },
+  {
+    "key": "optimizeWorld.info.converted",
+    "english_translation": "Upgraded chunks: %s"
+  },
+  {
+    "key": "optimizeWorld.info.skipped",
+    "english_translation": "Skipped chunks: %s"
+  },
+  {
+    "key": "optimizeWorld.info.total",
+    "english_translation": "Total chunks: %s"
+  },
+  {
+    "key": "selectWorld.title",
+    "english_translation": "Select World"
+  },
+  {
+    "key": "selectWorld.search",
+    "english_translation": "search for worlds"
+  },
+  {
+    "key": "selectWorld.world",
+    "english_translation": "World"
+  },
+  {
+    "key": "selectWorld.select",
+    "english_translation": "Play Selected World"
+  },
+  {
+    "key": "selectWorld.create",
+    "english_translation": "Create New World"
+  },
+  {
+    "key": "selectWorld.recreate",
+    "english_translation": "Re-Create"
+  },
+  {
+    "key": "selectWorld.createDemo",
+    "english_translation": "Play New Demo World"
+  },
+  {
+    "key": "selectWorld.delete",
+    "english_translation": "Delete"
+  },
+  {
+    "key": "selectWorld.edit",
+    "english_translation": "Edit"
+  },
+  {
+    "key": "selectWorld.edit.title",
+    "english_translation": "Edit World"
+  },
+  {
+    "key": "selectWorld.edit.resetIcon",
+    "english_translation": "Reset Icon"
+  },
+  {
+    "key": "selectWorld.edit.openFolder",
+    "english_translation": "Open World Folder"
+  },
+  {
+    "key": "selectWorld.edit.save",
+    "english_translation": "Save"
+  },
+  {
+    "key": "selectWorld.edit.backup",
+    "english_translation": "Make Backup"
+  },
+  {
+    "key": "selectWorld.edit.backupFolder",
+    "english_translation": "Open Backups Folder"
+  },
+  {
+    "key": "selectWorld.edit.backupFailed",
+    "english_translation": "Backup failed"
+  },
+  {
+    "key": "selectWorld.edit.backupCreated",
+    "english_translation": "Backed up: %s"
+  },
+  {
+    "key": "selectWorld.edit.backupSize",
+    "english_translation": "size: %s MB"
+  },
+  {
+    "key": "selectWorld.edit.optimize",
+    "english_translation": "Optimize World"
+  },
+  {
+    "key": "selectWorld.edit.export_worldgen_settings",
+    "english_translation": "Export World Generation Settings"
+  },
+  {
+    "key": "selectWorld.edit.export_worldgen_settings.success",
+    "english_translation": "Exported"
+  },
+  {
+    "key": "selectWorld.edit.export_worldgen_settings.failure",
+    "english_translation": "Export failed"
+  },
+  {
+    "key": "selectWorld.deleteQuestion",
+    "english_translation": "Are you sure you want to delete this world?"
+  },
+  {
+    "key": "selectWorld.deleteWarning",
+    "english_translation": "'%s' will be lost forever! (A long time!)"
+  },
+  {
+    "key": "selectWorld.deleteButton",
+    "english_translation": "Delete"
+  },
+  {
+    "key": "selectWorld.conversion",
+    "english_translation": "Must be converted!"
+  },
+  {
+    "key": "selectWorld.conversion.tooltip",
+    "english_translation": "This world must be opened in an older version (like 1.6.4) to be safely converted"
+  },
+  {
+    "key": "selectWorld.locked",
+    "english_translation": "Locked by another running instance of Minecraft"
+  },
+  {
+    "key": "selectWorld.incompatible_series",
+    "english_translation": "Created by an incompatible version"
+  },
+  {
+    "key": "selectWorld.newWorld",
+    "english_translation": "New World"
+  },
+  {
+    "key": "selectWorld.enterName",
+    "english_translation": "World Name"
+  },
+  {
+    "key": "selectWorld.resultFolder",
+    "english_translation": "Will be saved in:"
+  },
+  {
+    "key": "selectWorld.enterSeed",
+    "english_translation": "Seed for the world generator"
+  },
+  {
+    "key": "selectWorld.seedInfo",
+    "english_translation": "Leave blank for a random seed"
+  },
+  {
+    "key": "selectWorld.cheats",
+    "english_translation": "Cheats"
+  },
+  {
+    "key": "selectWorld.customizeType",
+    "english_translation": "Customize"
+  },
+  {
+    "key": "selectWorld.version",
+    "english_translation": "Version:"
+  },
+  {
+    "key": "selectWorld.versionUnknown",
+    "english_translation": "unknown"
+  },
+  {
+    "key": "selectWorld.versionQuestion",
+    "english_translation": "Do you really want to load this world?"
+  },
+  {
+    "key": "selectWorld.versionWarning",
+    "english_translation": "This world was last played in version %s and loading it in this version could cause corruption!"
+  },
+  {
+    "key": "selectWorld.versionJoinButton",
+    "english_translation": "Load Anyway"
+  },
+  {
+    "key": "selectWorld.backupQuestion.snapshot",
+    "english_translation": "Do you really want to load this world?"
+  },
+  {
+    "key": "selectWorld.backupWarning.snapshot",
+    "english_translation": "This world was last played in version %s; you are on version %s. Please make a backup in case you experience world corruptions!"
+  },
+  {
+    "key": "selectWorld.backupQuestion.downgrade",
+    "english_translation": "Downgrading a world is not supported"
+  },
+  {
+    "key": "selectWorld.backupWarning.downgrade",
+    "english_translation": "This world was last played in version %s; you are on version %s. Downgrading a world could cause corruption - we cannot guarantee that it will load or work. If you still want to continue, please make a backup!"
+  },
+  {
+    "key": "selectWorld.backupQuestion.customized",
+    "english_translation": "Customized worlds are no longer supported"
+  },
+  {
+    "key": "selectWorld.backupWarning.customized",
+    "english_translation": "Unfortunately, we do not support customized worlds in this version of Minecraft. We can still load this world and keep everything the way it was, but any newly generated terrain will no longer be customized. We're sorry for the inconvenience!"
+  },
+  {
+    "key": "selectWorld.backupQuestion.experimental",
+    "english_translation": "Worlds using Experimental Settings are not supported"
+  },
+  {
+    "key": "selectWorld.backupWarning.experimental",
+    "english_translation": "This world uses experimental settings that could stop working at any time. We cannot guarantee it will load or work. Here be dragons!"
+  },
+  {
+    "key": "selectWorld.backupEraseCache",
+    "english_translation": "Erase cached data"
+  },
+  {
+    "key": "selectWorld.backupJoinConfirmButton",
+    "english_translation": "Create Backup and Load"
+  },
+  {
+    "key": "selectWorld.backupJoinSkipButton",
+    "english_translation": "I know what I'm doing!"
+  },
+  {
+    "key": "selectWorld.tooltip.fromNewerVersion1",
+    "english_translation": "World was saved in a newer version,"
+  },
+  {
+    "key": "selectWorld.tooltip.fromNewerVersion2",
+    "english_translation": "loading this world could cause problems!"
+  },
+  {
+    "key": "selectWorld.tooltip.snapshot1",
+    "english_translation": "Don't forget to back up this world"
+  },
+  {
+    "key": "selectWorld.tooltip.snapshot2",
+    "english_translation": "before you load it in this snapshot."
+  },
+  {
+    "key": "selectWorld.unable_to_load",
+    "english_translation": "Unable to load worlds"
+  },
+  {
+    "key": "selectWorld.futureworld.error.title",
+    "english_translation": "An error occurred!"
+  },
+  {
+    "key": "selectWorld.futureworld.error.text",
+    "english_translation": "Something went wrong while trying to load a world from a future version. This was a risky operation to begin with; sorry it didn't work."
+  },
+  {
+    "key": "selectWorld.recreate.error.title",
+    "english_translation": "An error occurred!"
+  },
+  {
+    "key": "selectWorld.recreate.error.text",
+    "english_translation": "Something went wrong while trying to recreate a world."
+  },
+  {
+    "key": "selectWorld.recreate.customized.title",
+    "english_translation": "Customized worlds are no longer supported"
+  },
+  {
+    "key": "selectWorld.recreate.customized.text",
+    "english_translation": "Customized worlds are no longer supported in this version of Minecraft. We can try to recreate it with the same seed and properties, but any terrain customizations will be lost. We're sorry for the inconvenience!"
+  },
+  {
+    "key": "selectWorld.load_folder_access",
+    "english_translation": "Unable to read or access folder where game worlds are saved!"
+  },
+  {
+    "key": "selectWorld.access_failure",
+    "english_translation": "Failed to access world"
+  },
+  {
+    "key": "selectWorld.delete_failure",
+    "english_translation": "Failed to delete world"
+  },
+  {
+    "key": "selectWorld.data_read",
+    "english_translation": "Reading world data..."
+  },
+  {
+    "key": "selectWorld.loading_list",
+    "english_translation": "Loading world list"
+  },
+  {
+    "key": "createWorld.customize.presets",
+    "english_translation": "Presets"
+  },
+  {
+    "key": "createWorld.customize.presets.title",
+    "english_translation": "Select a Preset"
+  },
+  {
+    "key": "createWorld.customize.presets.select",
+    "english_translation": "Use Preset"
+  },
+  {
+    "key": "createWorld.customize.presets.share",
+    "english_translation": "Want to share your preset with someone? Use the box below!"
+  },
+  {
+    "key": "createWorld.customize.presets.list",
+    "english_translation": "Alternatively, here's some we made earlier!"
+  },
+  {
+    "key": "createWorld.customize.flat.title",
+    "english_translation": "Superflat Customization"
+  },
+  {
+    "key": "createWorld.customize.flat.tile",
+    "english_translation": "Layer Material"
+  },
+  {
+    "key": "createWorld.customize.flat.height",
+    "english_translation": "Height"
+  },
+  {
+    "key": "createWorld.customize.flat.removeLayer",
+    "english_translation": "Remove Layer"
+  },
+  {
+    "key": "createWorld.customize.flat.layer.top",
+    "english_translation": "Top - %s"
+  },
+  {
+    "key": "createWorld.customize.flat.layer",
+    "english_translation": "%s"
+  },
+  {
+    "key": "createWorld.customize.flat.layer.bottom",
+    "english_translation": "Bottom - %s"
+  },
+  {
+    "key": "createWorld.customize.buffet.title",
+    "english_translation": "Buffet world customization"
+  },
+  {
+    "key": "createWorld.customize.buffet.biome",
+    "english_translation": "Please select a biome"
+  },
+  {
+    "key": "flat_world_preset.unknown",
+    "english_translation": "???"
+  },
+  {
+    "key": "flat_world_preset.minecraft.classic_flat",
+    "english_translation": "Classic Flat"
+  },
+  {
+    "key": "flat_world_preset.minecraft.tunnelers_dream",
+    "english_translation": "Tunnelers' Dream"
+  },
+  {
+    "key": "flat_world_preset.minecraft.water_world",
+    "english_translation": "Water World"
+  },
+  {
+    "key": "flat_world_preset.minecraft.overworld",
+    "english_translation": "Overworld"
+  },
+  {
+    "key": "flat_world_preset.minecraft.snowy_kingdom",
+    "english_translation": "Snowy Kingdom"
+  },
+  {
+    "key": "flat_world_preset.minecraft.bottomless_pit",
+    "english_translation": "Bottomless Pit"
+  },
+  {
+    "key": "flat_world_preset.minecraft.desert",
+    "english_translation": "Desert"
+  },
+  {
+    "key": "flat_world_preset.minecraft.redstone_ready",
+    "english_translation": "Redstone Ready"
+  },
+  {
+    "key": "flat_world_preset.minecraft.the_void",
+    "english_translation": "The Void"
+  },
+  {
+    "key": "createWorld.customize.custom.page0",
+    "english_translation": "Basic Settings"
+  },
+  {
+    "key": "createWorld.customize.custom.page1",
+    "english_translation": "Ore Settings"
+  },
+  {
+    "key": "createWorld.customize.custom.page2",
+    "english_translation": "Advanced Settings (Expert Users Only!)"
+  },
+  {
+    "key": "createWorld.customize.custom.page3",
+    "english_translation": "Extra Advanced Settings (Expert Users Only!)"
+  },
+  {
+    "key": "createWorld.customize.custom.randomize",
+    "english_translation": "Randomize"
+  },
+  {
+    "key": "createWorld.customize.custom.prev",
+    "english_translation": "Previous Page"
+  },
+  {
+    "key": "createWorld.customize.custom.next",
+    "english_translation": "Next Page"
+  },
+  {
+    "key": "createWorld.customize.custom.defaults",
+    "english_translation": "Defaults"
+  },
+  {
+    "key": "createWorld.customize.custom.confirm1",
+    "english_translation": "This will overwrite your current"
+  },
+  {
+    "key": "createWorld.customize.custom.confirm2",
+    "english_translation": "settings and cannot be undone."
+  },
+  {
+    "key": "createWorld.customize.custom.confirmTitle",
+    "english_translation": "Warning!"
+  },
+  {
+    "key": "createWorld.customize.custom.mainNoiseScaleX",
+    "english_translation": "Main Noise Scale X"
+  },
+  {
+    "key": "createWorld.customize.custom.mainNoiseScaleY",
+    "english_translation": "Main Noise Scale Y"
+  },
+  {
+    "key": "createWorld.customize.custom.mainNoiseScaleZ",
+    "english_translation": "Main Noise Scale Z"
+  },
+  {
+    "key": "createWorld.customize.custom.depthNoiseScaleX",
+    "english_translation": "Depth Noise Scale X"
+  },
+  {
+    "key": "createWorld.customize.custom.depthNoiseScaleZ",
+    "english_translation": "Depth Noise Scale Z"
+  },
+  {
+    "key": "createWorld.customize.custom.depthNoiseScaleExponent",
+    "english_translation": "Depth Noise Exponent"
+  },
+  {
+    "key": "createWorld.customize.custom.baseSize",
+    "english_translation": "Depth Base Size"
+  },
+  {
+    "key": "createWorld.customize.custom.coordinateScale",
+    "english_translation": "Coordinate Scale"
+  },
+  {
+    "key": "createWorld.customize.custom.heightScale",
+    "english_translation": "Height Scale"
+  },
+  {
+    "key": "createWorld.customize.custom.stretchY",
+    "english_translation": "Height Stretch"
+  },
+  {
+    "key": "createWorld.customize.custom.upperLimitScale",
+    "english_translation": "Upper Limit Scale"
+  },
+  {
+    "key": "createWorld.customize.custom.lowerLimitScale",
+    "english_translation": "Lower Limit Scale"
+  },
+  {
+    "key": "createWorld.customize.custom.biomeDepthWeight",
+    "english_translation": "Biome Depth Weight"
+  },
+  {
+    "key": "createWorld.customize.custom.biomeDepthOffset",
+    "english_translation": "Biome Depth Offset"
+  },
+  {
+    "key": "createWorld.customize.custom.biomeScaleWeight",
+    "english_translation": "Biome Scale Weight"
+  },
+  {
+    "key": "createWorld.customize.custom.biomeScaleOffset",
+    "english_translation": "Biome Scale Offset"
+  },
+  {
+    "key": "createWorld.customize.custom.seaLevel",
+    "english_translation": "Sea Level"
+  },
+  {
+    "key": "createWorld.customize.custom.useCaves",
+    "english_translation": "Caves"
+  },
+  {
+    "key": "createWorld.customize.custom.useStrongholds",
+    "english_translation": "Strongholds"
+  },
+  {
+    "key": "createWorld.customize.custom.useVillages",
+    "english_translation": "Villages"
+  },
+  {
+    "key": "createWorld.customize.custom.useMineShafts",
+    "english_translation": "Mineshafts"
+  },
+  {
+    "key": "createWorld.customize.custom.useTemples",
+    "english_translation": "Temples"
+  },
+  {
+    "key": "createWorld.customize.custom.useOceanRuins",
+    "english_translation": "Ocean Ruins"
+  },
+  {
+    "key": "createWorld.customize.custom.useMonuments",
+    "english_translation": "Ocean Monuments"
+  },
+  {
+    "key": "createWorld.customize.custom.useMansions",
+    "english_translation": "Woodland Mansions"
+  },
+  {
+    "key": "createWorld.customize.custom.useRavines",
+    "english_translation": "Ravines"
+  },
+  {
+    "key": "createWorld.customize.custom.useDungeons",
+    "english_translation": "Dungeons"
+  },
+  {
+    "key": "createWorld.customize.custom.dungeonChance",
+    "english_translation": "Dungeon Count"
+  },
+  {
+    "key": "createWorld.customize.custom.useWaterLakes",
+    "english_translation": "Water Lakes"
+  },
+  {
+    "key": "createWorld.customize.custom.waterLakeChance",
+    "english_translation": "Water Lake Rarity"
+  },
+  {
+    "key": "createWorld.customize.custom.useLavaLakes",
+    "english_translation": "Lava Lakes"
+  },
+  {
+    "key": "createWorld.customize.custom.lavaLakeChance",
+    "english_translation": "Lava Lake Rarity"
+  },
+  {
+    "key": "createWorld.customize.custom.useLavaOceans",
+    "english_translation": "Lava Oceans"
+  },
+  {
+    "key": "createWorld.customize.custom.fixedBiome",
+    "english_translation": "Biome"
+  },
+  {
+    "key": "createWorld.customize.custom.biomeSize",
+    "english_translation": "Biome Size"
+  },
+  {
+    "key": "createWorld.customize.custom.riverSize",
+    "english_translation": "River Size"
+  },
+  {
+    "key": "createWorld.customize.custom.size",
+    "english_translation": "Spawn Size"
+  },
+  {
+    "key": "createWorld.customize.custom.count",
+    "english_translation": "Spawn Tries"
+  },
+  {
+    "key": "createWorld.customize.custom.minHeight",
+    "english_translation": "Min. Height"
+  },
+  {
+    "key": "createWorld.customize.custom.maxHeight",
+    "english_translation": "Max. Height"
+  },
+  {
+    "key": "createWorld.customize.custom.center",
+    "english_translation": "Center Height"
+  },
+  {
+    "key": "createWorld.customize.custom.spread",
+    "english_translation": "Spread Height"
+  },
+  {
+    "key": "createWorld.customize.custom.presets.title",
+    "english_translation": "Customize World Presets"
+  },
+  {
+    "key": "createWorld.customize.custom.presets",
+    "english_translation": "Presets"
+  },
+  {
+    "key": "createWorld.customize.custom.preset.waterWorld",
+    "english_translation": "Water World"
+  },
+  {
+    "key": "createWorld.customize.custom.preset.isleLand",
+    "english_translation": "Isle Land"
+  },
+  {
+    "key": "createWorld.customize.custom.preset.caveDelight",
+    "english_translation": "Caver's Delight"
+  },
+  {
+    "key": "createWorld.customize.custom.preset.mountains",
+    "english_translation": "Mountain Madness"
+  },
+  {
+    "key": "createWorld.customize.custom.preset.drought",
+    "english_translation": "Drought"
+  },
+  {
+    "key": "createWorld.customize.custom.preset.caveChaos",
+    "english_translation": "Caves of Chaos"
+  },
+  {
+    "key": "createWorld.customize.custom.preset.goodLuck",
+    "english_translation": "Good Luck"
+  },
+  {
+    "key": "createWorld.preparing",
+    "english_translation": "Preparing for world creation..."
+  },
+  {
+    "key": "datapackFailure.title",
+    "english_translation": "Errors in currently selected datapacks prevented the world from loading.\nYou can either try to load it with only the vanilla data pack (\"safe mode\"), or go back to the title screen and fix it manually."
+  },
+  {
+    "key": "datapackFailure.safeMode",
+    "english_translation": "Safe Mode"
+  },
+  {
+    "key": "editGamerule.title",
+    "english_translation": "Edit Game Rules"
+  },
+  {
+    "key": "editGamerule.default",
+    "english_translation": "Default: %s"
+  },
+  {
+    "key": "gameMode.survival",
+    "english_translation": "Survival Mode"
+  },
+  {
+    "key": "gameMode.creative",
+    "english_translation": "Creative Mode"
+  },
+  {
+    "key": "gameMode.adventure",
+    "english_translation": "Adventure Mode"
+  },
+  {
+    "key": "gameMode.spectator",
+    "english_translation": "Spectator Mode"
+  },
+  {
+    "key": "gameMode.hardcore",
+    "english_translation": "Hardcore Mode!"
+  },
+  {
+    "key": "gameMode.changed",
+    "english_translation": "Your game mode has been updated to %s"
+  },
+  {
+    "key": "spectatorMenu.previous_page",
+    "english_translation": "Previous Page"
+  },
+  {
+    "key": "spectatorMenu.next_page",
+    "english_translation": "Next Page"
+  },
+  {
+    "key": "spectatorMenu.close",
+    "english_translation": "Close Menu"
+  },
+  {
+    "key": "spectatorMenu.teleport",
+    "english_translation": "Teleport to Player"
+  },
+  {
+    "key": "spectatorMenu.teleport.prompt",
+    "english_translation": "Select a player to teleport to"
+  },
+  {
+    "key": "spectatorMenu.team_teleport",
+    "english_translation": "Teleport to Team Member"
+  },
+  {
+    "key": "spectatorMenu.team_teleport.prompt",
+    "english_translation": "Select a team to teleport to"
+  },
+  {
+    "key": "spectatorMenu.root.prompt",
+    "english_translation": "Press a key to select a command, and again to use it."
+  },
+  {
+    "key": "selectWorld.gameMode",
+    "english_translation": "Game Mode"
+  },
+  {
+    "key": "selectWorld.gameMode.survival",
+    "english_translation": "Survival"
+  },
+  {
+    "key": "selectWorld.gameMode.survival.line1",
+    "english_translation": "Search for resources, craft, gain"
+  },
+  {
+    "key": "selectWorld.gameMode.survival.line2",
+    "english_translation": "levels, health and hunger"
+  },
+  {
+    "key": "selectWorld.gameMode.creative",
+    "english_translation": "Creative"
+  },
+  {
+    "key": "selectWorld.gameMode.creative.line1",
+    "english_translation": "Unlimited resources, free flying and"
+  },
+  {
+    "key": "selectWorld.gameMode.creative.line2",
+    "english_translation": "destroy blocks instantly"
+  },
+  {
+    "key": "selectWorld.gameMode.spectator",
+    "english_translation": "Spectator"
+  },
+  {
+    "key": "selectWorld.gameMode.spectator.line1",
+    "english_translation": "You can look but don't touch"
+  },
+  {
+    "key": "selectWorld.gameMode.spectator.line2",
+    "english_translation": ""
+  },
+  {
+    "key": "selectWorld.gameMode.hardcore",
+    "english_translation": "Hardcore"
+  },
+  {
+    "key": "selectWorld.gameMode.hardcore.line1",
+    "english_translation": "Same as Survival Mode, locked at hardest"
+  },
+  {
+    "key": "selectWorld.gameMode.hardcore.line2",
+    "english_translation": "difficulty, and one life only"
+  },
+  {
+    "key": "selectWorld.gameMode.adventure",
+    "english_translation": "Adventure"
+  },
+  {
+    "key": "selectWorld.gameMode.adventure.line1",
+    "english_translation": "Same as Survival Mode, but blocks can't"
+  },
+  {
+    "key": "selectWorld.gameMode.adventure.line2",
+    "english_translation": "be added or removed"
+  },
+  {
+    "key": "selectWorld.moreWorldOptions",
+    "english_translation": "More World Options..."
+  },
+  {
+    "key": "selectWorld.gameRules",
+    "english_translation": "Game Rules"
+  },
+  {
+    "key": "selectWorld.mapFeatures",
+    "english_translation": "Generate Structures"
+  },
+  {
+    "key": "selectWorld.mapFeatures.info",
+    "english_translation": "Villages, dungeons etc."
+  },
+  {
+    "key": "selectWorld.mapType",
+    "english_translation": "World Type"
+  },
+  {
+    "key": "selectWorld.mapType.normal",
+    "english_translation": "Normal"
+  },
+  {
+    "key": "selectWorld.allowCommands",
+    "english_translation": "Allow Cheats"
+  },
+  {
+    "key": "selectWorld.allowCommands.info",
+    "english_translation": "Commands like /gamemode, /experience"
+  },
+  {
+    "key": "selectWorld.dataPacks",
+    "english_translation": "Data Packs"
+  },
+  {
+    "key": "selectWorld.bonusItems",
+    "english_translation": "Bonus Chest"
+  },
+  {
+    "key": "selectWorld.import_worldgen_settings",
+    "english_translation": "Import Settings"
+  },
+  {
+    "key": "selectWorld.import_worldgen_settings.select_file",
+    "english_translation": "Select settings file (.json)"
+  },
+  {
+    "key": "selectWorld.import_worldgen_settings.failure",
+    "english_translation": "Error importing settings"
+  },
+  {
+    "key": "selectWorld.import_worldgen_settings.experimental.title",
+    "english_translation": "Warning! These settings are using experimental features"
+  },
+  {
+    "key": "selectWorld.import_worldgen_settings.experimental.question",
+    "english_translation": "These settings are experimental and could one day stop working. Do you wish to proceed?"
+  },
+  {
+    "key": "selectWorld.import_worldgen_settings.deprecated.title",
+    "english_translation": "Warning! These settings are using deprecated features"
+  },
+  {
+    "key": "selectWorld.import_worldgen_settings.deprecated.question",
+    "english_translation": "Some features used are deprecated and will stop working in the future. Do you wish to proceed?"
+  },
+  {
+    "key": "generator.custom",
+    "english_translation": "Custom"
+  },
+  {
+    "key": "generator.minecraft.normal",
+    "english_translation": "Default"
+  },
+  {
+    "key": "generator.minecraft.flat",
+    "english_translation": "Superflat"
+  },
+  {
+    "key": "generator.minecraft.large_biomes",
+    "english_translation": "Large Biomes"
+  },
+  {
+    "key": "generator.minecraft.amplified",
+    "english_translation": "AMPLIFIED"
+  },
+  {
+    "key": "generator.minecraft.amplified.info",
+    "english_translation": "Notice: Just for fun! Requires a beefy computer."
+  },
+  {
+    "key": "generator.minecraft.debug_all_block_states",
+    "english_translation": "Debug Mode"
+  },
+  {
+    "key": "generator.minecraft.single_biome_surface",
+    "english_translation": "Single Biome"
+  },
+  {
+    "key": "generator.customized",
+    "english_translation": "Old Customized"
+  },
+  {
+    "key": "generator.single_biome_caves",
+    "english_translation": "Caves"
+  },
+  {
+    "key": "generator.single_biome_floating_islands",
+    "english_translation": "Floating Islands"
+  },
+  {
+    "key": "selectServer.title",
+    "english_translation": "Select Server"
+  },
+  {
+    "key": "selectServer.select",
+    "english_translation": "Join Server"
+  },
+  {
+    "key": "selectServer.direct",
+    "english_translation": "Direct Connection"
+  },
+  {
+    "key": "selectServer.edit",
+    "english_translation": "Edit"
+  },
+  {
+    "key": "selectServer.delete",
+    "english_translation": "Delete"
+  },
+  {
+    "key": "selectServer.add",
+    "english_translation": "Add Server"
+  },
+  {
+    "key": "selectServer.defaultName",
+    "english_translation": "Minecraft Server"
+  },
+  {
+    "key": "selectServer.deleteQuestion",
+    "english_translation": "Are you sure you want to remove this server?"
+  },
+  {
+    "key": "selectServer.deleteWarning",
+    "english_translation": "'%s' will be lost forever! (A long time!)"
+  },
+  {
+    "key": "selectServer.deleteButton",
+    "english_translation": "Delete"
+  },
+  {
+    "key": "selectServer.refresh",
+    "english_translation": "Refresh"
+  },
+  {
+    "key": "selectServer.hiddenAddress",
+    "english_translation": "(Hidden)"
+  },
+  {
+    "key": "addServer.title",
+    "english_translation": "Edit Server Info"
+  },
+  {
+    "key": "addServer.enterName",
+    "english_translation": "Server Name"
+  },
+  {
+    "key": "addServer.enterIp",
+    "english_translation": "Server Address"
+  },
+  {
+    "key": "addServer.add",
+    "english_translation": "Done"
+  },
+  {
+    "key": "addServer.hideAddress",
+    "english_translation": "Hide Address"
+  },
+  {
+    "key": "addServer.resourcePack",
+    "english_translation": "Server Resource Packs"
+  },
+  {
+    "key": "addServer.resourcePack.enabled",
+    "english_translation": "Enabled"
+  },
+  {
+    "key": "addServer.resourcePack.disabled",
+    "english_translation": "Disabled"
+  },
+  {
+    "key": "addServer.resourcePack.prompt",
+    "english_translation": "Prompt"
+  },
+  {
+    "key": "lanServer.title",
+    "english_translation": "LAN World"
+  },
+  {
+    "key": "lanServer.scanning",
+    "english_translation": "Scanning for games on your local network"
+  },
+  {
+    "key": "lanServer.start",
+    "english_translation": "Start LAN World"
+  },
+  {
+    "key": "lanServer.otherPlayers",
+    "english_translation": "Settings for Other Players"
+  },
+  {
+    "key": "multiplayerWarning.header",
+    "english_translation": "Caution: Third-Party Online Play"
+  },
+  {
+    "key": "multiplayerWarning.message",
+    "english_translation": "Caution: Online play is offered by third-party servers that are not owned, operated, or supervised by Mojang Studios or Microsoft. During online play, you may be exposed to unmoderated chat messages or other types of user-generated content that may not be suitable for everyone."
+  },
+  {
+    "key": "multiplayerWarning.check",
+    "english_translation": "Do not show this screen again"
+  },
+  {
+    "key": "multiplayer.title",
+    "english_translation": "Play Multiplayer"
+  },
+  {
+    "key": "multiplayer.texturePrompt.line1",
+    "english_translation": "This server recommends the use of a custom resource pack."
+  },
+  {
+    "key": "multiplayer.texturePrompt.line2",
+    "english_translation": "Would you like to download and install it automagically?"
+  },
+  {
+    "key": "multiplayer.requiredTexturePrompt.line1",
+    "english_translation": "This server requires the use of a custom resource pack."
+  },
+  {
+    "key": "multiplayer.requiredTexturePrompt.line2",
+    "english_translation": "Rejecting this custom resource pack will disconnect you from this server."
+  },
+  {
+    "key": "multiplayer.requiredTexturePrompt.disconnect",
+    "english_translation": "Server requires a custom resource pack"
+  },
+  {
+    "key": "multiplayer.texturePrompt.failure.line1",
+    "english_translation": "Server resource pack couldn't be applied"
+  },
+  {
+    "key": "multiplayer.texturePrompt.failure.line2",
+    "english_translation": "Any functionality that requires custom resources might not work as expected"
+  },
+  {
+    "key": "multiplayer.texturePrompt.serverPrompt",
+    "english_translation": "%s\n\nMessage from server:\n%s"
+  },
+  {
+    "key": "multiplayer.applyingPack",
+    "english_translation": "Applying resource pack"
+  },
+  {
+    "key": "multiplayer.downloadingTerrain",
+    "english_translation": "Loading terrain..."
+  },
+  {
+    "key": "multiplayer.downloadingStats",
+    "english_translation": "Retrieving statistics..."
+  },
+  {
+    "key": "multiplayer.stopSleeping",
+    "english_translation": "Leave Bed"
+  },
+  {
+    "key": "multiplayer.message_not_delivered",
+    "english_translation": "Can't deliver chat message, check server logs: %s"
+  },
+  {
+    "key": "multiplayer.player.joined",
+    "english_translation": "%s joined the game"
+  },
+  {
+    "key": "multiplayer.player.joined.renamed",
+    "english_translation": "%s (formerly known as %s) joined the game"
+  },
+  {
+    "key": "multiplayer.player.left",
+    "english_translation": "%s left the game"
+  },
+  {
+    "key": "multiplayer.status.and_more",
+    "english_translation": "... and %s more ..."
+  },
+  {
+    "key": "multiplayer.status.cancelled",
+    "english_translation": "Cancelled"
+  },
+  {
+    "key": "multiplayer.status.cannot_connect",
+    "english_translation": "Can't connect to server"
+  },
+  {
+    "key": "multiplayer.status.cannot_resolve",
+    "english_translation": "Can't resolve hostname"
+  },
+  {
+    "key": "multiplayer.status.finished",
+    "english_translation": "Finished"
+  },
+  {
+    "key": "multiplayer.status.incompatible",
+    "english_translation": "Incompatible version!"
+  },
+  {
+    "key": "multiplayer.status.no_connection",
+    "english_translation": "(no connection)"
+  },
+  {
+    "key": "multiplayer.status.ping",
+    "english_translation": "%s ms"
+  },
+  {
+    "key": "multiplayer.status.old",
+    "english_translation": "Old"
+  },
+  {
+    "key": "multiplayer.status.pinging",
+    "english_translation": "Pinging..."
+  },
+  {
+    "key": "multiplayer.status.quitting",
+    "english_translation": "Quitting"
+  },
+  {
+    "key": "multiplayer.status.unknown",
+    "english_translation": "???"
+  },
+  {
+    "key": "multiplayer.status.unrequested",
+    "english_translation": "Received unrequested status"
+  },
+  {
+    "key": "multiplayer.status.request_handled",
+    "english_translation": "Status request has been handled"
+  },
+  {
+    "key": "multiplayer.disconnect.authservers_down",
+    "english_translation": "Authentication servers are down. Please try again later, sorry!"
+  },
+  {
+    "key": "multiplayer.disconnect.banned",
+    "english_translation": "You are banned from this server"
+  },
+  {
+    "key": "multiplayer.disconnect.banned.reason",
+    "english_translation": "You are banned from this server.\nReason: %s"
+  },
+  {
+    "key": "multiplayer.disconnect.banned.expiration",
+    "english_translation": "\nYour ban will be removed on %s"
+  },
+  {
+    "key": "multiplayer.disconnect.banned_ip.reason",
+    "english_translation": "Your IP address is banned from this server.\nReason: %s"
+  },
+  {
+    "key": "multiplayer.disconnect.banned_ip.expiration",
+    "english_translation": "\nYour ban will be removed on %s"
+  },
+  {
+    "key": "multiplayer.disconnect.duplicate_login",
+    "english_translation": "You logged in from another location"
+  },
+  {
+    "key": "multiplayer.disconnect.flying",
+    "english_translation": "Flying is not enabled on this server"
+  },
+  {
+    "key": "multiplayer.disconnect.generic",
+    "english_translation": "Disconnected"
+  },
+  {
+    "key": "multiplayer.disconnect.idling",
+    "english_translation": "You have been idle for too long!"
+  },
+  {
+    "key": "multiplayer.disconnect.illegal_characters",
+    "english_translation": "Illegal characters in chat"
+  },
+  {
+    "key": "multiplayer.disconnect.invalid_entity_attacked",
+    "english_translation": "Attempting to attack an invalid entity"
+  },
+  {
+    "key": "multiplayer.disconnect.invalid_packet",
+    "english_translation": "Server sent an invalid packet"
+  },
+  {
+    "key": "multiplayer.disconnect.invalid_player_data",
+    "english_translation": "Invalid player data"
+  },
+  {
+    "key": "multiplayer.disconnect.invalid_player_movement",
+    "english_translation": "Invalid move player packet received"
+  },
+  {
+    "key": "multiplayer.disconnect.invalid_vehicle_movement",
+    "english_translation": "Invalid move vehicle packet received"
+  },
+  {
+    "key": "multiplayer.disconnect.ip_banned",
+    "english_translation": "You have been IP banned from this server"
+  },
+  {
+    "key": "multiplayer.disconnect.kicked",
+    "english_translation": "Kicked by an operator"
+  },
+  {
+    "key": "multiplayer.disconnect.incompatible",
+    "english_translation": "Incompatible client! Please use %s"
+  },
+  {
+    "key": "multiplayer.disconnect.outdated_client",
+    "english_translation": "Incompatible client! Please use %s"
+  },
+  {
+    "key": "multiplayer.disconnect.outdated_server",
+    "english_translation": "Incompatible client! Please use %s"
+  },
+  {
+    "key": "multiplayer.disconnect.server_shutdown",
+    "english_translation": "Server closed"
+  },
+  {
+    "key": "multiplayer.disconnect.slow_login",
+    "english_translation": "Took too long to log in"
+  },
+  {
+    "key": "multiplayer.disconnect.unverified_username",
+    "english_translation": "Failed to verify username!"
+  },
+  {
+    "key": "multiplayer.disconnect.not_whitelisted",
+    "english_translation": "You are not white-listed on this server!"
+  },
+  {
+    "key": "multiplayer.disconnect.server_full",
+    "english_translation": "The server is full!"
+  },
+  {
+    "key": "multiplayer.disconnect.name_taken",
+    "english_translation": "That name is already taken"
+  },
+  {
+    "key": "multiplayer.disconnect.unexpected_query_response",
+    "english_translation": "Unexpected custom data from client"
+  },
+  {
+    "key": "multiplayer.disconnect.missing_tags",
+    "english_translation": "Incomplete set of tags received from server.\nPlease contact server operator."
+  },
+  {
+    "key": "multiplayer.disconnect.missing_public_key",
+    "english_translation": "Missing profile public key.\nThis server requires secure profiles."
+  },
+  {
+    "key": "multiplayer.disconnect.expired_public_key",
+    "english_translation": "Expired profile public key. Check that your system time is synchronized, and try restarting your game."
+  },
+  {
+    "key": "multiplayer.disconnect.invalid_public_key_signature",
+    "english_translation": "Invalid signature for profile public key.\nTry restarting your game."
+  },
+  {
+    "key": "multiplayer.disconnect.out_of_order_chat",
+    "english_translation": "Out-of-order chat packet received. Did your system time change?"
+  },
+  {
+    "key": "multiplayer.disconnect.unsigned_chat",
+    "english_translation": "Received chat packet with missing or invalid signature."
+  },
+  {
+    "key": "multiplayer.disconnect.too_many_pending_chats",
+    "english_translation": "Too many unacknowledged chat messages"
+  },
+  {
+    "key": "multiplayer.disconnect.chat_validation_failed",
+    "english_translation": "Chat message validation failure"
+  },
+  {
+    "key": "multiplayer.socialInteractions.not_available",
+    "english_translation": "Social Interactions are only available in Multiplayer worlds"
+  },
+  {
+    "key": "multiplayer.unsecureserver.toast.title",
+    "english_translation": "Chat messages can't be verified"
+  },
+  {
+    "key": "multiplayer.unsecureserver.toast",
+    "english_translation": "Messages sent on this server may be modified and might not reflect the original message"
+  },
+  {
+    "key": "chatPreview.warning.title",
+    "english_translation": "This server uses Chat Preview"
+  },
+  {
+    "key": "chatPreview.warning.content",
+    "english_translation": "Chat Preview allows the server to see your messages before they are sent to other players. This allows a server to send you a preview of your chat messages with custom modifications and styling applied.\n\nThe Chat Preview behavior can be changed in your Chat Settings. Current setting is: [%s]"
+  },
+  {
+    "key": "chatPreview.warning.check",
+    "english_translation": "Do not notify again for this server"
+  },
+  {
+    "key": "chatPreview.warning.toast.title",
+    "english_translation": "Chat Preview is enabled"
+  },
+  {
+    "key": "chatPreview.warning.toast",
+    "english_translation": "This server uses Chat Preview and can see your messages before they are sent to other players. You can turn this off in Chat Settings."
+  },
+  {
+    "key": "chat.editBox",
+    "english_translation": "chat"
+  },
+  {
+    "key": "chat.cannotSend",
+    "english_translation": "Cannot send chat message"
+  },
+  {
+    "key": "chat.disabled.options",
+    "english_translation": "Chat disabled in client options"
+  },
+  {
+    "key": "chat.disabled.launcher",
+    "english_translation": "Chat disabled by launcher option. Cannot send message"
+  },
+  {
+    "key": "chat.disabled.profile",
+    "english_translation": "Chat not allowed by account settings. Press '%s' again for more information"
+  },
+  {
+    "key": "chat.disabled.profile.moreInfo",
+    "english_translation": "Chat not allowed by account settings. Cannot send or view messages."
+  },
+  {
+    "key": "chat.disabled.expiredProfileKey",
+    "english_translation": "Chat disabled due to expired profile public key. Please try reconnecting."
+  },
+  {
+    "key": "chat.previewInput",
+    "english_translation": "Press [%s] to preview"
+  },
+  {
+    "key": "chat.type.text",
+    "english_translation": "<%s> %s"
+  },
+  {
+    "key": "chat.type.text.narrate",
+    "english_translation": "%s says %s"
+  },
+  {
+    "key": "chat.type.emote",
+    "english_translation": "* %s %s"
+  },
+  {
+    "key": "chat.type.announcement",
+    "english_translation": "[%s] %s"
+  },
+  {
+    "key": "chat.type.admin",
+    "english_translation": "[%s: %s]"
+  },
+  {
+    "key": "chat.type.advancement.task",
+    "english_translation": "%s has made the advancement %s"
+  },
+  {
+    "key": "chat.type.advancement.challenge",
+    "english_translation": "%s has completed the challenge %s"
+  },
+  {
+    "key": "chat.type.advancement.goal",
+    "english_translation": "%s has reached the goal %s"
+  },
+  {
+    "key": "chat.type.team.text",
+    "english_translation": "%s <%s> %s"
+  },
+  {
+    "key": "chat.type.team.sent",
+    "english_translation": "-> %s <%s> %s"
+  },
+  {
+    "key": "chat.type.team.hover",
+    "english_translation": "Message Team"
+  },
+  {
+    "key": "chat.link.confirm",
+    "english_translation": "Are you sure you want to open the following website?"
+  },
+  {
+    "key": "chat.link.warning",
+    "english_translation": "Never open links from people that you don't trust!"
+  },
+  {
+    "key": "chat.copy",
+    "english_translation": "Copy to Clipboard"
+  },
+  {
+    "key": "chat.copy.click",
+    "english_translation": "Click to Copy to Clipboard"
+  },
+  {
+    "key": "chat.link.confirmTrusted",
+    "english_translation": "Do you want to open this link or copy it to your clipboard?"
+  },
+  {
+    "key": "chat.link.open",
+    "english_translation": "Open in Browser"
+  },
+  {
+    "key": "chat.coordinates",
+    "english_translation": "%s, %s, %s"
+  },
+  {
+    "key": "chat.coordinates.tooltip",
+    "english_translation": "Click to teleport"
+  },
+  {
+    "key": "chat.queue",
+    "english_translation": "[+%s pending lines]"
+  },
+  {
+    "key": "chat.square_brackets",
+    "english_translation": "[%s]"
+  },
+  {
+    "key": "chat.tag.not_secure",
+    "english_translation": "This message is not secure, which means that it might have been modified by the server"
+  },
+  {
+    "key": "chat.tag.modified",
+    "english_translation": "This message has been modified by the server."
+  },
+  {
+    "key": "chat.tag.modified.original",
+    "english_translation": "Original text: %s"
+  },
+  {
+    "key": "chat.tag.filtered",
+    "english_translation": "This message has been filtered by the server."
+  },
+  {
+    "key": "chat.filtered_full",
+    "english_translation": "The server has hidden your message for some players."
+  },
+  {
+    "key": "menu.playdemo",
+    "english_translation": "Play Demo World"
+  },
+  {
+    "key": "menu.resetdemo",
+    "english_translation": "Reset Demo World"
+  },
+  {
+    "key": "demo.day.1",
+    "english_translation": "This demo will last five game days. Do your best!"
+  },
+  {
+    "key": "demo.day.2",
+    "english_translation": "Day Two"
+  },
+  {
+    "key": "demo.day.3",
+    "english_translation": "Day Three"
+  },
+  {
+    "key": "demo.day.4",
+    "english_translation": "Day Four"
+  },
+  {
+    "key": "demo.day.5",
+    "english_translation": "This is your last day!"
+  },
+  {
+    "key": "demo.day.warning",
+    "english_translation": "Your time is almost up!"
+  },
+  {
+    "key": "demo.day.6",
+    "english_translation": "You have passed your fifth day. Use %s to save a screenshot of your creation."
+  },
+  {
+    "key": "demo.reminder",
+    "english_translation": "The demo time has expired. Buy the game to continue or start a new world!"
+  },
+  {
+    "key": "demo.remainingTime",
+    "english_translation": "Remaining time: %s"
+  },
+  {
+    "key": "demo.demoExpired",
+    "english_translation": "Demo time's up!"
+  },
+  {
+    "key": "demo.help.movement",
+    "english_translation": "Use the %1$s, %2$s, %3$s, %4$s keys and the mouse to move around"
+  },
+  {
+    "key": "demo.help.movementShort",
+    "english_translation": "Move by pressing the %1$s, %2$s, %3$s, %4$s keys"
+  },
+  {
+    "key": "demo.help.movementMouse",
+    "english_translation": "Look around using the mouse"
+  },
+  {
+    "key": "demo.help.jump",
+    "english_translation": "Jump by pressing the %1$s key"
+  },
+  {
+    "key": "demo.help.inventory",
+    "english_translation": "Use the %1$s key to open your inventory"
+  },
+  {
+    "key": "demo.help.title",
+    "english_translation": "Minecraft Demo Mode"
+  },
+  {
+    "key": "demo.help.fullWrapped",
+    "english_translation": "This demo will last 5 in-game days (about 1 hour and 40 minutes of real time). Check the advancements for hints! Have fun!"
+  },
+  {
+    "key": "demo.help.buy",
+    "english_translation": "Purchase Now!"
+  },
+  {
+    "key": "demo.help.later",
+    "english_translation": "Continue Playing!"
+  },
+  {
+    "key": "connect.connecting",
+    "english_translation": "Connecting to the server..."
+  },
+  {
+    "key": "connect.aborted",
+    "english_translation": "Aborted"
+  },
+  {
+    "key": "connect.authorizing",
+    "english_translation": "Logging in..."
+  },
+  {
+    "key": "connect.negotiating",
+    "english_translation": "Negotiating..."
+  },
+  {
+    "key": "connect.encrypting",
+    "english_translation": "Encrypting..."
+  },
+  {
+    "key": "connect.joining",
+    "english_translation": "Joining world..."
+  },
+  {
+    "key": "connect.failed",
+    "english_translation": "Failed to connect to the server"
+  },
+  {
+    "key": "disconnect.genericReason",
+    "english_translation": "%s"
+  },
+  {
+    "key": "disconnect.unknownHost",
+    "english_translation": "Unknown host"
+  },
+  {
+    "key": "disconnect.disconnected",
+    "english_translation": "Disconnected by Server"
+  },
+  {
+    "key": "disconnect.lost",
+    "english_translation": "Connection Lost"
+  },
+  {
+    "key": "disconnect.kicked",
+    "english_translation": "Was kicked from the game"
+  },
+  {
+    "key": "disconnect.timeout",
+    "english_translation": "Timed out"
+  },
+  {
+    "key": "disconnect.closed",
+    "english_translation": "Connection closed"
+  },
+  {
+    "key": "disconnect.loginFailed",
+    "english_translation": "Failed to log in"
+  },
+  {
+    "key": "disconnect.loginFailedInfo",
+    "english_translation": "Failed to log in: %s"
+  },
+  {
+    "key": "disconnect.loginFailedInfo.serversUnavailable",
+    "english_translation": "The authentication servers are currently not reachable. Please try again."
+  },
+  {
+    "key": "disconnect.loginFailedInfo.invalidSession",
+    "english_translation": "Invalid session (Try restarting your game and the launcher)"
+  },
+  {
+    "key": "disconnect.loginFailedInfo.insufficientPrivileges",
+    "english_translation": "Multiplayer is disabled. Please check your Microsoft account settings."
+  },
+  {
+    "key": "disconnect.loginFailedInfo.userBanned",
+    "english_translation": "You are banned from playing online"
+  },
+  {
+    "key": "disconnect.quitting",
+    "english_translation": "Quitting"
+  },
+  {
+    "key": "disconnect.endOfStream",
+    "english_translation": "End of stream"
+  },
+  {
+    "key": "disconnect.overflow",
+    "english_translation": "Buffer overflow"
+  },
+  {
+    "key": "disconnect.spam",
+    "english_translation": "Kicked for spamming"
+  },
+  {
+    "key": "disconnect.exceeded_packet_rate",
+    "english_translation": "Kicked for exceeding packet rate limit"
+  },
+  {
+    "key": "soundCategory.master",
+    "english_translation": "Master Volume"
+  },
+  {
+    "key": "soundCategory.music",
+    "english_translation": "Music"
+  },
+  {
+    "key": "soundCategory.record",
+    "english_translation": "Jukebox/Note Blocks"
+  },
+  {
+    "key": "soundCategory.weather",
+    "english_translation": "Weather"
+  },
+  {
+    "key": "soundCategory.hostile",
+    "english_translation": "Hostile Creatures"
+  },
+  {
+    "key": "soundCategory.neutral",
+    "english_translation": "Friendly Creatures"
+  },
+  {
+    "key": "soundCategory.player",
+    "english_translation": "Players"
+  },
+  {
+    "key": "soundCategory.block",
+    "english_translation": "Blocks"
+  },
+  {
+    "key": "soundCategory.ambient",
+    "english_translation": "Ambient/Environment"
+  },
+  {
+    "key": "soundCategory.voice",
+    "english_translation": "Voice/Speech"
+  },
+  {
+    "key": "record.nowPlaying",
+    "english_translation": "Now Playing: %s"
+  },
+  {
+    "key": "options.off",
+    "english_translation": "OFF"
+  },
+  {
+    "key": "options.on",
+    "english_translation": "ON"
+  },
+  {
+    "key": "options.off.composed",
+    "english_translation": "%s: OFF"
+  },
+  {
+    "key": "options.on.composed",
+    "english_translation": "%s: ON"
+  },
+  {
+    "key": "options.generic_value",
+    "english_translation": "%s: %s"
+  },
+  {
+    "key": "options.pixel_value",
+    "english_translation": "%s: %spx"
+  },
+  {
+    "key": "options.percent_value",
+    "english_translation": "%s: %s%%"
+  },
+  {
+    "key": "options.percent_add_value",
+    "english_translation": "%s: +%s%%"
+  },
+  {
+    "key": "options.visible",
+    "english_translation": "Shown"
+  },
+  {
+    "key": "options.hidden",
+    "english_translation": "Hidden"
+  },
+  {
+    "key": "options.title",
+    "english_translation": "Options"
+  },
+  {
+    "key": "options.controls",
+    "english_translation": "Controls..."
+  },
+  {
+    "key": "options.video",
+    "english_translation": "Video Settings..."
+  },
+  {
+    "key": "options.language",
+    "english_translation": "Language..."
+  },
+  {
+    "key": "options.sounds",
+    "english_translation": "Music & Sounds..."
+  },
+  {
+    "key": "options.sounds.title",
+    "english_translation": "Music & Sound Options"
+  },
+  {
+    "key": "options.languageWarning",
+    "english_translation": "Language translations may not be 100%% accurate"
+  },
+  {
+    "key": "options.videoTitle",
+    "english_translation": "Video Settings"
+  },
+  {
+    "key": "options.mouse_settings",
+    "english_translation": "Mouse Settings..."
+  },
+  {
+    "key": "options.mouse_settings.title",
+    "english_translation": "Mouse Settings"
+  },
+  {
+    "key": "options.customizeTitle",
+    "english_translation": "Customize World Settings"
+  },
+  {
+    "key": "options.invertMouse",
+    "english_translation": "Invert Mouse"
+  },
+  {
+    "key": "options.fov",
+    "english_translation": "FOV"
+  },
+  {
+    "key": "options.fov.min",
+    "english_translation": "Normal"
+  },
+  {
+    "key": "options.fov.max",
+    "english_translation": "Quake Pro"
+  },
+  {
+    "key": "options.screenEffectScale",
+    "english_translation": "Distortion Effects"
+  },
+  {
+    "key": "options.screenEffectScale.tooltip",
+    "english_translation": "Strength of nausea and Nether portal screen distortion effects.\nAt lower values, the nausea effect is replaced with a green overlay."
+  },
+  {
+    "key": "options.fovEffectScale",
+    "english_translation": "FOV Effects"
+  },
+  {
+    "key": "options.fovEffectScale.tooltip",
+    "english_translation": "Controls how much the field of view can change with gameplay effects."
+  },
+  {
+    "key": "options.darknessEffectScale",
+    "english_translation": "Darkness Pulsing"
+  },
+  {
+    "key": "options.darknessEffectScale.tooltip",
+    "english_translation": "Controls how much the Darkness effect pulses when a Warden or Sculk Shrieker gives it to you."
+  },
+  {
+    "key": "options.biomeBlendRadius",
+    "english_translation": "Biome Blend"
+  },
+  {
+    "key": "options.biomeBlendRadius.1",
+    "english_translation": "OFF (Fastest)"
+  },
+  {
+    "key": "options.biomeBlendRadius.3",
+    "english_translation": "3x3 (Fast)"
+  },
+  {
+    "key": "options.biomeBlendRadius.5",
+    "english_translation": "5x5 (Normal)"
+  },
+  {
+    "key": "options.biomeBlendRadius.7",
+    "english_translation": "7x7 (High)"
+  },
+  {
+    "key": "options.biomeBlendRadius.9",
+    "english_translation": "9x9 (Very High)"
+  },
+  {
+    "key": "options.biomeBlendRadius.11",
+    "english_translation": "11x11 (Extreme)"
+  },
+  {
+    "key": "options.biomeBlendRadius.13",
+    "english_translation": "13x13 (Showoff)"
+  },
+  {
+    "key": "options.biomeBlendRadius.15",
+    "english_translation": "15x15 (Maximum)"
+  },
+  {
+    "key": "options.gamma",
+    "english_translation": "Brightness"
+  },
+  {
+    "key": "options.gamma.min",
+    "english_translation": "Moody"
+  },
+  {
+    "key": "options.gamma.default",
+    "english_translation": "Default"
+  },
+  {
+    "key": "options.gamma.max",
+    "english_translation": "Bright"
+  },
+  {
+    "key": "options.sensitivity",
+    "english_translation": "Sensitivity"
+  },
+  {
+    "key": "options.sensitivity.min",
+    "english_translation": "*yawn*"
+  },
+  {
+    "key": "options.sensitivity.max",
+    "english_translation": "HYPERSPEED!!!"
+  },
+  {
+    "key": "options.renderDistance",
+    "english_translation": "Render Distance"
+  },
+  {
+    "key": "options.simulationDistance",
+    "english_translation": "Simulation Distance"
+  },
+  {
+    "key": "options.entityDistanceScaling",
+    "english_translation": "Entity Distance"
+  },
+  {
+    "key": "options.viewBobbing",
+    "english_translation": "View Bobbing"
+  },
+  {
+    "key": "options.ao",
+    "english_translation": "Smooth Lighting"
+  },
+  {
+    "key": "options.ao.off",
+    "english_translation": "OFF"
+  },
+  {
+    "key": "options.ao.min",
+    "english_translation": "Minimum"
+  },
+  {
+    "key": "options.ao.max",
+    "english_translation": "Maximum"
+  },
+  {
+    "key": "options.prioritizeChunkUpdates",
+    "english_translation": "Chunk Builder"
+  },
+  {
+    "key": "options.prioritizeChunkUpdates.none",
+    "english_translation": "Threaded"
+  },
+  {
+    "key": "options.prioritizeChunkUpdates.byPlayer",
+    "english_translation": "Semi Blocking"
+  },
+  {
+    "key": "options.prioritizeChunkUpdates.nearby",
+    "english_translation": "Fully Blocking"
+  },
+  {
+    "key": "options.prioritizeChunkUpdates.none.tooltip",
+    "english_translation": "Nearby chunks are compiled in parallel threads. This may result in brief visual holes when blocks are destroyed."
+  },
+  {
+    "key": "options.prioritizeChunkUpdates.byPlayer.tooltip",
+    "english_translation": "Some actions within a chunk will recompile the chunk immediately. This includes block placing & destroying."
+  },
+  {
+    "key": "options.prioritizeChunkUpdates.nearby.tooltip",
+    "english_translation": "Nearby chunks are always compiled immediately. This may impact game performance when blocks are placed or destroyed."
+  },
+  {
+    "key": "options.chunks",
+    "english_translation": "%s chunks"
+  },
+  {
+    "key": "options.framerate",
+    "english_translation": "%s fps"
+  },
+  {
+    "key": "options.framerateLimit",
+    "english_translation": "Max Framerate"
+  },
+  {
+    "key": "options.framerateLimit.max",
+    "english_translation": "Unlimited"
+  },
+  {
+    "key": "options.difficulty",
+    "english_translation": "Difficulty"
+  },
+  {
+    "key": "options.difficulty.online",
+    "english_translation": "Server Difficulty"
+  },
+  {
+    "key": "options.difficulty.peaceful",
+    "english_translation": "Peaceful"
+  },
+  {
+    "key": "options.difficulty.easy",
+    "english_translation": "Easy"
+  },
+  {
+    "key": "options.difficulty.normal",
+    "english_translation": "Normal"
+  },
+  {
+    "key": "options.difficulty.hard",
+    "english_translation": "Hard"
+  },
+  {
+    "key": "options.difficulty.hardcore",
+    "english_translation": "Hardcore"
+  },
+  {
+    "key": "options.graphics",
+    "english_translation": "Graphics"
+  },
+  {
+    "key": "options.graphics.fabulous.tooltip",
+    "english_translation": "%s graphics uses screen shaders for drawing weather, clouds, and particles behind translucent blocks and water.\nThis may severely impact performance for portable devices and 4K displays."
+  },
+  {
+    "key": "options.graphics.fabulous",
+    "english_translation": "Fabulous!"
+  },
+  {
+    "key": "options.graphics.fancy.tooltip",
+    "english_translation": "Fancy graphics balances performance and quality for the majority of machines.\nWeather, clouds, and particles may not appear behind translucent blocks or water."
+  },
+  {
+    "key": "options.graphics.fancy",
+    "english_translation": "Fancy"
+  },
+  {
+    "key": "options.graphics.fast.tooltip",
+    "english_translation": "Fast graphics reduces the amount of visible rain and snow.\nTransparency effects are disabled for various blocks such as leaves."
+  },
+  {
+    "key": "options.graphics.fast",
+    "english_translation": "Fast"
+  },
+  {
+    "key": "options.graphics.warning.title",
+    "english_translation": "Graphics Device Unsupported"
+  },
+  {
+    "key": "options.graphics.warning.message",
+    "english_translation": "Your graphics device is detected as unsupported for the %s graphics option.\n\nYou may ignore this and continue, however support will not be provided for your device if you choose to use %s graphics."
+  },
+  {
+    "key": "options.graphics.warning.renderer",
+    "english_translation": "Renderer detected: [%s]"
+  },
+  {
+    "key": "options.graphics.warning.vendor",
+    "english_translation": "Vendor detected: [%s]"
+  },
+  {
+    "key": "options.graphics.warning.version",
+    "english_translation": "OpenGL Version detected: [%s]"
+  },
+  {
+    "key": "options.graphics.warning.accept",
+    "english_translation": "Continue without Support"
+  },
+  {
+    "key": "options.graphics.warning.cancel",
+    "english_translation": "Take me Back"
+  },
+  {
+    "key": "options.clouds.fancy",
+    "english_translation": "Fancy"
+  },
+  {
+    "key": "options.clouds.fast",
+    "english_translation": "Fast"
+  },
+  {
+    "key": "options.guiScale",
+    "english_translation": "GUI Scale"
+  },
+  {
+    "key": "options.guiScale.auto",
+    "english_translation": "Auto"
+  },
+  {
+    "key": "options.renderClouds",
+    "english_translation": "Clouds"
+  },
+  {
+    "key": "options.particles",
+    "english_translation": "Particles"
+  },
+  {
+    "key": "options.particles.all",
+    "english_translation": "All"
+  },
+  {
+    "key": "options.particles.decreased",
+    "english_translation": "Decreased"
+  },
+  {
+    "key": "options.particles.minimal",
+    "english_translation": "Minimal"
+  },
+  {
+    "key": "options.multiplayer.title",
+    "english_translation": "Multiplayer Settings..."
+  },
+  {
+    "key": "options.chat.title",
+    "english_translation": "Chat Settings..."
+  },
+  {
+    "key": "options.chat.visibility",
+    "english_translation": "Chat"
+  },
+  {
+    "key": "options.chat.visibility.full",
+    "english_translation": "Shown"
+  },
+  {
+    "key": "options.chat.visibility.system",
+    "english_translation": "Commands Only"
+  },
+  {
+    "key": "options.chat.visibility.hidden",
+    "english_translation": "Hidden"
+  },
+  {
+    "key": "options.chat.color",
+    "english_translation": "Colors"
+  },
+  {
+    "key": "options.chat.opacity",
+    "english_translation": "Chat Text Opacity"
+  },
+  {
+    "key": "options.chat.line_spacing",
+    "english_translation": "Line Spacing"
+  },
+  {
+    "key": "options.chat.links",
+    "english_translation": "Web Links"
+  },
+  {
+    "key": "options.chat.links.prompt",
+    "english_translation": "Prompt on Links"
+  },
+  {
+    "key": "options.chat.delay_none",
+    "english_translation": "Chat Delay: None"
+  },
+  {
+    "key": "options.chat.delay",
+    "english_translation": "Chat Delay: %s seconds"
+  },
+  {
+    "key": "options.chat.scale",
+    "english_translation": "Chat Text Size"
+  },
+  {
+    "key": "options.chat.width",
+    "english_translation": "Width"
+  },
+  {
+    "key": "options.chat.height.focused",
+    "english_translation": "Focused Height"
+  },
+  {
+    "key": "options.chat.height.unfocused",
+    "english_translation": "Unfocused Height"
+  },
+  {
+    "key": "options.chatPreview",
+    "english_translation": "Chat Preview"
+  },
+  {
+    "key": "options.chatPreview.live",
+    "english_translation": "While Typing"
+  },
+  {
+    "key": "options.chatPreview.confirm",
+    "english_translation": "When Sending"
+  },
+  {
+    "key": "options.chatPreview.tooltip.off",
+    "english_translation": "Any modifications applied to your chat messages by a server will not be previewed and will be treated as insecure."
+  },
+  {
+    "key": "options.chatPreview.tooltip.live",
+    "english_translation": "If a server uses Chat Previews: Any modifications applied to your chat messages by a server will be dynamically sent for previewing as the chat message is typed."
+  },
+  {
+    "key": "options.chatPreview.tooltip.confirm",
+    "english_translation": "If a server uses Chat Previews: A chat preview is only generated when attempting to send a message that does not have a preview or is waiting for a preview.\nSending the message requires confirmation."
+  },
+  {
+    "key": "options.onlyShowSecureChat",
+    "english_translation": "Only Show Secure Chat"
+  },
+  {
+    "key": "options.onlyShowSecureChat.tooltip",
+    "english_translation": "Only display messages from other players that can be verified to have been sent by that player, and have not been modified."
+  },
+  {
+    "key": "options.accessibility.title",
+    "english_translation": "Accessibility Settings..."
+  },
+  {
+    "key": "options.accessibility.text_background",
+    "english_translation": "Text Background"
+  },
+  {
+    "key": "options.accessibility.text_background.chat",
+    "english_translation": "Chat"
+  },
+  {
+    "key": "options.accessibility.text_background.everywhere",
+    "english_translation": "Everywhere"
+  },
+  {
+    "key": "options.accessibility.text_background_opacity",
+    "english_translation": "Text Background Opacity"
+  },
+  {
+    "key": "options.accessibility.link",
+    "english_translation": "Accessibility Guide"
+  },
+  {
+    "key": "options.audioDevice",
+    "english_translation": "Device"
+  },
+  {
+    "key": "options.audioDevice.default",
+    "english_translation": "System Default"
+  },
+  {
+    "key": "options.key.toggle",
+    "english_translation": "Toggle"
+  },
+  {
+    "key": "options.key.hold",
+    "english_translation": "Hold"
+  },
+  {
+    "key": "options.skinCustomisation",
+    "english_translation": "Skin Customization..."
+  },
+  {
+    "key": "options.skinCustomisation.title",
+    "english_translation": "Skin Customization"
+  },
+  {
+    "key": "options.modelPart.cape",
+    "english_translation": "Cape"
+  },
+  {
+    "key": "options.modelPart.hat",
+    "english_translation": "Hat"
+  },
+  {
+    "key": "options.modelPart.jacket",
+    "english_translation": "Jacket"
+  },
+  {
+    "key": "options.modelPart.left_sleeve",
+    "english_translation": "Left Sleeve"
+  },
+  {
+    "key": "options.modelPart.right_sleeve",
+    "english_translation": "Right Sleeve"
+  },
+  {
+    "key": "options.modelPart.left_pants_leg",
+    "english_translation": "Left Pants Leg"
+  },
+  {
+    "key": "options.modelPart.right_pants_leg",
+    "english_translation": "Right Pants Leg"
+  },
+  {
+    "key": "options.resourcepack",
+    "english_translation": "Resource Packs..."
+  },
+  {
+    "key": "options.fullscreen",
+    "english_translation": "Fullscreen"
+  },
+  {
+    "key": "options.vsync",
+    "english_translation": "VSync"
+  },
+  {
+    "key": "options.touchscreen",
+    "english_translation": "Touchscreen Mode"
+  },
+  {
+    "key": "options.reducedDebugInfo",
+    "english_translation": "Reduced Debug Info"
+  },
+  {
+    "key": "options.entityShadows",
+    "english_translation": "Entity Shadows"
+  },
+  {
+    "key": "options.mainHand",
+    "english_translation": "Main Hand"
+  },
+  {
+    "key": "options.mainHand.left",
+    "english_translation": "Left"
+  },
+  {
+    "key": "options.mainHand.right",
+    "english_translation": "Right"
+  },
+  {
+    "key": "options.attackIndicator",
+    "english_translation": "Attack Indicator"
+  },
+  {
+    "key": "options.attack.crosshair",
+    "english_translation": "Crosshair"
+  },
+  {
+    "key": "options.attack.hotbar",
+    "english_translation": "Hotbar"
+  },
+  {
+    "key": "options.showSubtitles",
+    "english_translation": "Show Subtitles"
+  },
+  {
+    "key": "options.directionalAudio",
+    "english_translation": "Directional Audio"
+  },
+  {
+    "key": "options.directionalAudio.on.tooltip",
+    "english_translation": "Uses HRTF-based directional audio to improve the simulation of 3D sound. Requires HRTF compatible audio hardware, and is best experienced with headphones."
+  },
+  {
+    "key": "options.directionalAudio.off.tooltip",
+    "english_translation": "Classic Stereo sound"
+  },
+  {
+    "key": "options.online",
+    "english_translation": "Online..."
+  },
+  {
+    "key": "options.online.title",
+    "english_translation": "Online Options"
+  },
+  {
+    "key": "options.allowServerListing",
+    "english_translation": "Allow Server Listings"
+  },
+  {
+    "key": "options.allowServerListing.tooltip",
+    "english_translation": "Servers may list online players as part of their public status.\nWith this option off your name will not show up in such lists."
+  },
+  {
+    "key": "options.realmsNotifications",
+    "english_translation": "Realms Notifications"
+  },
+  {
+    "key": "options.autoJump",
+    "english_translation": "Auto-Jump"
+  },
+  {
+    "key": "options.autoSuggestCommands",
+    "english_translation": "Command Suggestions"
+  },
+  {
+    "key": "options.autosaveIndicator",
+    "english_translation": "Autosave Indicator"
+  },
+  {
+    "key": "options.discrete_mouse_scroll",
+    "english_translation": "Discrete Scrolling"
+  },
+  {
+    "key": "options.mouseWheelSensitivity",
+    "english_translation": "Scroll Sensitivity"
+  },
+  {
+    "key": "options.rawMouseInput",
+    "english_translation": "Raw Input"
+  },
+  {
+    "key": "options.narrator",
+    "english_translation": "Narrator"
+  },
+  {
+    "key": "options.narrator.off",
+    "english_translation": "OFF"
+  },
+  {
+    "key": "options.narrator.all",
+    "english_translation": "Narrates All"
+  },
+  {
+    "key": "options.narrator.chat",
+    "english_translation": "Narrates Chat"
+  },
+  {
+    "key": "options.narrator.system",
+    "english_translation": "Narrates System"
+  },
+  {
+    "key": "options.narrator.notavailable",
+    "english_translation": "Not Available"
+  },
+  {
+    "key": "options.fullscreen.resolution",
+    "english_translation": "Fullscreen Resolution"
+  },
+  {
+    "key": "options.fullscreen.unavailable",
+    "english_translation": "Setting unavailable"
+  },
+  {
+    "key": "options.fullscreen.current",
+    "english_translation": "Current"
+  },
+  {
+    "key": "options.mipmapLevels",
+    "english_translation": "Mipmap Levels"
+  },
+  {
+    "key": "options.forceUnicodeFont",
+    "english_translation": "Force Unicode Font"
+  },
+  {
+    "key": "options.hideMatchedNames",
+    "english_translation": "Hide Matched Names"
+  },
+  {
+    "key": "options.hideMatchedNames.tooltip",
+    "english_translation": "3rd-party Servers may send chat messages in non-standard formats.\nWith this option on: hidden players will be matched based on chat sender names."
+  },
+  {
+    "key": "options.darkMojangStudiosBackgroundColor",
+    "english_translation": "Monochrome Logo"
+  },
+  {
+    "key": "options.darkMojangStudiosBackgroundColor.tooltip",
+    "english_translation": "Changes the Mojang Studios loading screen background color to black."
+  },
+  {
+    "key": "options.hideLightningFlashes",
+    "english_translation": "Hide Lightning Flashes"
+  },
+  {
+    "key": "options.hideLightningFlashes.tooltip",
+    "english_translation": "Prevents lightning bolts from making the sky flash. The bolts themselves will still be visible."
+  },
+  {
+    "key": "narrator.toast.disabled",
+    "english_translation": "Narrator Disabled"
+  },
+  {
+    "key": "narrator.toast.enabled",
+    "english_translation": "Narrator Enabled"
+  },
+  {
+    "key": "difficulty.lock.title",
+    "english_translation": "Lock World Difficulty"
+  },
+  {
+    "key": "difficulty.lock.question",
+    "english_translation": "Are you sure you want to lock the difficulty of this world? This will set this world to always be %1$s, and you will never be able to change that again."
+  },
+  {
+    "key": "title.32bit.deprecation",
+    "english_translation": "32-bit system detected: this may prevent you from playing in the future as a 64-bit system will be required!"
+  },
+  {
+    "key": "title.32bit.deprecation.realms.header",
+    "english_translation": "32-bit system detected"
+  },
+  {
+    "key": "title.32bit.deprecation.realms",
+    "english_translation": "Minecraft will soon require a 64-bit system, which will prevent you from playing or using Realms on this device. You will need to manually cancel any Realms subscription."
+  },
+  {
+    "key": "title.32bit.deprecation.realms.check",
+    "english_translation": "Do not show this screen again"
+  },
+  {
+    "key": "title.multiplayer.disabled",
+    "english_translation": "Multiplayer is disabled. Please check your Microsoft account settings."
+  },
+  {
+    "key": "title.multiplayer.disabled.banned.temporary",
+    "english_translation": "Your account is temporarily suspended from online play"
+  },
+  {
+    "key": "title.multiplayer.disabled.banned.permanent",
+    "english_translation": "Your account is permanently suspended from online play"
+  },
+  {
+    "key": "controls.title",
+    "english_translation": "Controls"
+  },
+  {
+    "key": "controls.reset",
+    "english_translation": "Reset"
+  },
+  {
+    "key": "controls.resetAll",
+    "english_translation": "Reset Keys"
+  },
+  {
+    "key": "controls.keybinds",
+    "english_translation": "Key Binds..."
+  },
+  {
+    "key": "controls.keybinds.title",
+    "english_translation": "Key Binds"
+  },
+  {
+    "key": "key.sprint",
+    "english_translation": "Sprint"
+  },
+  {
+    "key": "key.forward",
+    "english_translation": "Walk Forwards"
+  },
+  {
+    "key": "key.left",
+    "english_translation": "Strafe Left"
+  },
+  {
+    "key": "key.back",
+    "english_translation": "Walk Backwards"
+  },
+  {
+    "key": "key.right",
+    "english_translation": "Strafe Right"
+  },
+  {
+    "key": "key.jump",
+    "english_translation": "Jump"
+  },
+  {
+    "key": "key.inventory",
+    "english_translation": "Open/Close Inventory"
+  },
+  {
+    "key": "key.drop",
+    "english_translation": "Drop Selected Item"
+  },
+  {
+    "key": "key.swapOffhand",
+    "english_translation": "Swap Item With Offhand"
+  },
+  {
+    "key": "key.chat",
+    "english_translation": "Open Chat"
+  },
+  {
+    "key": "key.sneak",
+    "english_translation": "Sneak"
+  },
+  {
+    "key": "key.playerlist",
+    "english_translation": "List Players"
+  },
+  {
+    "key": "key.attack",
+    "english_translation": "Attack/Destroy"
+  },
+  {
+    "key": "key.use",
+    "english_translation": "Use Item/Place Block"
+  },
+  {
+    "key": "key.pickItem",
+    "english_translation": "Pick Block"
+  },
+  {
+    "key": "key.command",
+    "english_translation": "Open Command"
+  },
+  {
+    "key": "key.socialInteractions",
+    "english_translation": "Social Interactions Screen"
+  },
+  {
+    "key": "key.screenshot",
+    "english_translation": "Take Screenshot"
+  },
+  {
+    "key": "key.togglePerspective",
+    "english_translation": "Toggle Perspective"
+  },
+  {
+    "key": "key.smoothCamera",
+    "english_translation": "Toggle Cinematic Camera"
+  },
+  {
+    "key": "key.fullscreen",
+    "english_translation": "Toggle Fullscreen"
+  },
+  {
+    "key": "key.spectatorOutlines",
+    "english_translation": "Highlight Players (Spectators)"
+  },
+  {
+    "key": "key.hotbar.1",
+    "english_translation": "Hotbar Slot 1"
+  },
+  {
+    "key": "key.hotbar.2",
+    "english_translation": "Hotbar Slot 2"
+  },
+  {
+    "key": "key.hotbar.3",
+    "english_translation": "Hotbar Slot 3"
+  },
+  {
+    "key": "key.hotbar.4",
+    "english_translation": "Hotbar Slot 4"
+  },
+  {
+    "key": "key.hotbar.5",
+    "english_translation": "Hotbar Slot 5"
+  },
+  {
+    "key": "key.hotbar.6",
+    "english_translation": "Hotbar Slot 6"
+  },
+  {
+    "key": "key.hotbar.7",
+    "english_translation": "Hotbar Slot 7"
+  },
+  {
+    "key": "key.hotbar.8",
+    "english_translation": "Hotbar Slot 8"
+  },
+  {
+    "key": "key.hotbar.9",
+    "english_translation": "Hotbar Slot 9"
+  },
+  {
+    "key": "key.saveToolbarActivator",
+    "english_translation": "Save Hotbar Activator"
+  },
+  {
+    "key": "key.loadToolbarActivator",
+    "english_translation": "Load Hotbar Activator"
+  },
+  {
+    "key": "key.advancements",
+    "english_translation": "Advancements"
+  },
+  {
+    "key": "key.categories.movement",
+    "english_translation": "Movement"
+  },
+  {
+    "key": "key.categories.misc",
+    "english_translation": "Miscellaneous"
+  },
+  {
+    "key": "key.categories.multiplayer",
+    "english_translation": "Multiplayer"
+  },
+  {
+    "key": "key.categories.gameplay",
+    "english_translation": "Gameplay"
+  },
+  {
+    "key": "key.categories.ui",
+    "english_translation": "Game Interface"
+  },
+  {
+    "key": "key.categories.inventory",
+    "english_translation": "Inventory"
+  },
+  {
+    "key": "key.categories.creative",
+    "english_translation": "Creative Mode"
+  },
+  {
+    "key": "key.mouse.left",
+    "english_translation": "Left Button"
+  },
+  {
+    "key": "key.mouse.right",
+    "english_translation": "Right Button"
+  },
+  {
+    "key": "key.mouse.middle",
+    "english_translation": "Middle Button"
+  },
+  {
+    "key": "key.mouse",
+    "english_translation": "Button %1$s"
+  },
+  {
+    "key": "key.keyboard.unknown",
+    "english_translation": "Not bound"
+  },
+  {
+    "key": "key.keyboard.apostrophe",
+    "english_translation": "'"
+  },
+  {
+    "key": "key.keyboard.backslash",
+    "english_translation": "\\"
+  },
+  {
+    "key": "key.keyboard.backspace",
+    "english_translation": "Backspace"
+  },
+  {
+    "key": "key.keyboard.comma",
+    "english_translation": ","
+  },
+  {
+    "key": "key.keyboard.delete",
+    "english_translation": "Delete"
+  },
+  {
+    "key": "key.keyboard.end",
+    "english_translation": "End"
+  },
+  {
+    "key": "key.keyboard.enter",
+    "english_translation": "Enter"
+  },
+  {
+    "key": "key.keyboard.equal",
+    "english_translation": "="
+  },
+  {
+    "key": "key.keyboard.escape",
+    "english_translation": "Escape"
+  },
+  {
+    "key": "key.keyboard.f1",
+    "english_translation": "F1"
+  },
+  {
+    "key": "key.keyboard.f2",
+    "english_translation": "F2"
+  },
+  {
+    "key": "key.keyboard.f3",
+    "english_translation": "F3"
+  },
+  {
+    "key": "key.keyboard.f4",
+    "english_translation": "F4"
+  },
+  {
+    "key": "key.keyboard.f5",
+    "english_translation": "F5"
+  },
+  {
+    "key": "key.keyboard.f6",
+    "english_translation": "F6"
+  },
+  {
+    "key": "key.keyboard.f7",
+    "english_translation": "F7"
+  },
+  {
+    "key": "key.keyboard.f8",
+    "english_translation": "F8"
+  },
+  {
+    "key": "key.keyboard.f9",
+    "english_translation": "F9"
+  },
+  {
+    "key": "key.keyboard.f10",
+    "english_translation": "F10"
+  },
+  {
+    "key": "key.keyboard.f11",
+    "english_translation": "F11"
+  },
+  {
+    "key": "key.keyboard.f12",
+    "english_translation": "F12"
+  },
+  {
+    "key": "key.keyboard.f13",
+    "english_translation": "F13"
+  },
+  {
+    "key": "key.keyboard.f14",
+    "english_translation": "F14"
+  },
+  {
+    "key": "key.keyboard.f15",
+    "english_translation": "F15"
+  },
+  {
+    "key": "key.keyboard.f16",
+    "english_translation": "F16"
+  },
+  {
+    "key": "key.keyboard.f17",
+    "english_translation": "F17"
+  },
+  {
+    "key": "key.keyboard.f18",
+    "english_translation": "F18"
+  },
+  {
+    "key": "key.keyboard.f19",
+    "english_translation": "F19"
+  },
+  {
+    "key": "key.keyboard.f20",
+    "english_translation": "F20"
+  },
+  {
+    "key": "key.keyboard.f21",
+    "english_translation": "F21"
+  },
+  {
+    "key": "key.keyboard.f22",
+    "english_translation": "F22"
+  },
+  {
+    "key": "key.keyboard.f23",
+    "english_translation": "F23"
+  },
+  {
+    "key": "key.keyboard.f24",
+    "english_translation": "F24"
+  },
+  {
+    "key": "key.keyboard.f25",
+    "english_translation": "F25"
+  },
+  {
+    "key": "key.keyboard.grave.accent",
+    "english_translation": "`"
+  },
+  {
+    "key": "key.keyboard.home",
+    "english_translation": "Home"
+  },
+  {
+    "key": "key.keyboard.insert",
+    "english_translation": "Insert"
+  },
+  {
+    "key": "key.keyboard.keypad.0",
+    "english_translation": "Keypad 0"
+  },
+  {
+    "key": "key.keyboard.keypad.1",
+    "english_translation": "Keypad 1"
+  },
+  {
+    "key": "key.keyboard.keypad.2",
+    "english_translation": "Keypad 2"
+  },
+  {
+    "key": "key.keyboard.keypad.3",
+    "english_translation": "Keypad 3"
+  },
+  {
+    "key": "key.keyboard.keypad.4",
+    "english_translation": "Keypad 4"
+  },
+  {
+    "key": "key.keyboard.keypad.5",
+    "english_translation": "Keypad 5"
+  },
+  {
+    "key": "key.keyboard.keypad.6",
+    "english_translation": "Keypad 6"
+  },
+  {
+    "key": "key.keyboard.keypad.7",
+    "english_translation": "Keypad 7"
+  },
+  {
+    "key": "key.keyboard.keypad.8",
+    "english_translation": "Keypad 8"
+  },
+  {
+    "key": "key.keyboard.keypad.9",
+    "english_translation": "Keypad 9"
+  },
+  {
+    "key": "key.keyboard.keypad.add",
+    "english_translation": "Keypad +"
+  },
+  {
+    "key": "key.keyboard.keypad.decimal",
+    "english_translation": "Keypad Decimal"
+  },
+  {
+    "key": "key.keyboard.keypad.enter",
+    "english_translation": "Keypad Enter"
+  },
+  {
+    "key": "key.keyboard.keypad.equal",
+    "english_translation": "Keypad ="
+  },
+  {
+    "key": "key.keyboard.keypad.multiply",
+    "english_translation": "Keypad *"
+  },
+  {
+    "key": "key.keyboard.keypad.divide",
+    "english_translation": "Keypad /"
+  },
+  {
+    "key": "key.keyboard.keypad.subtract",
+    "english_translation": "Keypad -"
+  },
+  {
+    "key": "key.keyboard.left.bracket",
+    "english_translation": "["
+  },
+  {
+    "key": "key.keyboard.right.bracket",
+    "english_translation": "]"
+  },
+  {
+    "key": "key.keyboard.minus",
+    "english_translation": "-"
+  },
+  {
+    "key": "key.keyboard.num.lock",
+    "english_translation": "Num Lock"
+  },
+  {
+    "key": "key.keyboard.caps.lock",
+    "english_translation": "Caps Lock"
+  },
+  {
+    "key": "key.keyboard.scroll.lock",
+    "english_translation": "Scroll Lock"
+  },
+  {
+    "key": "key.keyboard.page.down",
+    "english_translation": "Page Down"
+  },
+  {
+    "key": "key.keyboard.page.up",
+    "english_translation": "Page Up"
+  },
+  {
+    "key": "key.keyboard.pause",
+    "english_translation": "Pause"
+  },
+  {
+    "key": "key.keyboard.period",
+    "english_translation": "."
+  },
+  {
+    "key": "key.keyboard.left.control",
+    "english_translation": "Left Control"
+  },
+  {
+    "key": "key.keyboard.right.control",
+    "english_translation": "Right Control"
+  },
+  {
+    "key": "key.keyboard.left.alt",
+    "english_translation": "Left Alt"
+  },
+  {
+    "key": "key.keyboard.right.alt",
+    "english_translation": "Right Alt"
+  },
+  {
+    "key": "key.keyboard.left.shift",
+    "english_translation": "Left Shift"
+  },
+  {
+    "key": "key.keyboard.right.shift",
+    "english_translation": "Right Shift"
+  },
+  {
+    "key": "key.keyboard.left.win",
+    "english_translation": "Left Win"
+  },
+  {
+    "key": "key.keyboard.right.win",
+    "english_translation": "Right Win"
+  },
+  {
+    "key": "key.keyboard.semicolon",
+    "english_translation": ";"
+  },
+  {
+    "key": "key.keyboard.slash",
+    "english_translation": "/"
+  },
+  {
+    "key": "key.keyboard.space",
+    "english_translation": "Space"
+  },
+  {
+    "key": "key.keyboard.tab",
+    "english_translation": "Tab"
+  },
+  {
+    "key": "key.keyboard.up",
+    "english_translation": "Up Arrow"
+  },
+  {
+    "key": "key.keyboard.down",
+    "english_translation": "Down Arrow"
+  },
+  {
+    "key": "key.keyboard.left",
+    "english_translation": "Left Arrow"
+  },
+  {
+    "key": "key.keyboard.right",
+    "english_translation": "Right Arrow"
+  },
+  {
+    "key": "key.keyboard.menu",
+    "english_translation": "Menu"
+  },
+  {
+    "key": "key.keyboard.print.screen",
+    "english_translation": "Print Screen"
+  },
+  {
+    "key": "key.keyboard.world.1",
+    "english_translation": "World 1"
+  },
+  {
+    "key": "key.keyboard.world.2",
+    "english_translation": "World 2"
+  },
+  {
+    "key": "pack.available.title",
+    "english_translation": "Available"
+  },
+  {
+    "key": "pack.selected.title",
+    "english_translation": "Selected"
+  },
+  {
+    "key": "pack.incompatible",
+    "english_translation": "Incompatible"
+  },
+  {
+    "key": "pack.incompatible.old",
+    "english_translation": "(Made for an older version of Minecraft)"
+  },
+  {
+    "key": "pack.incompatible.new",
+    "english_translation": "(Made for a newer version of Minecraft)"
+  },
+  {
+    "key": "pack.incompatible.confirm.title",
+    "english_translation": "Are you sure you want to load this pack?"
+  },
+  {
+    "key": "pack.incompatible.confirm.old",
+    "english_translation": "This pack was made for an older version of Minecraft and may no longer work correctly."
+  },
+  {
+    "key": "pack.incompatible.confirm.new",
+    "english_translation": "This pack was made for a newer version of Minecraft and may not work correctly."
+  },
+  {
+    "key": "pack.dropInfo",
+    "english_translation": "Drag and drop files into this window to add packs"
+  },
+  {
+    "key": "pack.dropConfirm",
+    "english_translation": "Do you want to add the following packs to Minecraft?"
+  },
+  {
+    "key": "pack.copyFailure",
+    "english_translation": "Failed to copy packs"
+  },
+  {
+    "key": "pack.nameAndSource",
+    "english_translation": "%s (%s)"
+  },
+  {
+    "key": "pack.openFolder",
+    "english_translation": "Open Pack Folder"
+  },
+  {
+    "key": "pack.folderInfo",
+    "english_translation": "(Place pack files here)"
+  },
+  {
+    "key": "resourcePack.title",
+    "english_translation": "Select Resource Packs"
+  },
+  {
+    "key": "resourcePack.server.name",
+    "english_translation": "World Specific Resources"
+  },
+  {
+    "key": "resourcePack.broken_assets",
+    "english_translation": "BROKEN ASSETS DETECTED"
+  },
+  {
+    "key": "resourcePack.vanilla.description",
+    "english_translation": "The default resources for Minecraft"
+  },
+  {
+    "key": "resourcePack.load_fail",
+    "english_translation": "Resource reload failed"
+  },
+  {
+    "key": "dataPack.title",
+    "english_translation": "Select Data Packs"
+  },
+  {
+    "key": "dataPack.validation.working",
+    "english_translation": "Validating selected data packs..."
+  },
+  {
+    "key": "dataPack.validation.failed",
+    "english_translation": "Data pack validation failed!"
+  },
+  {
+    "key": "dataPack.validation.back",
+    "english_translation": "Go Back"
+  },
+  {
+    "key": "dataPack.validation.reset",
+    "english_translation": "Reset to Default"
+  },
+  {
+    "key": "dataPack.vanilla.description",
+    "english_translation": "The default data for Minecraft"
+  },
+  {
+    "key": "sign.edit",
+    "english_translation": "Edit Sign Message"
+  },
+  {
+    "key": "book.pageIndicator",
+    "english_translation": "Page %1$s of %2$s"
+  },
+  {
+    "key": "book.byAuthor",
+    "english_translation": "by %1$s"
+  },
+  {
+    "key": "book.signButton",
+    "english_translation": "Sign"
+  },
+  {
+    "key": "book.editTitle",
+    "english_translation": "Enter Book Title:"
+  },
+  {
+    "key": "book.finalizeButton",
+    "english_translation": "Sign and Close"
+  },
+  {
+    "key": "book.finalizeWarning",
+    "english_translation": "Note! When you sign the book, it will no longer be editable."
+  },
+  {
+    "key": "book.generation.0",
+    "english_translation": "Original"
+  },
+  {
+    "key": "book.generation.1",
+    "english_translation": "Copy of original"
+  },
+  {
+    "key": "book.generation.2",
+    "english_translation": "Copy of a copy"
+  },
+  {
+    "key": "book.generation.3",
+    "english_translation": "Tattered"
+  },
+  {
+    "key": "book.invalid.tag",
+    "english_translation": "* Invalid book tag *"
+  },
+  {
+    "key": "merchant.deprecated",
+    "english_translation": "Villagers restock up to two times per day."
+  },
+  {
+    "key": "merchant.current_level",
+    "english_translation": "Trader's current level"
+  },
+  {
+    "key": "merchant.next_level",
+    "english_translation": "Trader's next level"
+  },
+  {
+    "key": "merchant.level.1",
+    "english_translation": "Novice"
+  },
+  {
+    "key": "merchant.level.2",
+    "english_translation": "Apprentice"
+  },
+  {
+    "key": "merchant.level.3",
+    "english_translation": "Journeyman"
+  },
+  {
+    "key": "merchant.level.4",
+    "english_translation": "Expert"
+  },
+  {
+    "key": "merchant.level.5",
+    "english_translation": "Master"
+  },
+  {
+    "key": "merchant.trades",
+    "english_translation": "Trades"
+  },
+  {
+    "key": "block.minecraft.air",
+    "english_translation": "Air"
+  },
+  {
+    "key": "block.minecraft.barrier",
+    "english_translation": "Barrier"
+  },
+  {
+    "key": "block.minecraft.light",
+    "english_translation": "Light"
+  },
+  {
+    "key": "block.minecraft.stone",
+    "english_translation": "Stone"
+  },
+  {
+    "key": "block.minecraft.granite",
+    "english_translation": "Granite"
+  },
+  {
+    "key": "block.minecraft.polished_granite",
+    "english_translation": "Polished Granite"
+  },
+  {
+    "key": "block.minecraft.diorite",
+    "english_translation": "Diorite"
+  },
+  {
+    "key": "block.minecraft.polished_diorite",
+    "english_translation": "Polished Diorite"
+  },
+  {
+    "key": "block.minecraft.andesite",
+    "english_translation": "Andesite"
+  },
+  {
+    "key": "block.minecraft.polished_andesite",
+    "english_translation": "Polished Andesite"
+  },
+  {
+    "key": "block.minecraft.hay_block",
+    "english_translation": "Hay Bale"
+  },
+  {
+    "key": "block.minecraft.grass_block",
+    "english_translation": "Grass Block"
+  },
+  {
+    "key": "block.minecraft.dirt",
+    "english_translation": "Dirt"
+  },
+  {
+    "key": "block.minecraft.coarse_dirt",
+    "english_translation": "Coarse Dirt"
+  },
+  {
+    "key": "block.minecraft.podzol",
+    "english_translation": "Podzol"
+  },
+  {
+    "key": "block.minecraft.cobblestone",
+    "english_translation": "Cobblestone"
+  },
+  {
+    "key": "block.minecraft.oak_planks",
+    "english_translation": "Oak Planks"
+  },
+  {
+    "key": "block.minecraft.spruce_planks",
+    "english_translation": "Spruce Planks"
+  },
+  {
+    "key": "block.minecraft.birch_planks",
+    "english_translation": "Birch Planks"
+  },
+  {
+    "key": "block.minecraft.jungle_planks",
+    "english_translation": "Jungle Planks"
+  },
+  {
+    "key": "block.minecraft.acacia_planks",
+    "english_translation": "Acacia Planks"
+  },
+  {
+    "key": "block.minecraft.dark_oak_planks",
+    "english_translation": "Dark Oak Planks"
+  },
+  {
+    "key": "block.minecraft.mangrove_planks",
+    "english_translation": "Mangrove Planks"
+  },
+  {
+    "key": "block.minecraft.oak_sapling",
+    "english_translation": "Oak Sapling"
+  },
+  {
+    "key": "block.minecraft.spruce_sapling",
+    "english_translation": "Spruce Sapling"
+  },
+  {
+    "key": "block.minecraft.birch_sapling",
+    "english_translation": "Birch Sapling"
+  },
+  {
+    "key": "block.minecraft.jungle_sapling",
+    "english_translation": "Jungle Sapling"
+  },
+  {
+    "key": "block.minecraft.acacia_sapling",
+    "english_translation": "Acacia Sapling"
+  },
+  {
+    "key": "block.minecraft.dark_oak_sapling",
+    "english_translation": "Dark Oak Sapling"
+  },
+  {
+    "key": "block.minecraft.mangrove_propagule",
+    "english_translation": "Mangrove Propagule"
+  },
+  {
+    "key": "block.minecraft.oak_door",
+    "english_translation": "Oak Door"
+  },
+  {
+    "key": "block.minecraft.spruce_door",
+    "english_translation": "Spruce Door"
+  },
+  {
+    "key": "block.minecraft.birch_door",
+    "english_translation": "Birch Door"
+  },
+  {
+    "key": "block.minecraft.jungle_door",
+    "english_translation": "Jungle Door"
+  },
+  {
+    "key": "block.minecraft.acacia_door",
+    "english_translation": "Acacia Door"
+  },
+  {
+    "key": "block.minecraft.dark_oak_door",
+    "english_translation": "Dark Oak Door"
+  },
+  {
+    "key": "block.minecraft.mangrove_door",
+    "english_translation": "Mangrove Door"
+  },
+  {
+    "key": "block.minecraft.bedrock",
+    "english_translation": "Bedrock"
+  },
+  {
+    "key": "block.minecraft.water",
+    "english_translation": "Water"
+  },
+  {
+    "key": "block.minecraft.lava",
+    "english_translation": "Lava"
+  },
+  {
+    "key": "block.minecraft.sand",
+    "english_translation": "Sand"
+  },
+  {
+    "key": "block.minecraft.red_sand",
+    "english_translation": "Red Sand"
+  },
+  {
+    "key": "block.minecraft.sandstone",
+    "english_translation": "Sandstone"
+  },
+  {
+    "key": "block.minecraft.chiseled_sandstone",
+    "english_translation": "Chiseled Sandstone"
+  },
+  {
+    "key": "block.minecraft.cut_sandstone",
+    "english_translation": "Cut Sandstone"
+  },
+  {
+    "key": "block.minecraft.red_sandstone",
+    "english_translation": "Red Sandstone"
+  },
+  {
+    "key": "block.minecraft.chiseled_red_sandstone",
+    "english_translation": "Chiseled Red Sandstone"
+  },
+  {
+    "key": "block.minecraft.cut_red_sandstone",
+    "english_translation": "Cut Red Sandstone"
+  },
+  {
+    "key": "block.minecraft.gravel",
+    "english_translation": "Gravel"
+  },
+  {
+    "key": "block.minecraft.gold_ore",
+    "english_translation": "Gold Ore"
+  },
+  {
+    "key": "block.minecraft.deepslate_gold_ore",
+    "english_translation": "Deepslate Gold Ore"
+  },
+  {
+    "key": "block.minecraft.nether_gold_ore",
+    "english_translation": "Nether Gold Ore"
+  },
+  {
+    "key": "block.minecraft.iron_ore",
+    "english_translation": "Iron Ore"
+  },
+  {
+    "key": "block.minecraft.deepslate_iron_ore",
+    "english_translation": "Deepslate Iron Ore"
+  },
+  {
+    "key": "block.minecraft.coal_ore",
+    "english_translation": "Coal Ore"
+  },
+  {
+    "key": "block.minecraft.deepslate_coal_ore",
+    "english_translation": "Deepslate Coal Ore"
+  },
+  {
+    "key": "block.minecraft.oak_wood",
+    "english_translation": "Oak Wood"
+  },
+  {
+    "key": "block.minecraft.spruce_wood",
+    "english_translation": "Spruce Wood"
+  },
+  {
+    "key": "block.minecraft.birch_wood",
+    "english_translation": "Birch Wood"
+  },
+  {
+    "key": "block.minecraft.jungle_wood",
+    "english_translation": "Jungle Wood"
+  },
+  {
+    "key": "block.minecraft.acacia_wood",
+    "english_translation": "Acacia Wood"
+  },
+  {
+    "key": "block.minecraft.dark_oak_wood",
+    "english_translation": "Dark Oak Wood"
+  },
+  {
+    "key": "block.minecraft.mangrove_wood",
+    "english_translation": "Mangrove Wood"
+  },
+  {
+    "key": "block.minecraft.oak_log",
+    "english_translation": "Oak Log"
+  },
+  {
+    "key": "block.minecraft.spruce_log",
+    "english_translation": "Spruce Log"
+  },
+  {
+    "key": "block.minecraft.birch_log",
+    "english_translation": "Birch Log"
+  },
+  {
+    "key": "block.minecraft.jungle_log",
+    "english_translation": "Jungle Log"
+  },
+  {
+    "key": "block.minecraft.acacia_log",
+    "english_translation": "Acacia Log"
+  },
+  {
+    "key": "block.minecraft.dark_oak_log",
+    "english_translation": "Dark Oak Log"
+  },
+  {
+    "key": "block.minecraft.mangrove_log",
+    "english_translation": "Mangrove Log"
+  },
+  {
+    "key": "block.minecraft.mangrove_roots",
+    "english_translation": "Mangrove Roots"
+  },
+  {
+    "key": "block.minecraft.muddy_mangrove_roots",
+    "english_translation": "Muddy Mangrove Roots"
+  },
+  {
+    "key": "block.minecraft.stripped_oak_log",
+    "english_translation": "Stripped Oak Log"
+  },
+  {
+    "key": "block.minecraft.stripped_spruce_log",
+    "english_translation": "Stripped Spruce Log"
+  },
+  {
+    "key": "block.minecraft.stripped_birch_log",
+    "english_translation": "Stripped Birch Log"
+  },
+  {
+    "key": "block.minecraft.stripped_jungle_log",
+    "english_translation": "Stripped Jungle Log"
+  },
+  {
+    "key": "block.minecraft.stripped_acacia_log",
+    "english_translation": "Stripped Acacia Log"
+  },
+  {
+    "key": "block.minecraft.stripped_dark_oak_log",
+    "english_translation": "Stripped Dark Oak Log"
+  },
+  {
+    "key": "block.minecraft.stripped_mangrove_log",
+    "english_translation": "Stripped Mangrove Log"
+  },
+  {
+    "key": "block.minecraft.stripped_oak_wood",
+    "english_translation": "Stripped Oak Wood"
+  },
+  {
+    "key": "block.minecraft.stripped_spruce_wood",
+    "english_translation": "Stripped Spruce Wood"
+  },
+  {
+    "key": "block.minecraft.stripped_birch_wood",
+    "english_translation": "Stripped Birch Wood"
+  },
+  {
+    "key": "block.minecraft.stripped_jungle_wood",
+    "english_translation": "Stripped Jungle Wood"
+  },
+  {
+    "key": "block.minecraft.stripped_acacia_wood",
+    "english_translation": "Stripped Acacia Wood"
+  },
+  {
+    "key": "block.minecraft.stripped_dark_oak_wood",
+    "english_translation": "Stripped Dark Oak Wood"
+  },
+  {
+    "key": "block.minecraft.stripped_mangrove_wood",
+    "english_translation": "Stripped Mangrove Wood"
+  },
+  {
+    "key": "block.minecraft.oak_leaves",
+    "english_translation": "Oak Leaves"
+  },
+  {
+    "key": "block.minecraft.spruce_leaves",
+    "english_translation": "Spruce Leaves"
+  },
+  {
+    "key": "block.minecraft.birch_leaves",
+    "english_translation": "Birch Leaves"
+  },
+  {
+    "key": "block.minecraft.jungle_leaves",
+    "english_translation": "Jungle Leaves"
+  },
+  {
+    "key": "block.minecraft.acacia_leaves",
+    "english_translation": "Acacia Leaves"
+  },
+  {
+    "key": "block.minecraft.dark_oak_leaves",
+    "english_translation": "Dark Oak Leaves"
+  },
+  {
+    "key": "block.minecraft.mangrove_leaves",
+    "english_translation": "Mangrove Leaves"
+  },
+  {
+    "key": "block.minecraft.dead_bush",
+    "english_translation": "Dead Bush"
+  },
+  {
+    "key": "block.minecraft.grass",
+    "english_translation": "Grass"
+  },
+  {
+    "key": "block.minecraft.fern",
+    "english_translation": "Fern"
+  },
+  {
+    "key": "block.minecraft.sponge",
+    "english_translation": "Sponge"
+  },
+  {
+    "key": "block.minecraft.wet_sponge",
+    "english_translation": "Wet Sponge"
+  },
+  {
+    "key": "block.minecraft.glass",
+    "english_translation": "Glass"
+  },
+  {
+    "key": "block.minecraft.kelp_plant",
+    "english_translation": "Kelp Plant"
+  },
+  {
+    "key": "block.minecraft.kelp",
+    "english_translation": "Kelp"
+  },
+  {
+    "key": "block.minecraft.dried_kelp_block",
+    "english_translation": "Dried Kelp Block"
+  },
+  {
+    "key": "block.minecraft.white_stained_glass",
+    "english_translation": "White Stained Glass"
+  },
+  {
+    "key": "block.minecraft.orange_stained_glass",
+    "english_translation": "Orange Stained Glass"
+  },
+  {
+    "key": "block.minecraft.magenta_stained_glass",
+    "english_translation": "Magenta Stained Glass"
+  },
+  {
+    "key": "block.minecraft.light_blue_stained_glass",
+    "english_translation": "Light Blue Stained Glass"
+  },
+  {
+    "key": "block.minecraft.yellow_stained_glass",
+    "english_translation": "Yellow Stained Glass"
+  },
+  {
+    "key": "block.minecraft.lime_stained_glass",
+    "english_translation": "Lime Stained Glass"
+  },
+  {
+    "key": "block.minecraft.pink_stained_glass",
+    "english_translation": "Pink Stained Glass"
+  },
+  {
+    "key": "block.minecraft.gray_stained_glass",
+    "english_translation": "Gray Stained Glass"
+  },
+  {
+    "key": "block.minecraft.light_gray_stained_glass",
+    "english_translation": "Light Gray Stained Glass"
+  },
+  {
+    "key": "block.minecraft.cyan_stained_glass",
+    "english_translation": "Cyan Stained Glass"
+  },
+  {
+    "key": "block.minecraft.purple_stained_glass",
+    "english_translation": "Purple Stained Glass"
+  },
+  {
+    "key": "block.minecraft.blue_stained_glass",
+    "english_translation": "Blue Stained Glass"
+  },
+  {
+    "key": "block.minecraft.brown_stained_glass",
+    "english_translation": "Brown Stained Glass"
+  },
+  {
+    "key": "block.minecraft.green_stained_glass",
+    "english_translation": "Green Stained Glass"
+  },
+  {
+    "key": "block.minecraft.red_stained_glass",
+    "english_translation": "Red Stained Glass"
+  },
+  {
+    "key": "block.minecraft.black_stained_glass",
+    "english_translation": "Black Stained Glass"
+  },
+  {
+    "key": "block.minecraft.white_stained_glass_pane",
+    "english_translation": "White Stained Glass Pane"
+  },
+  {
+    "key": "block.minecraft.orange_stained_glass_pane",
+    "english_translation": "Orange Stained Glass Pane"
+  },
+  {
+    "key": "block.minecraft.magenta_stained_glass_pane",
+    "english_translation": "Magenta Stained Glass Pane"
+  },
+  {
+    "key": "block.minecraft.light_blue_stained_glass_pane",
+    "english_translation": "Light Blue Stained Glass Pane"
+  },
+  {
+    "key": "block.minecraft.yellow_stained_glass_pane",
+    "english_translation": "Yellow Stained Glass Pane"
+  },
+  {
+    "key": "block.minecraft.lime_stained_glass_pane",
+    "english_translation": "Lime Stained Glass Pane"
+  },
+  {
+    "key": "block.minecraft.pink_stained_glass_pane",
+    "english_translation": "Pink Stained Glass Pane"
+  },
+  {
+    "key": "block.minecraft.gray_stained_glass_pane",
+    "english_translation": "Gray Stained Glass Pane"
+  },
+  {
+    "key": "block.minecraft.light_gray_stained_glass_pane",
+    "english_translation": "Light Gray Stained Glass Pane"
+  },
+  {
+    "key": "block.minecraft.cyan_stained_glass_pane",
+    "english_translation": "Cyan Stained Glass Pane"
+  },
+  {
+    "key": "block.minecraft.purple_stained_glass_pane",
+    "english_translation": "Purple Stained Glass Pane"
+  },
+  {
+    "key": "block.minecraft.blue_stained_glass_pane",
+    "english_translation": "Blue Stained Glass Pane"
+  },
+  {
+    "key": "block.minecraft.brown_stained_glass_pane",
+    "english_translation": "Brown Stained Glass Pane"
+  },
+  {
+    "key": "block.minecraft.green_stained_glass_pane",
+    "english_translation": "Green Stained Glass Pane"
+  },
+  {
+    "key": "block.minecraft.red_stained_glass_pane",
+    "english_translation": "Red Stained Glass Pane"
+  },
+  {
+    "key": "block.minecraft.black_stained_glass_pane",
+    "english_translation": "Black Stained Glass Pane"
+  },
+  {
+    "key": "block.minecraft.glass_pane",
+    "english_translation": "Glass Pane"
+  },
+  {
+    "key": "block.minecraft.dandelion",
+    "english_translation": "Dandelion"
+  },
+  {
+    "key": "block.minecraft.poppy",
+    "english_translation": "Poppy"
+  },
+  {
+    "key": "block.minecraft.blue_orchid",
+    "english_translation": "Blue Orchid"
+  },
+  {
+    "key": "block.minecraft.allium",
+    "english_translation": "Allium"
+  },
+  {
+    "key": "block.minecraft.azure_bluet",
+    "english_translation": "Azure Bluet"
+  },
+  {
+    "key": "block.minecraft.red_tulip",
+    "english_translation": "Red Tulip"
+  },
+  {
+    "key": "block.minecraft.orange_tulip",
+    "english_translation": "Orange Tulip"
+  },
+  {
+    "key": "block.minecraft.white_tulip",
+    "english_translation": "White Tulip"
+  },
+  {
+    "key": "block.minecraft.pink_tulip",
+    "english_translation": "Pink Tulip"
+  },
+  {
+    "key": "block.minecraft.oxeye_daisy",
+    "english_translation": "Oxeye Daisy"
+  },
+  {
+    "key": "block.minecraft.cornflower",
+    "english_translation": "Cornflower"
+  },
+  {
+    "key": "block.minecraft.lily_of_the_valley",
+    "english_translation": "Lily of the Valley"
+  },
+  {
+    "key": "block.minecraft.wither_rose",
+    "english_translation": "Wither Rose"
+  },
+  {
+    "key": "block.minecraft.sunflower",
+    "english_translation": "Sunflower"
+  },
+  {
+    "key": "block.minecraft.lilac",
+    "english_translation": "Lilac"
+  },
+  {
+    "key": "block.minecraft.tall_grass",
+    "english_translation": "Tall Grass"
+  },
+  {
+    "key": "block.minecraft.tall_seagrass",
+    "english_translation": "Tall Seagrass"
+  },
+  {
+    "key": "block.minecraft.large_fern",
+    "english_translation": "Large Fern"
+  },
+  {
+    "key": "block.minecraft.rose_bush",
+    "english_translation": "Rose Bush"
+  },
+  {
+    "key": "block.minecraft.peony",
+    "english_translation": "Peony"
+  },
+  {
+    "key": "block.minecraft.seagrass",
+    "english_translation": "Seagrass"
+  },
+  {
+    "key": "block.minecraft.sea_pickle",
+    "english_translation": "Sea Pickle"
+  },
+  {
+    "key": "block.minecraft.brown_mushroom",
+    "english_translation": "Brown Mushroom"
+  },
+  {
+    "key": "block.minecraft.red_mushroom_block",
+    "english_translation": "Red Mushroom Block"
+  },
+  {
+    "key": "block.minecraft.brown_mushroom_block",
+    "english_translation": "Brown Mushroom Block"
+  },
+  {
+    "key": "block.minecraft.mushroom_stem",
+    "english_translation": "Mushroom Stem"
+  },
+  {
+    "key": "block.minecraft.gold_block",
+    "english_translation": "Block of Gold"
+  },
+  {
+    "key": "block.minecraft.iron_block",
+    "english_translation": "Block of Iron"
+  },
+  {
+    "key": "block.minecraft.smooth_stone",
+    "english_translation": "Smooth Stone"
+  },
+  {
+    "key": "block.minecraft.smooth_sandstone",
+    "english_translation": "Smooth Sandstone"
+  },
+  {
+    "key": "block.minecraft.smooth_red_sandstone",
+    "english_translation": "Smooth Red Sandstone"
+  },
+  {
+    "key": "block.minecraft.smooth_quartz",
+    "english_translation": "Smooth Quartz Block"
+  },
+  {
+    "key": "block.minecraft.stone_slab",
+    "english_translation": "Stone Slab"
+  },
+  {
+    "key": "block.minecraft.smooth_stone_slab",
+    "english_translation": "Smooth Stone Slab"
+  },
+  {
+    "key": "block.minecraft.sandstone_slab",
+    "english_translation": "Sandstone Slab"
+  },
+  {
+    "key": "block.minecraft.red_sandstone_slab",
+    "english_translation": "Red Sandstone Slab"
+  },
+  {
+    "key": "block.minecraft.cut_sandstone_slab",
+    "english_translation": "Cut Sandstone Slab"
+  },
+  {
+    "key": "block.minecraft.cut_red_sandstone_slab",
+    "english_translation": "Cut Red Sandstone Slab"
+  },
+  {
+    "key": "block.minecraft.petrified_oak_slab",
+    "english_translation": "Petrified Oak Slab"
+  },
+  {
+    "key": "block.minecraft.cobblestone_slab",
+    "english_translation": "Cobblestone Slab"
+  },
+  {
+    "key": "block.minecraft.brick_slab",
+    "english_translation": "Brick Slab"
+  },
+  {
+    "key": "block.minecraft.stone_brick_slab",
+    "english_translation": "Stone Brick Slab"
+  },
+  {
+    "key": "block.minecraft.mud_brick_slab",
+    "english_translation": "Mud Brick Slab"
+  },
+  {
+    "key": "block.minecraft.nether_brick_slab",
+    "english_translation": "Nether Brick Slab"
+  },
+  {
+    "key": "block.minecraft.quartz_slab",
+    "english_translation": "Quartz Slab"
+  },
+  {
+    "key": "block.minecraft.oak_slab",
+    "english_translation": "Oak Slab"
+  },
+  {
+    "key": "block.minecraft.spruce_slab",
+    "english_translation": "Spruce Slab"
+  },
+  {
+    "key": "block.minecraft.birch_slab",
+    "english_translation": "Birch Slab"
+  },
+  {
+    "key": "block.minecraft.jungle_slab",
+    "english_translation": "Jungle Slab"
+  },
+  {
+    "key": "block.minecraft.acacia_slab",
+    "english_translation": "Acacia Slab"
+  },
+  {
+    "key": "block.minecraft.dark_oak_slab",
+    "english_translation": "Dark Oak Slab"
+  },
+  {
+    "key": "block.minecraft.mangrove_slab",
+    "english_translation": "Mangrove Slab"
+  },
+  {
+    "key": "block.minecraft.dark_prismarine_slab",
+    "english_translation": "Dark Prismarine Slab"
+  },
+  {
+    "key": "block.minecraft.prismarine_slab",
+    "english_translation": "Prismarine Slab"
+  },
+  {
+    "key": "block.minecraft.prismarine_brick_slab",
+    "english_translation": "Prismarine Brick Slab"
+  },
+  {
+    "key": "block.minecraft.bricks",
+    "english_translation": "Bricks"
+  },
+  {
+    "key": "block.minecraft.tnt",
+    "english_translation": "TNT"
+  },
+  {
+    "key": "block.minecraft.bookshelf",
+    "english_translation": "Bookshelf"
+  },
+  {
+    "key": "block.minecraft.mossy_cobblestone",
+    "english_translation": "Mossy Cobblestone"
+  },
+  {
+    "key": "block.minecraft.obsidian",
+    "english_translation": "Obsidian"
+  },
+  {
+    "key": "block.minecraft.torch",
+    "english_translation": "Torch"
+  },
+  {
+    "key": "block.minecraft.wall_torch",
+    "english_translation": "Wall Torch"
+  },
+  {
+    "key": "block.minecraft.soul_torch",
+    "english_translation": "Soul Torch"
+  },
+  {
+    "key": "block.minecraft.soul_wall_torch",
+    "english_translation": "Soul Wall Torch"
+  },
+  {
+    "key": "block.minecraft.fire",
+    "english_translation": "Fire"
+  },
+  {
+    "key": "block.minecraft.spawner",
+    "english_translation": "Spawner"
+  },
+  {
+    "key": "block.minecraft.respawn_anchor",
+    "english_translation": "Respawn Anchor"
+  },
+  {
+    "key": "block.minecraft.oak_stairs",
+    "english_translation": "Oak Stairs"
+  },
+  {
+    "key": "block.minecraft.spruce_stairs",
+    "english_translation": "Spruce Stairs"
+  },
+  {
+    "key": "block.minecraft.birch_stairs",
+    "english_translation": "Birch Stairs"
+  },
+  {
+    "key": "block.minecraft.jungle_stairs",
+    "english_translation": "Jungle Stairs"
+  },
+  {
+    "key": "block.minecraft.acacia_stairs",
+    "english_translation": "Acacia Stairs"
+  },
+  {
+    "key": "block.minecraft.dark_oak_stairs",
+    "english_translation": "Dark Oak Stairs"
+  },
+  {
+    "key": "block.minecraft.mangrove_stairs",
+    "english_translation": "Mangrove Stairs"
+  },
+  {
+    "key": "block.minecraft.dark_prismarine_stairs",
+    "english_translation": "Dark Prismarine Stairs"
+  },
+  {
+    "key": "block.minecraft.prismarine_stairs",
+    "english_translation": "Prismarine Stairs"
+  },
+  {
+    "key": "block.minecraft.prismarine_brick_stairs",
+    "english_translation": "Prismarine Brick Stairs"
+  },
+  {
+    "key": "block.minecraft.chest",
+    "english_translation": "Chest"
+  },
+  {
+    "key": "block.minecraft.trapped_chest",
+    "english_translation": "Trapped Chest"
+  },
+  {
+    "key": "block.minecraft.redstone_wire",
+    "english_translation": "Redstone Wire"
+  },
+  {
+    "key": "block.minecraft.diamond_ore",
+    "english_translation": "Diamond Ore"
+  },
+  {
+    "key": "block.minecraft.deepslate_diamond_ore",
+    "english_translation": "Deepslate Diamond Ore"
+  },
+  {
+    "key": "block.minecraft.coal_block",
+    "english_translation": "Block of Coal"
+  },
+  {
+    "key": "block.minecraft.diamond_block",
+    "english_translation": "Block of Diamond"
+  },
+  {
+    "key": "block.minecraft.crafting_table",
+    "english_translation": "Crafting Table"
+  },
+  {
+    "key": "block.minecraft.wheat",
+    "english_translation": "Wheat Crops"
+  },
+  {
+    "key": "block.minecraft.farmland",
+    "english_translation": "Farmland"
+  },
+  {
+    "key": "block.minecraft.furnace",
+    "english_translation": "Furnace"
+  },
+  {
+    "key": "block.minecraft.oak_sign",
+    "english_translation": "Oak Sign"
+  },
+  {
+    "key": "block.minecraft.spruce_sign",
+    "english_translation": "Spruce Sign"
+  },
+  {
+    "key": "block.minecraft.birch_sign",
+    "english_translation": "Birch Sign"
+  },
+  {
+    "key": "block.minecraft.acacia_sign",
+    "english_translation": "Acacia Sign"
+  },
+  {
+    "key": "block.minecraft.jungle_sign",
+    "english_translation": "Jungle Sign"
+  },
+  {
+    "key": "block.minecraft.dark_oak_sign",
+    "english_translation": "Dark Oak Sign"
+  },
+  {
+    "key": "block.minecraft.mangrove_sign",
+    "english_translation": "Mangrove Sign"
+  },
+  {
+    "key": "block.minecraft.oak_wall_sign",
+    "english_translation": "Oak Wall Sign"
+  },
+  {
+    "key": "block.minecraft.spruce_wall_sign",
+    "english_translation": "Spruce Wall Sign"
+  },
+  {
+    "key": "block.minecraft.birch_wall_sign",
+    "english_translation": "Birch Wall Sign"
+  },
+  {
+    "key": "block.minecraft.acacia_wall_sign",
+    "english_translation": "Acacia Wall Sign"
+  },
+  {
+    "key": "block.minecraft.jungle_wall_sign",
+    "english_translation": "Jungle Wall Sign"
+  },
+  {
+    "key": "block.minecraft.dark_oak_wall_sign",
+    "english_translation": "Dark Oak Wall Sign"
+  },
+  {
+    "key": "block.minecraft.mangrove_wall_sign",
+    "english_translation": "Mangrove Wall Sign"
+  },
+  {
+    "key": "block.minecraft.ladder",
+    "english_translation": "Ladder"
+  },
+  {
+    "key": "block.minecraft.scaffolding",
+    "english_translation": "Scaffolding"
+  },
+  {
+    "key": "block.minecraft.rail",
+    "english_translation": "Rail"
+  },
+  {
+    "key": "block.minecraft.powered_rail",
+    "english_translation": "Powered Rail"
+  },
+  {
+    "key": "block.minecraft.activator_rail",
+    "english_translation": "Activator Rail"
+  },
+  {
+    "key": "block.minecraft.detector_rail",
+    "english_translation": "Detector Rail"
+  },
+  {
+    "key": "block.minecraft.cobblestone_stairs",
+    "english_translation": "Cobblestone Stairs"
+  },
+  {
+    "key": "block.minecraft.sandstone_stairs",
+    "english_translation": "Sandstone Stairs"
+  },
+  {
+    "key": "block.minecraft.red_sandstone_stairs",
+    "english_translation": "Red Sandstone Stairs"
+  },
+  {
+    "key": "block.minecraft.lever",
+    "english_translation": "Lever"
+  },
+  {
+    "key": "block.minecraft.stone_pressure_plate",
+    "english_translation": "Stone Pressure Plate"
+  },
+  {
+    "key": "block.minecraft.oak_pressure_plate",
+    "english_translation": "Oak Pressure Plate"
+  },
+  {
+    "key": "block.minecraft.spruce_pressure_plate",
+    "english_translation": "Spruce Pressure Plate"
+  },
+  {
+    "key": "block.minecraft.birch_pressure_plate",
+    "english_translation": "Birch Pressure Plate"
+  },
+  {
+    "key": "block.minecraft.jungle_pressure_plate",
+    "english_translation": "Jungle Pressure Plate"
+  },
+  {
+    "key": "block.minecraft.acacia_pressure_plate",
+    "english_translation": "Acacia Pressure Plate"
+  },
+  {
+    "key": "block.minecraft.dark_oak_pressure_plate",
+    "english_translation": "Dark Oak Pressure Plate"
+  },
+  {
+    "key": "block.minecraft.mangrove_pressure_plate",
+    "english_translation": "Mangrove Pressure Plate"
+  },
+  {
+    "key": "block.minecraft.light_weighted_pressure_plate",
+    "english_translation": "Light Weighted Pressure Plate"
+  },
+  {
+    "key": "block.minecraft.heavy_weighted_pressure_plate",
+    "english_translation": "Heavy Weighted Pressure Plate"
+  },
+  {
+    "key": "block.minecraft.iron_door",
+    "english_translation": "Iron Door"
+  },
+  {
+    "key": "block.minecraft.redstone_ore",
+    "english_translation": "Redstone Ore"
+  },
+  {
+    "key": "block.minecraft.deepslate_redstone_ore",
+    "english_translation": "Deepslate Redstone Ore"
+  },
+  {
+    "key": "block.minecraft.redstone_torch",
+    "english_translation": "Redstone Torch"
+  },
+  {
+    "key": "block.minecraft.redstone_wall_torch",
+    "english_translation": "Redstone Wall Torch"
+  },
+  {
+    "key": "block.minecraft.stone_button",
+    "english_translation": "Stone Button"
+  },
+  {
+    "key": "block.minecraft.oak_button",
+    "english_translation": "Oak Button"
+  },
+  {
+    "key": "block.minecraft.spruce_button",
+    "english_translation": "Spruce Button"
+  },
+  {
+    "key": "block.minecraft.birch_button",
+    "english_translation": "Birch Button"
+  },
+  {
+    "key": "block.minecraft.jungle_button",
+    "english_translation": "Jungle Button"
+  },
+  {
+    "key": "block.minecraft.acacia_button",
+    "english_translation": "Acacia Button"
+  },
+  {
+    "key": "block.minecraft.dark_oak_button",
+    "english_translation": "Dark Oak Button"
+  },
+  {
+    "key": "block.minecraft.mangrove_button",
+    "english_translation": "Mangrove Button"
+  },
+  {
+    "key": "block.minecraft.snow",
+    "english_translation": "Snow"
+  },
+  {
+    "key": "block.minecraft.white_carpet",
+    "english_translation": "White Carpet"
+  },
+  {
+    "key": "block.minecraft.orange_carpet",
+    "english_translation": "Orange Carpet"
+  },
+  {
+    "key": "block.minecraft.magenta_carpet",
+    "english_translation": "Magenta Carpet"
+  },
+  {
+    "key": "block.minecraft.light_blue_carpet",
+    "english_translation": "Light Blue Carpet"
+  },
+  {
+    "key": "block.minecraft.yellow_carpet",
+    "english_translation": "Yellow Carpet"
+  },
+  {
+    "key": "block.minecraft.lime_carpet",
+    "english_translation": "Lime Carpet"
+  },
+  {
+    "key": "block.minecraft.pink_carpet",
+    "english_translation": "Pink Carpet"
+  },
+  {
+    "key": "block.minecraft.gray_carpet",
+    "english_translation": "Gray Carpet"
+  },
+  {
+    "key": "block.minecraft.light_gray_carpet",
+    "english_translation": "Light Gray Carpet"
+  },
+  {
+    "key": "block.minecraft.cyan_carpet",
+    "english_translation": "Cyan Carpet"
+  },
+  {
+    "key": "block.minecraft.purple_carpet",
+    "english_translation": "Purple Carpet"
+  },
+  {
+    "key": "block.minecraft.blue_carpet",
+    "english_translation": "Blue Carpet"
+  },
+  {
+    "key": "block.minecraft.brown_carpet",
+    "english_translation": "Brown Carpet"
+  },
+  {
+    "key": "block.minecraft.green_carpet",
+    "english_translation": "Green Carpet"
+  },
+  {
+    "key": "block.minecraft.red_carpet",
+    "english_translation": "Red Carpet"
+  },
+  {
+    "key": "block.minecraft.black_carpet",
+    "english_translation": "Black Carpet"
+  },
+  {
+    "key": "block.minecraft.ice",
+    "english_translation": "Ice"
+  },
+  {
+    "key": "block.minecraft.frosted_ice",
+    "english_translation": "Frosted Ice"
+  },
+  {
+    "key": "block.minecraft.packed_ice",
+    "english_translation": "Packed Ice"
+  },
+  {
+    "key": "block.minecraft.blue_ice",
+    "english_translation": "Blue Ice"
+  },
+  {
+    "key": "block.minecraft.cactus",
+    "english_translation": "Cactus"
+  },
+  {
+    "key": "block.minecraft.clay",
+    "english_translation": "Clay"
+  },
+  {
+    "key": "block.minecraft.white_terracotta",
+    "english_translation": "White Terracotta"
+  },
+  {
+    "key": "block.minecraft.orange_terracotta",
+    "english_translation": "Orange Terracotta"
+  },
+  {
+    "key": "block.minecraft.magenta_terracotta",
+    "english_translation": "Magenta Terracotta"
+  },
+  {
+    "key": "block.minecraft.light_blue_terracotta",
+    "english_translation": "Light Blue Terracotta"
+  },
+  {
+    "key": "block.minecraft.yellow_terracotta",
+    "english_translation": "Yellow Terracotta"
+  },
+  {
+    "key": "block.minecraft.lime_terracotta",
+    "english_translation": "Lime Terracotta"
+  },
+  {
+    "key": "block.minecraft.pink_terracotta",
+    "english_translation": "Pink Terracotta"
+  },
+  {
+    "key": "block.minecraft.gray_terracotta",
+    "english_translation": "Gray Terracotta"
+  },
+  {
+    "key": "block.minecraft.light_gray_terracotta",
+    "english_translation": "Light Gray Terracotta"
+  },
+  {
+    "key": "block.minecraft.cyan_terracotta",
+    "english_translation": "Cyan Terracotta"
+  },
+  {
+    "key": "block.minecraft.purple_terracotta",
+    "english_translation": "Purple Terracotta"
+  },
+  {
+    "key": "block.minecraft.blue_terracotta",
+    "english_translation": "Blue Terracotta"
+  },
+  {
+    "key": "block.minecraft.brown_terracotta",
+    "english_translation": "Brown Terracotta"
+  },
+  {
+    "key": "block.minecraft.green_terracotta",
+    "english_translation": "Green Terracotta"
+  },
+  {
+    "key": "block.minecraft.red_terracotta",
+    "english_translation": "Red Terracotta"
+  },
+  {
+    "key": "block.minecraft.black_terracotta",
+    "english_translation": "Black Terracotta"
+  },
+  {
+    "key": "block.minecraft.terracotta",
+    "english_translation": "Terracotta"
+  },
+  {
+    "key": "block.minecraft.sugar_cane",
+    "english_translation": "Sugar Cane"
+  },
+  {
+    "key": "block.minecraft.jukebox",
+    "english_translation": "Jukebox"
+  },
+  {
+    "key": "block.minecraft.oak_fence",
+    "english_translation": "Oak Fence"
+  },
+  {
+    "key": "block.minecraft.spruce_fence",
+    "english_translation": "Spruce Fence"
+  },
+  {
+    "key": "block.minecraft.birch_fence",
+    "english_translation": "Birch Fence"
+  },
+  {
+    "key": "block.minecraft.jungle_fence",
+    "english_translation": "Jungle Fence"
+  },
+  {
+    "key": "block.minecraft.acacia_fence",
+    "english_translation": "Acacia Fence"
+  },
+  {
+    "key": "block.minecraft.dark_oak_fence",
+    "english_translation": "Dark Oak Fence"
+  },
+  {
+    "key": "block.minecraft.mangrove_fence",
+    "english_translation": "Mangrove Fence"
+  },
+  {
+    "key": "block.minecraft.oak_fence_gate",
+    "english_translation": "Oak Fence Gate"
+  },
+  {
+    "key": "block.minecraft.spruce_fence_gate",
+    "english_translation": "Spruce Fence Gate"
+  },
+  {
+    "key": "block.minecraft.birch_fence_gate",
+    "english_translation": "Birch Fence Gate"
+  },
+  {
+    "key": "block.minecraft.jungle_fence_gate",
+    "english_translation": "Jungle Fence Gate"
+  },
+  {
+    "key": "block.minecraft.acacia_fence_gate",
+    "english_translation": "Acacia Fence Gate"
+  },
+  {
+    "key": "block.minecraft.dark_oak_fence_gate",
+    "english_translation": "Dark Oak Fence Gate"
+  },
+  {
+    "key": "block.minecraft.mangrove_fence_gate",
+    "english_translation": "Mangrove Fence Gate"
+  },
+  {
+    "key": "block.minecraft.pumpkin_stem",
+    "english_translation": "Pumpkin Stem"
+  },
+  {
+    "key": "block.minecraft.attached_pumpkin_stem",
+    "english_translation": "Attached Pumpkin Stem"
+  },
+  {
+    "key": "block.minecraft.pumpkin",
+    "english_translation": "Pumpkin"
+  },
+  {
+    "key": "block.minecraft.carved_pumpkin",
+    "english_translation": "Carved Pumpkin"
+  },
+  {
+    "key": "block.minecraft.jack_o_lantern",
+    "english_translation": "Jack o'Lantern"
+  },
+  {
+    "key": "block.minecraft.netherrack",
+    "english_translation": "Netherrack"
+  },
+  {
+    "key": "block.minecraft.soul_sand",
+    "english_translation": "Soul Sand"
+  },
+  {
+    "key": "block.minecraft.glowstone",
+    "english_translation": "Glowstone"
+  },
+  {
+    "key": "block.minecraft.nether_portal",
+    "english_translation": "Nether Portal"
+  },
+  {
+    "key": "block.minecraft.white_wool",
+    "english_translation": "White Wool"
+  },
+  {
+    "key": "block.minecraft.orange_wool",
+    "english_translation": "Orange Wool"
+  },
+  {
+    "key": "block.minecraft.magenta_wool",
+    "english_translation": "Magenta Wool"
+  },
+  {
+    "key": "block.minecraft.light_blue_wool",
+    "english_translation": "Light Blue Wool"
+  },
+  {
+    "key": "block.minecraft.yellow_wool",
+    "english_translation": "Yellow Wool"
+  },
+  {
+    "key": "block.minecraft.lime_wool",
+    "english_translation": "Lime Wool"
+  },
+  {
+    "key": "block.minecraft.pink_wool",
+    "english_translation": "Pink Wool"
+  },
+  {
+    "key": "block.minecraft.gray_wool",
+    "english_translation": "Gray Wool"
+  },
+  {
+    "key": "block.minecraft.light_gray_wool",
+    "english_translation": "Light Gray Wool"
+  },
+  {
+    "key": "block.minecraft.cyan_wool",
+    "english_translation": "Cyan Wool"
+  },
+  {
+    "key": "block.minecraft.purple_wool",
+    "english_translation": "Purple Wool"
+  },
+  {
+    "key": "block.minecraft.blue_wool",
+    "english_translation": "Blue Wool"
+  },
+  {
+    "key": "block.minecraft.brown_wool",
+    "english_translation": "Brown Wool"
+  },
+  {
+    "key": "block.minecraft.green_wool",
+    "english_translation": "Green Wool"
+  },
+  {
+    "key": "block.minecraft.red_wool",
+    "english_translation": "Red Wool"
+  },
+  {
+    "key": "block.minecraft.black_wool",
+    "english_translation": "Black Wool"
+  },
+  {
+    "key": "block.minecraft.lapis_ore",
+    "english_translation": "Lapis Lazuli Ore"
+  },
+  {
+    "key": "block.minecraft.deepslate_lapis_ore",
+    "english_translation": "Deepslate Lapis Lazuli Ore"
+  },
+  {
+    "key": "block.minecraft.lapis_block",
+    "english_translation": "Block of Lapis Lazuli"
+  },
+  {
+    "key": "block.minecraft.dispenser",
+    "english_translation": "Dispenser"
+  },
+  {
+    "key": "block.minecraft.dropper",
+    "english_translation": "Dropper"
+  },
+  {
+    "key": "block.minecraft.note_block",
+    "english_translation": "Note Block"
+  },
+  {
+    "key": "block.minecraft.cake",
+    "english_translation": "Cake"
+  },
+  {
+    "key": "block.minecraft.bed.occupied",
+    "english_translation": "This bed is occupied"
+  },
+  {
+    "key": "block.minecraft.bed.obstructed",
+    "english_translation": "This bed is obstructed"
+  },
+  {
+    "key": "block.minecraft.bed.no_sleep",
+    "english_translation": "You can sleep only at night or during thunderstorms"
+  },
+  {
+    "key": "block.minecraft.bed.too_far_away",
+    "english_translation": "You may not rest now; the bed is too far away"
+  },
+  {
+    "key": "block.minecraft.bed.not_safe",
+    "english_translation": "You may not rest now; there are monsters nearby"
+  },
+  {
+    "key": "block.minecraft.spawn.not_valid",
+    "english_translation": "You have no home bed or charged respawn anchor, or it was obstructed"
+  },
+  {
+    "key": "block.minecraft.set_spawn",
+    "english_translation": "Respawn point set"
+  },
+  {
+    "key": "block.minecraft.oak_trapdoor",
+    "english_translation": "Oak Trapdoor"
+  },
+  {
+    "key": "block.minecraft.spruce_trapdoor",
+    "english_translation": "Spruce Trapdoor"
+  },
+  {
+    "key": "block.minecraft.birch_trapdoor",
+    "english_translation": "Birch Trapdoor"
+  },
+  {
+    "key": "block.minecraft.jungle_trapdoor",
+    "english_translation": "Jungle Trapdoor"
+  },
+  {
+    "key": "block.minecraft.acacia_trapdoor",
+    "english_translation": "Acacia Trapdoor"
+  },
+  {
+    "key": "block.minecraft.dark_oak_trapdoor",
+    "english_translation": "Dark Oak Trapdoor"
+  },
+  {
+    "key": "block.minecraft.mangrove_trapdoor",
+    "english_translation": "Mangrove Trapdoor"
+  },
+  {
+    "key": "block.minecraft.iron_trapdoor",
+    "english_translation": "Iron Trapdoor"
+  },
+  {
+    "key": "block.minecraft.cobweb",
+    "english_translation": "Cobweb"
+  },
+  {
+    "key": "block.minecraft.stone_bricks",
+    "english_translation": "Stone Bricks"
+  },
+  {
+    "key": "block.minecraft.mossy_stone_bricks",
+    "english_translation": "Mossy Stone Bricks"
+  },
+  {
+    "key": "block.minecraft.cracked_stone_bricks",
+    "english_translation": "Cracked Stone Bricks"
+  },
+  {
+    "key": "block.minecraft.chiseled_stone_bricks",
+    "english_translation": "Chiseled Stone Bricks"
+  },
+  {
+    "key": "block.minecraft.packed_mud",
+    "english_translation": "Packed Mud"
+  },
+  {
+    "key": "block.minecraft.mud_bricks",
+    "english_translation": "Mud Bricks"
+  },
+  {
+    "key": "block.minecraft.infested_stone",
+    "english_translation": "Infested Stone"
+  },
+  {
+    "key": "block.minecraft.infested_cobblestone",
+    "english_translation": "Infested Cobblestone"
+  },
+  {
+    "key": "block.minecraft.infested_stone_bricks",
+    "english_translation": "Infested Stone Bricks"
+  },
+  {
+    "key": "block.minecraft.infested_mossy_stone_bricks",
+    "english_translation": "Infested Mossy Stone Bricks"
+  },
+  {
+    "key": "block.minecraft.infested_cracked_stone_bricks",
+    "english_translation": "Infested Cracked Stone Bricks"
+  },
+  {
+    "key": "block.minecraft.infested_chiseled_stone_bricks",
+    "english_translation": "Infested Chiseled Stone Bricks"
+  },
+  {
+    "key": "block.minecraft.piston",
+    "english_translation": "Piston"
+  },
+  {
+    "key": "block.minecraft.sticky_piston",
+    "english_translation": "Sticky Piston"
+  },
+  {
+    "key": "block.minecraft.iron_bars",
+    "english_translation": "Iron Bars"
+  },
+  {
+    "key": "block.minecraft.melon",
+    "english_translation": "Melon"
+  },
+  {
+    "key": "block.minecraft.brick_stairs",
+    "english_translation": "Brick Stairs"
+  },
+  {
+    "key": "block.minecraft.stone_brick_stairs",
+    "english_translation": "Stone Brick Stairs"
+  },
+  {
+    "key": "block.minecraft.mud_brick_stairs",
+    "english_translation": "Mud Brick Stairs"
+  },
+  {
+    "key": "block.minecraft.vine",
+    "english_translation": "Vines"
+  },
+  {
+    "key": "block.minecraft.nether_bricks",
+    "english_translation": "Nether Bricks"
+  },
+  {
+    "key": "block.minecraft.nether_brick_fence",
+    "english_translation": "Nether Brick Fence"
+  },
+  {
+    "key": "block.minecraft.nether_brick_stairs",
+    "english_translation": "Nether Brick Stairs"
+  },
+  {
+    "key": "block.minecraft.nether_wart",
+    "english_translation": "Nether Wart"
+  },
+  {
+    "key": "block.minecraft.warped_wart_block",
+    "english_translation": "Warped Wart Block"
+  },
+  {
+    "key": "block.minecraft.warped_stem",
+    "english_translation": "Warped Stem"
+  },
+  {
+    "key": "block.minecraft.stripped_warped_stem",
+    "english_translation": "Stripped Warped Stem"
+  },
+  {
+    "key": "block.minecraft.warped_hyphae",
+    "english_translation": "Warped Hyphae"
+  },
+  {
+    "key": "block.minecraft.stripped_warped_hyphae",
+    "english_translation": "Stripped Warped Hyphae"
+  },
+  {
+    "key": "block.minecraft.crimson_stem",
+    "english_translation": "Crimson Stem"
+  },
+  {
+    "key": "block.minecraft.stripped_crimson_stem",
+    "english_translation": "Stripped Crimson Stem"
+  },
+  {
+    "key": "block.minecraft.crimson_hyphae",
+    "english_translation": "Crimson Hyphae"
+  },
+  {
+    "key": "block.minecraft.stripped_crimson_hyphae",
+    "english_translation": "Stripped Crimson Hyphae"
+  },
+  {
+    "key": "block.minecraft.warped_nylium",
+    "english_translation": "Warped Nylium"
+  },
+  {
+    "key": "block.minecraft.crimson_nylium",
+    "english_translation": "Crimson Nylium"
+  },
+  {
+    "key": "block.minecraft.warped_fungus",
+    "english_translation": "Warped Fungus"
+  },
+  {
+    "key": "block.minecraft.crimson_fungus",
+    "english_translation": "Crimson Fungus"
+  },
+  {
+    "key": "block.minecraft.crimson_roots",
+    "english_translation": "Crimson Roots"
+  },
+  {
+    "key": "block.minecraft.warped_roots",
+    "english_translation": "Warped Roots"
+  },
+  {
+    "key": "block.minecraft.nether_sprouts",
+    "english_translation": "Nether Sprouts"
+  },
+  {
+    "key": "block.minecraft.shroomlight",
+    "english_translation": "Shroomlight"
+  },
+  {
+    "key": "block.minecraft.weeping_vines",
+    "english_translation": "Weeping Vines"
+  },
+  {
+    "key": "block.minecraft.weeping_vines_plant",
+    "english_translation": "Weeping Vines Plant"
+  },
+  {
+    "key": "block.minecraft.twisting_vines",
+    "english_translation": "Twisting Vines"
+  },
+  {
+    "key": "block.minecraft.twisting_vines_plant",
+    "english_translation": "Twisting Vines Plant"
+  },
+  {
+    "key": "block.minecraft.soul_soil",
+    "english_translation": "Soul Soil"
+  },
+  {
+    "key": "block.minecraft.basalt",
+    "english_translation": "Basalt"
+  },
+  {
+    "key": "block.minecraft.polished_basalt",
+    "english_translation": "Polished Basalt"
+  },
+  {
+    "key": "block.minecraft.warped_planks",
+    "english_translation": "Warped Planks"
+  },
+  {
+    "key": "block.minecraft.warped_slab",
+    "english_translation": "Warped Slab"
+  },
+  {
+    "key": "block.minecraft.warped_pressure_plate",
+    "english_translation": "Warped Pressure Plate"
+  },
+  {
+    "key": "block.minecraft.warped_fence",
+    "english_translation": "Warped Fence"
+  },
+  {
+    "key": "block.minecraft.warped_trapdoor",
+    "english_translation": "Warped Trapdoor"
+  },
+  {
+    "key": "block.minecraft.warped_fence_gate",
+    "english_translation": "Warped Fence Gate"
+  },
+  {
+    "key": "block.minecraft.warped_stairs",
+    "english_translation": "Warped Stairs"
+  },
+  {
+    "key": "block.minecraft.warped_button",
+    "english_translation": "Warped Button"
+  },
+  {
+    "key": "block.minecraft.warped_door",
+    "english_translation": "Warped Door"
+  },
+  {
+    "key": "block.minecraft.warped_sign",
+    "english_translation": "Warped Sign"
+  },
+  {
+    "key": "block.minecraft.warped_wall_sign",
+    "english_translation": "Warped Wall Sign"
+  },
+  {
+    "key": "block.minecraft.crimson_planks",
+    "english_translation": "Crimson Planks"
+  },
+  {
+    "key": "block.minecraft.crimson_slab",
+    "english_translation": "Crimson Slab"
+  },
+  {
+    "key": "block.minecraft.crimson_pressure_plate",
+    "english_translation": "Crimson Pressure Plate"
+  },
+  {
+    "key": "block.minecraft.crimson_fence",
+    "english_translation": "Crimson Fence"
+  },
+  {
+    "key": "block.minecraft.crimson_trapdoor",
+    "english_translation": "Crimson Trapdoor"
+  },
+  {
+    "key": "block.minecraft.crimson_fence_gate",
+    "english_translation": "Crimson Fence Gate"
+  },
+  {
+    "key": "block.minecraft.crimson_stairs",
+    "english_translation": "Crimson Stairs"
+  },
+  {
+    "key": "block.minecraft.crimson_button",
+    "english_translation": "Crimson Button"
+  },
+  {
+    "key": "block.minecraft.crimson_door",
+    "english_translation": "Crimson Door"
+  },
+  {
+    "key": "block.minecraft.crimson_sign",
+    "english_translation": "Crimson Sign"
+  },
+  {
+    "key": "block.minecraft.crimson_wall_sign",
+    "english_translation": "Crimson Wall Sign"
+  },
+  {
+    "key": "block.minecraft.soul_fire",
+    "english_translation": "Soul Fire"
+  },
+  {
+    "key": "block.minecraft.cauldron",
+    "english_translation": "Cauldron"
+  },
+  {
+    "key": "block.minecraft.water_cauldron",
+    "english_translation": "Water Cauldron"
+  },
+  {
+    "key": "block.minecraft.lava_cauldron",
+    "english_translation": "Lava Cauldron"
+  },
+  {
+    "key": "block.minecraft.powder_snow_cauldron",
+    "english_translation": "Powder Snow Cauldron"
+  },
+  {
+    "key": "block.minecraft.enchanting_table",
+    "english_translation": "Enchanting Table"
+  },
+  {
+    "key": "block.minecraft.anvil",
+    "english_translation": "Anvil"
+  },
+  {
+    "key": "block.minecraft.chipped_anvil",
+    "english_translation": "Chipped Anvil"
+  },
+  {
+    "key": "block.minecraft.damaged_anvil",
+    "english_translation": "Damaged Anvil"
+  },
+  {
+    "key": "block.minecraft.end_stone",
+    "english_translation": "End Stone"
+  },
+  {
+    "key": "block.minecraft.end_portal_frame",
+    "english_translation": "End Portal Frame"
+  },
+  {
+    "key": "block.minecraft.mycelium",
+    "english_translation": "Mycelium"
+  },
+  {
+    "key": "block.minecraft.lily_pad",
+    "english_translation": "Lily Pad"
+  },
+  {
+    "key": "block.minecraft.dragon_egg",
+    "english_translation": "Dragon Egg"
+  },
+  {
+    "key": "block.minecraft.redstone_lamp",
+    "english_translation": "Redstone Lamp"
+  },
+  {
+    "key": "block.minecraft.cocoa",
+    "english_translation": "Cocoa"
+  },
+  {
+    "key": "block.minecraft.ender_chest",
+    "english_translation": "Ender Chest"
+  },
+  {
+    "key": "block.minecraft.emerald_ore",
+    "english_translation": "Emerald Ore"
+  },
+  {
+    "key": "block.minecraft.deepslate_emerald_ore",
+    "english_translation": "Deepslate Emerald Ore"
+  },
+  {
+    "key": "block.minecraft.emerald_block",
+    "english_translation": "Block of Emerald"
+  },
+  {
+    "key": "block.minecraft.redstone_block",
+    "english_translation": "Block of Redstone"
+  },
+  {
+    "key": "block.minecraft.tripwire",
+    "english_translation": "Tripwire"
+  },
+  {
+    "key": "block.minecraft.tripwire_hook",
+    "english_translation": "Tripwire Hook"
+  },
+  {
+    "key": "block.minecraft.command_block",
+    "english_translation": "Command Block"
+  },
+  {
+    "key": "block.minecraft.repeating_command_block",
+    "english_translation": "Repeating Command Block"
+  },
+  {
+    "key": "block.minecraft.chain_command_block",
+    "english_translation": "Chain Command Block"
+  },
+  {
+    "key": "block.minecraft.beacon",
+    "english_translation": "Beacon"
+  },
+  {
+    "key": "block.minecraft.beacon.primary",
+    "english_translation": "Primary Power"
+  },
+  {
+    "key": "block.minecraft.beacon.secondary",
+    "english_translation": "Secondary Power"
+  },
+  {
+    "key": "block.minecraft.cobblestone_wall",
+    "english_translation": "Cobblestone Wall"
+  },
+  {
+    "key": "block.minecraft.mossy_cobblestone_wall",
+    "english_translation": "Mossy Cobblestone Wall"
+  },
+  {
+    "key": "block.minecraft.carrots",
+    "english_translation": "Carrots"
+  },
+  {
+    "key": "block.minecraft.potatoes",
+    "english_translation": "Potatoes"
+  },
+  {
+    "key": "block.minecraft.daylight_detector",
+    "english_translation": "Daylight Detector"
+  },
+  {
+    "key": "block.minecraft.nether_quartz_ore",
+    "english_translation": "Nether Quartz Ore"
+  },
+  {
+    "key": "block.minecraft.hopper",
+    "english_translation": "Hopper"
+  },
+  {
+    "key": "block.minecraft.quartz_block",
+    "english_translation": "Block of Quartz"
+  },
+  {
+    "key": "block.minecraft.chiseled_quartz_block",
+    "english_translation": "Chiseled Quartz Block"
+  },
+  {
+    "key": "block.minecraft.quartz_pillar",
+    "english_translation": "Quartz Pillar"
+  },
+  {
+    "key": "block.minecraft.quartz_stairs",
+    "english_translation": "Quartz Stairs"
+  },
+  {
+    "key": "block.minecraft.slime_block",
+    "english_translation": "Slime Block"
+  },
+  {
+    "key": "block.minecraft.prismarine",
+    "english_translation": "Prismarine"
+  },
+  {
+    "key": "block.minecraft.prismarine_bricks",
+    "english_translation": "Prismarine Bricks"
+  },
+  {
+    "key": "block.minecraft.dark_prismarine",
+    "english_translation": "Dark Prismarine"
+  },
+  {
+    "key": "block.minecraft.sea_lantern",
+    "english_translation": "Sea Lantern"
+  },
+  {
+    "key": "block.minecraft.end_rod",
+    "english_translation": "End Rod"
+  },
+  {
+    "key": "block.minecraft.chorus_plant",
+    "english_translation": "Chorus Plant"
+  },
+  {
+    "key": "block.minecraft.chorus_flower",
+    "english_translation": "Chorus Flower"
+  },
+  {
+    "key": "block.minecraft.purpur_block",
+    "english_translation": "Purpur Block"
+  },
+  {
+    "key": "block.minecraft.purpur_pillar",
+    "english_translation": "Purpur Pillar"
+  },
+  {
+    "key": "block.minecraft.purpur_stairs",
+    "english_translation": "Purpur Stairs"
+  },
+  {
+    "key": "block.minecraft.purpur_slab",
+    "english_translation": "Purpur Slab"
+  },
+  {
+    "key": "block.minecraft.end_stone_bricks",
+    "english_translation": "End Stone Bricks"
+  },
+  {
+    "key": "block.minecraft.beetroots",
+    "english_translation": "Beetroots"
+  },
+  {
+    "key": "block.minecraft.dirt_path",
+    "english_translation": "Dirt Path"
+  },
+  {
+    "key": "block.minecraft.magma_block",
+    "english_translation": "Magma Block"
+  },
+  {
+    "key": "block.minecraft.nether_wart_block",
+    "english_translation": "Nether Wart Block"
+  },
+  {
+    "key": "block.minecraft.red_nether_bricks",
+    "english_translation": "Red Nether Bricks"
+  },
+  {
+    "key": "block.minecraft.bone_block",
+    "english_translation": "Bone Block"
+  },
+  {
+    "key": "block.minecraft.observer",
+    "english_translation": "Observer"
+  },
+  {
+    "key": "block.minecraft.shulker_box",
+    "english_translation": "Shulker Box"
+  },
+  {
+    "key": "block.minecraft.white_shulker_box",
+    "english_translation": "White Shulker Box"
+  },
+  {
+    "key": "block.minecraft.orange_shulker_box",
+    "english_translation": "Orange Shulker Box"
+  },
+  {
+    "key": "block.minecraft.magenta_shulker_box",
+    "english_translation": "Magenta Shulker Box"
+  },
+  {
+    "key": "block.minecraft.light_blue_shulker_box",
+    "english_translation": "Light Blue Shulker Box"
+  },
+  {
+    "key": "block.minecraft.yellow_shulker_box",
+    "english_translation": "Yellow Shulker Box"
+  },
+  {
+    "key": "block.minecraft.lime_shulker_box",
+    "english_translation": "Lime Shulker Box"
+  },
+  {
+    "key": "block.minecraft.pink_shulker_box",
+    "english_translation": "Pink Shulker Box"
+  },
+  {
+    "key": "block.minecraft.gray_shulker_box",
+    "english_translation": "Gray Shulker Box"
+  },
+  {
+    "key": "block.minecraft.light_gray_shulker_box",
+    "english_translation": "Light Gray Shulker Box"
+  },
+  {
+    "key": "block.minecraft.cyan_shulker_box",
+    "english_translation": "Cyan Shulker Box"
+  },
+  {
+    "key": "block.minecraft.purple_shulker_box",
+    "english_translation": "Purple Shulker Box"
+  },
+  {
+    "key": "block.minecraft.blue_shulker_box",
+    "english_translation": "Blue Shulker Box"
+  },
+  {
+    "key": "block.minecraft.brown_shulker_box",
+    "english_translation": "Brown Shulker Box"
+  },
+  {
+    "key": "block.minecraft.green_shulker_box",
+    "english_translation": "Green Shulker Box"
+  },
+  {
+    "key": "block.minecraft.red_shulker_box",
+    "english_translation": "Red Shulker Box"
+  },
+  {
+    "key": "block.minecraft.black_shulker_box",
+    "english_translation": "Black Shulker Box"
+  },
+  {
+    "key": "block.minecraft.white_glazed_terracotta",
+    "english_translation": "White Glazed Terracotta"
+  },
+  {
+    "key": "block.minecraft.orange_glazed_terracotta",
+    "english_translation": "Orange Glazed Terracotta"
+  },
+  {
+    "key": "block.minecraft.magenta_glazed_terracotta",
+    "english_translation": "Magenta Glazed Terracotta"
+  },
+  {
+    "key": "block.minecraft.light_blue_glazed_terracotta",
+    "english_translation": "Light Blue Glazed Terracotta"
+  },
+  {
+    "key": "block.minecraft.yellow_glazed_terracotta",
+    "english_translation": "Yellow Glazed Terracotta"
+  },
+  {
+    "key": "block.minecraft.lime_glazed_terracotta",
+    "english_translation": "Lime Glazed Terracotta"
+  },
+  {
+    "key": "block.minecraft.pink_glazed_terracotta",
+    "english_translation": "Pink Glazed Terracotta"
+  },
+  {
+    "key": "block.minecraft.gray_glazed_terracotta",
+    "english_translation": "Gray Glazed Terracotta"
+  },
+  {
+    "key": "block.minecraft.light_gray_glazed_terracotta",
+    "english_translation": "Light Gray Glazed Terracotta"
+  },
+  {
+    "key": "block.minecraft.cyan_glazed_terracotta",
+    "english_translation": "Cyan Glazed Terracotta"
+  },
+  {
+    "key": "block.minecraft.purple_glazed_terracotta",
+    "english_translation": "Purple Glazed Terracotta"
+  },
+  {
+    "key": "block.minecraft.blue_glazed_terracotta",
+    "english_translation": "Blue Glazed Terracotta"
+  },
+  {
+    "key": "block.minecraft.brown_glazed_terracotta",
+    "english_translation": "Brown Glazed Terracotta"
+  },
+  {
+    "key": "block.minecraft.green_glazed_terracotta",
+    "english_translation": "Green Glazed Terracotta"
+  },
+  {
+    "key": "block.minecraft.red_glazed_terracotta",
+    "english_translation": "Red Glazed Terracotta"
+  },
+  {
+    "key": "block.minecraft.black_glazed_terracotta",
+    "english_translation": "Black Glazed Terracotta"
+  },
+  {
+    "key": "block.minecraft.black_concrete",
+    "english_translation": "Black Concrete"
+  },
+  {
+    "key": "block.minecraft.red_concrete",
+    "english_translation": "Red Concrete"
+  },
+  {
+    "key": "block.minecraft.green_concrete",
+    "english_translation": "Green Concrete"
+  },
+  {
+    "key": "block.minecraft.brown_concrete",
+    "english_translation": "Brown Concrete"
+  },
+  {
+    "key": "block.minecraft.blue_concrete",
+    "english_translation": "Blue Concrete"
+  },
+  {
+    "key": "block.minecraft.purple_concrete",
+    "english_translation": "Purple Concrete"
+  },
+  {
+    "key": "block.minecraft.cyan_concrete",
+    "english_translation": "Cyan Concrete"
+  },
+  {
+    "key": "block.minecraft.light_gray_concrete",
+    "english_translation": "Light Gray Concrete"
+  },
+  {
+    "key": "block.minecraft.gray_concrete",
+    "english_translation": "Gray Concrete"
+  },
+  {
+    "key": "block.minecraft.pink_concrete",
+    "english_translation": "Pink Concrete"
+  },
+  {
+    "key": "block.minecraft.lime_concrete",
+    "english_translation": "Lime Concrete"
+  },
+  {
+    "key": "block.minecraft.yellow_concrete",
+    "english_translation": "Yellow Concrete"
+  },
+  {
+    "key": "block.minecraft.light_blue_concrete",
+    "english_translation": "Light Blue Concrete"
+  },
+  {
+    "key": "block.minecraft.magenta_concrete",
+    "english_translation": "Magenta Concrete"
+  },
+  {
+    "key": "block.minecraft.orange_concrete",
+    "english_translation": "Orange Concrete"
+  },
+  {
+    "key": "block.minecraft.white_concrete",
+    "english_translation": "White Concrete"
+  },
+  {
+    "key": "block.minecraft.black_concrete_powder",
+    "english_translation": "Black Concrete Powder"
+  },
+  {
+    "key": "block.minecraft.red_concrete_powder",
+    "english_translation": "Red Concrete Powder"
+  },
+  {
+    "key": "block.minecraft.green_concrete_powder",
+    "english_translation": "Green Concrete Powder"
+  },
+  {
+    "key": "block.minecraft.brown_concrete_powder",
+    "english_translation": "Brown Concrete Powder"
+  },
+  {
+    "key": "block.minecraft.blue_concrete_powder",
+    "english_translation": "Blue Concrete Powder"
+  },
+  {
+    "key": "block.minecraft.purple_concrete_powder",
+    "english_translation": "Purple Concrete Powder"
+  },
+  {
+    "key": "block.minecraft.cyan_concrete_powder",
+    "english_translation": "Cyan Concrete Powder"
+  },
+  {
+    "key": "block.minecraft.light_gray_concrete_powder",
+    "english_translation": "Light Gray Concrete Powder"
+  },
+  {
+    "key": "block.minecraft.gray_concrete_powder",
+    "english_translation": "Gray Concrete Powder"
+  },
+  {
+    "key": "block.minecraft.pink_concrete_powder",
+    "english_translation": "Pink Concrete Powder"
+  },
+  {
+    "key": "block.minecraft.lime_concrete_powder",
+    "english_translation": "Lime Concrete Powder"
+  },
+  {
+    "key": "block.minecraft.yellow_concrete_powder",
+    "english_translation": "Yellow Concrete Powder"
+  },
+  {
+    "key": "block.minecraft.light_blue_concrete_powder",
+    "english_translation": "Light Blue Concrete Powder"
+  },
+  {
+    "key": "block.minecraft.magenta_concrete_powder",
+    "english_translation": "Magenta Concrete Powder"
+  },
+  {
+    "key": "block.minecraft.orange_concrete_powder",
+    "english_translation": "Orange Concrete Powder"
+  },
+  {
+    "key": "block.minecraft.white_concrete_powder",
+    "english_translation": "White Concrete Powder"
+  },
+  {
+    "key": "block.minecraft.turtle_egg",
+    "english_translation": "Turtle Egg"
+  },
+  {
+    "key": "block.minecraft.piston_head",
+    "english_translation": "Piston Head"
+  },
+  {
+    "key": "block.minecraft.moving_piston",
+    "english_translation": "Moving Piston"
+  },
+  {
+    "key": "block.minecraft.red_mushroom",
+    "english_translation": "Red Mushroom"
+  },
+  {
+    "key": "block.minecraft.snow_block",
+    "english_translation": "Snow Block"
+  },
+  {
+    "key": "block.minecraft.attached_melon_stem",
+    "english_translation": "Attached Melon Stem"
+  },
+  {
+    "key": "block.minecraft.melon_stem",
+    "english_translation": "Melon Stem"
+  },
+  {
+    "key": "block.minecraft.brewing_stand",
+    "english_translation": "Brewing Stand"
+  },
+  {
+    "key": "block.minecraft.end_portal",
+    "english_translation": "End Portal"
+  },
+  {
+    "key": "block.minecraft.flower_pot",
+    "english_translation": "Flower Pot"
+  },
+  {
+    "key": "block.minecraft.potted_oak_sapling",
+    "english_translation": "Potted Oak Sapling"
+  },
+  {
+    "key": "block.minecraft.potted_spruce_sapling",
+    "english_translation": "Potted Spruce Sapling"
+  },
+  {
+    "key": "block.minecraft.potted_birch_sapling",
+    "english_translation": "Potted Birch Sapling"
+  },
+  {
+    "key": "block.minecraft.potted_jungle_sapling",
+    "english_translation": "Potted Jungle Sapling"
+  },
+  {
+    "key": "block.minecraft.potted_acacia_sapling",
+    "english_translation": "Potted Acacia Sapling"
+  },
+  {
+    "key": "block.minecraft.potted_dark_oak_sapling",
+    "english_translation": "Potted Dark Oak Sapling"
+  },
+  {
+    "key": "block.minecraft.potted_mangrove_propagule",
+    "english_translation": "Potted Mangrove Propagule"
+  },
+  {
+    "key": "block.minecraft.potted_fern",
+    "english_translation": "Potted Fern"
+  },
+  {
+    "key": "block.minecraft.potted_dandelion",
+    "english_translation": "Potted Dandelion"
+  },
+  {
+    "key": "block.minecraft.potted_poppy",
+    "english_translation": "Potted Poppy"
+  },
+  {
+    "key": "block.minecraft.potted_blue_orchid",
+    "english_translation": "Potted Blue Orchid"
+  },
+  {
+    "key": "block.minecraft.potted_allium",
+    "english_translation": "Potted Allium"
+  },
+  {
+    "key": "block.minecraft.potted_azure_bluet",
+    "english_translation": "Potted Azure Bluet"
+  },
+  {
+    "key": "block.minecraft.potted_red_tulip",
+    "english_translation": "Potted Red Tulip"
+  },
+  {
+    "key": "block.minecraft.potted_orange_tulip",
+    "english_translation": "Potted Orange Tulip"
+  },
+  {
+    "key": "block.minecraft.potted_white_tulip",
+    "english_translation": "Potted White Tulip"
+  },
+  {
+    "key": "block.minecraft.potted_pink_tulip",
+    "english_translation": "Potted Pink Tulip"
+  },
+  {
+    "key": "block.minecraft.potted_oxeye_daisy",
+    "english_translation": "Potted Oxeye Daisy"
+  },
+  {
+    "key": "block.minecraft.potted_cornflower",
+    "english_translation": "Potted Cornflower"
+  },
+  {
+    "key": "block.minecraft.potted_lily_of_the_valley",
+    "english_translation": "Potted Lily of the Valley"
+  },
+  {
+    "key": "block.minecraft.potted_wither_rose",
+    "english_translation": "Potted Wither Rose"
+  },
+  {
+    "key": "block.minecraft.potted_red_mushroom",
+    "english_translation": "Potted Red Mushroom"
+  },
+  {
+    "key": "block.minecraft.potted_brown_mushroom",
+    "english_translation": "Potted Brown Mushroom"
+  },
+  {
+    "key": "block.minecraft.potted_dead_bush",
+    "english_translation": "Potted Dead Bush"
+  },
+  {
+    "key": "block.minecraft.potted_cactus",
+    "english_translation": "Potted Cactus"
+  },
+  {
+    "key": "block.minecraft.potted_bamboo",
+    "english_translation": "Potted Bamboo"
+  },
+  {
+    "key": "block.minecraft.potted_crimson_fungus",
+    "english_translation": "Potted Crimson Fungus"
+  },
+  {
+    "key": "block.minecraft.potted_warped_fungus",
+    "english_translation": "Potted Warped Fungus"
+  },
+  {
+    "key": "block.minecraft.potted_crimson_roots",
+    "english_translation": "Potted Crimson Roots"
+  },
+  {
+    "key": "block.minecraft.potted_warped_roots",
+    "english_translation": "Potted Warped Roots"
+  },
+  {
+    "key": "block.minecraft.potted_azalea_bush",
+    "english_translation": "Potted Azalea"
+  },
+  {
+    "key": "block.minecraft.potted_flowering_azalea_bush",
+    "english_translation": "Potted Flowering Azalea"
+  },
+  {
+    "key": "block.minecraft.skeleton_wall_skull",
+    "english_translation": "Skeleton Wall Skull"
+  },
+  {
+    "key": "block.minecraft.skeleton_skull",
+    "english_translation": "Skeleton Skull"
+  },
+  {
+    "key": "block.minecraft.wither_skeleton_wall_skull",
+    "english_translation": "Wither Skeleton Wall Skull"
+  },
+  {
+    "key": "block.minecraft.wither_skeleton_skull",
+    "english_translation": "Wither Skeleton Skull"
+  },
+  {
+    "key": "block.minecraft.zombie_wall_head",
+    "english_translation": "Zombie Wall Head"
+  },
+  {
+    "key": "block.minecraft.zombie_head",
+    "english_translation": "Zombie Head"
+  },
+  {
+    "key": "block.minecraft.player_wall_head",
+    "english_translation": "Player Wall Head"
+  },
+  {
+    "key": "block.minecraft.player_head",
+    "english_translation": "Player Head"
+  },
+  {
+    "key": "block.minecraft.player_head.named",
+    "english_translation": "%s's Head"
+  },
+  {
+    "key": "block.minecraft.creeper_wall_head",
+    "english_translation": "Creeper Wall Head"
+  },
+  {
+    "key": "block.minecraft.creeper_head",
+    "english_translation": "Creeper Head"
+  },
+  {
+    "key": "block.minecraft.dragon_wall_head",
+    "english_translation": "Dragon Wall Head"
+  },
+  {
+    "key": "block.minecraft.dragon_head",
+    "english_translation": "Dragon Head"
+  },
+  {
+    "key": "block.minecraft.end_gateway",
+    "english_translation": "End Gateway"
+  },
+  {
+    "key": "block.minecraft.structure_void",
+    "english_translation": "Structure Void"
+  },
+  {
+    "key": "block.minecraft.structure_block",
+    "english_translation": "Structure Block"
+  },
+  {
+    "key": "block.minecraft.void_air",
+    "english_translation": "Void Air"
+  },
+  {
+    "key": "block.minecraft.cave_air",
+    "english_translation": "Cave Air"
+  },
+  {
+    "key": "block.minecraft.bubble_column",
+    "english_translation": "Bubble Column"
+  },
+  {
+    "key": "block.minecraft.dead_tube_coral_block",
+    "english_translation": "Dead Tube Coral Block"
+  },
+  {
+    "key": "block.minecraft.dead_brain_coral_block",
+    "english_translation": "Dead Brain Coral Block"
+  },
+  {
+    "key": "block.minecraft.dead_bubble_coral_block",
+    "english_translation": "Dead Bubble Coral Block"
+  },
+  {
+    "key": "block.minecraft.dead_fire_coral_block",
+    "english_translation": "Dead Fire Coral Block"
+  },
+  {
+    "key": "block.minecraft.dead_horn_coral_block",
+    "english_translation": "Dead Horn Coral Block"
+  },
+  {
+    "key": "block.minecraft.tube_coral_block",
+    "english_translation": "Tube Coral Block"
+  },
+  {
+    "key": "block.minecraft.brain_coral_block",
+    "english_translation": "Brain Coral Block"
+  },
+  {
+    "key": "block.minecraft.bubble_coral_block",
+    "english_translation": "Bubble Coral Block"
+  },
+  {
+    "key": "block.minecraft.fire_coral_block",
+    "english_translation": "Fire Coral Block"
+  },
+  {
+    "key": "block.minecraft.horn_coral_block",
+    "english_translation": "Horn Coral Block"
+  },
+  {
+    "key": "block.minecraft.tube_coral",
+    "english_translation": "Tube Coral"
+  },
+  {
+    "key": "block.minecraft.brain_coral",
+    "english_translation": "Brain Coral"
+  },
+  {
+    "key": "block.minecraft.bubble_coral",
+    "english_translation": "Bubble Coral"
+  },
+  {
+    "key": "block.minecraft.fire_coral",
+    "english_translation": "Fire Coral"
+  },
+  {
+    "key": "block.minecraft.horn_coral",
+    "english_translation": "Horn Coral"
+  },
+  {
+    "key": "block.minecraft.dead_tube_coral",
+    "english_translation": "Dead Tube Coral"
+  },
+  {
+    "key": "block.minecraft.dead_brain_coral",
+    "english_translation": "Dead Brain Coral"
+  },
+  {
+    "key": "block.minecraft.dead_bubble_coral",
+    "english_translation": "Dead Bubble Coral"
+  },
+  {
+    "key": "block.minecraft.dead_fire_coral",
+    "english_translation": "Dead Fire Coral"
+  },
+  {
+    "key": "block.minecraft.dead_horn_coral",
+    "english_translation": "Dead Horn Coral"
+  },
+  {
+    "key": "block.minecraft.tube_coral_fan",
+    "english_translation": "Tube Coral Fan"
+  },
+  {
+    "key": "block.minecraft.brain_coral_fan",
+    "english_translation": "Brain Coral Fan"
+  },
+  {
+    "key": "block.minecraft.bubble_coral_fan",
+    "english_translation": "Bubble Coral Fan"
+  },
+  {
+    "key": "block.minecraft.fire_coral_fan",
+    "english_translation": "Fire Coral Fan"
+  },
+  {
+    "key": "block.minecraft.horn_coral_fan",
+    "english_translation": "Horn Coral Fan"
+  },
+  {
+    "key": "block.minecraft.dead_tube_coral_fan",
+    "english_translation": "Dead Tube Coral Fan"
+  },
+  {
+    "key": "block.minecraft.dead_brain_coral_fan",
+    "english_translation": "Dead Brain Coral Fan"
+  },
+  {
+    "key": "block.minecraft.dead_bubble_coral_fan",
+    "english_translation": "Dead Bubble Coral Fan"
+  },
+  {
+    "key": "block.minecraft.dead_fire_coral_fan",
+    "english_translation": "Dead Fire Coral Fan"
+  },
+  {
+    "key": "block.minecraft.dead_horn_coral_fan",
+    "english_translation": "Dead Horn Coral Fan"
+  },
+  {
+    "key": "block.minecraft.tube_coral_wall_fan",
+    "english_translation": "Tube Coral Wall Fan"
+  },
+  {
+    "key": "block.minecraft.brain_coral_wall_fan",
+    "english_translation": "Brain Coral Wall Fan"
+  },
+  {
+    "key": "block.minecraft.bubble_coral_wall_fan",
+    "english_translation": "Bubble Coral Wall Fan"
+  },
+  {
+    "key": "block.minecraft.fire_coral_wall_fan",
+    "english_translation": "Fire Coral Wall Fan"
+  },
+  {
+    "key": "block.minecraft.horn_coral_wall_fan",
+    "english_translation": "Horn Coral Wall Fan"
+  },
+  {
+    "key": "block.minecraft.dead_tube_coral_wall_fan",
+    "english_translation": "Dead Tube Coral Wall Fan"
+  },
+  {
+    "key": "block.minecraft.dead_brain_coral_wall_fan",
+    "english_translation": "Dead Brain Coral Wall Fan"
+  },
+  {
+    "key": "block.minecraft.dead_bubble_coral_wall_fan",
+    "english_translation": "Dead Bubble Coral Wall Fan"
+  },
+  {
+    "key": "block.minecraft.dead_fire_coral_wall_fan",
+    "english_translation": "Dead Fire Coral Wall Fan"
+  },
+  {
+    "key": "block.minecraft.dead_horn_coral_wall_fan",
+    "english_translation": "Dead Horn Coral Wall Fan"
+  },
+  {
+    "key": "block.minecraft.loom",
+    "english_translation": "Loom"
+  },
+  {
+    "key": "block.minecraft.conduit",
+    "english_translation": "Conduit"
+  },
+  {
+    "key": "block.minecraft.bamboo",
+    "english_translation": "Bamboo"
+  },
+  {
+    "key": "block.minecraft.bamboo_sapling",
+    "english_translation": "Bamboo Shoot"
+  },
+  {
+    "key": "block.minecraft.jigsaw",
+    "english_translation": "Jigsaw Block"
+  },
+  {
+    "key": "block.minecraft.composter",
+    "english_translation": "Composter"
+  },
+  {
+    "key": "block.minecraft.target",
+    "english_translation": "Target"
+  },
+  {
+    "key": "block.minecraft.polished_granite_stairs",
+    "english_translation": "Polished Granite Stairs"
+  },
+  {
+    "key": "block.minecraft.smooth_red_sandstone_stairs",
+    "english_translation": "Smooth Red Sandstone Stairs"
+  },
+  {
+    "key": "block.minecraft.mossy_stone_brick_stairs",
+    "english_translation": "Mossy Stone Brick Stairs"
+  },
+  {
+    "key": "block.minecraft.polished_diorite_stairs",
+    "english_translation": "Polished Diorite Stairs"
+  },
+  {
+    "key": "block.minecraft.mossy_cobblestone_stairs",
+    "english_translation": "Mossy Cobblestone Stairs"
+  },
+  {
+    "key": "block.minecraft.end_stone_brick_stairs",
+    "english_translation": "End Stone Brick Stairs"
+  },
+  {
+    "key": "block.minecraft.stone_stairs",
+    "english_translation": "Stone Stairs"
+  },
+  {
+    "key": "block.minecraft.smooth_sandstone_stairs",
+    "english_translation": "Smooth Sandstone Stairs"
+  },
+  {
+    "key": "block.minecraft.smooth_quartz_stairs",
+    "english_translation": "Smooth Quartz Stairs"
+  },
+  {
+    "key": "block.minecraft.granite_stairs",
+    "english_translation": "Granite Stairs"
+  },
+  {
+    "key": "block.minecraft.andesite_stairs",
+    "english_translation": "Andesite Stairs"
+  },
+  {
+    "key": "block.minecraft.red_nether_brick_stairs",
+    "english_translation": "Red Nether Brick Stairs"
+  },
+  {
+    "key": "block.minecraft.polished_andesite_stairs",
+    "english_translation": "Polished Andesite Stairs"
+  },
+  {
+    "key": "block.minecraft.diorite_stairs",
+    "english_translation": "Diorite Stairs"
+  },
+  {
+    "key": "block.minecraft.polished_granite_slab",
+    "english_translation": "Polished Granite Slab"
+  },
+  {
+    "key": "block.minecraft.smooth_red_sandstone_slab",
+    "english_translation": "Smooth Red Sandstone Slab"
+  },
+  {
+    "key": "block.minecraft.mossy_stone_brick_slab",
+    "english_translation": "Mossy Stone Brick Slab"
+  },
+  {
+    "key": "block.minecraft.polished_diorite_slab",
+    "english_translation": "Polished Diorite Slab"
+  },
+  {
+    "key": "block.minecraft.mossy_cobblestone_slab",
+    "english_translation": "Mossy Cobblestone Slab"
+  },
+  {
+    "key": "block.minecraft.end_stone_brick_slab",
+    "english_translation": "End Stone Brick Slab"
+  },
+  {
+    "key": "block.minecraft.smooth_sandstone_slab",
+    "english_translation": "Smooth Sandstone Slab"
+  },
+  {
+    "key": "block.minecraft.smooth_quartz_slab",
+    "english_translation": "Smooth Quartz Slab"
+  },
+  {
+    "key": "block.minecraft.granite_slab",
+    "english_translation": "Granite Slab"
+  },
+  {
+    "key": "block.minecraft.andesite_slab",
+    "english_translation": "Andesite Slab"
+  },
+  {
+    "key": "block.minecraft.red_nether_brick_slab",
+    "english_translation": "Red Nether Brick Slab"
+  },
+  {
+    "key": "block.minecraft.polished_andesite_slab",
+    "english_translation": "Polished Andesite Slab"
+  },
+  {
+    "key": "block.minecraft.diorite_slab",
+    "english_translation": "Diorite Slab"
+  },
+  {
+    "key": "block.minecraft.brick_wall",
+    "english_translation": "Brick Wall"
+  },
+  {
+    "key": "block.minecraft.prismarine_wall",
+    "english_translation": "Prismarine Wall"
+  },
+  {
+    "key": "block.minecraft.red_sandstone_wall",
+    "english_translation": "Red Sandstone Wall"
+  },
+  {
+    "key": "block.minecraft.mossy_stone_brick_wall",
+    "english_translation": "Mossy Stone Brick Wall"
+  },
+  {
+    "key": "block.minecraft.granite_wall",
+    "english_translation": "Granite Wall"
+  },
+  {
+    "key": "block.minecraft.stone_brick_wall",
+    "english_translation": "Stone Brick Wall"
+  },
+  {
+    "key": "block.minecraft.mud_brick_wall",
+    "english_translation": "Mud Brick Wall"
+  },
+  {
+    "key": "block.minecraft.nether_brick_wall",
+    "english_translation": "Nether Brick Wall"
+  },
+  {
+    "key": "block.minecraft.andesite_wall",
+    "english_translation": "Andesite Wall"
+  },
+  {
+    "key": "block.minecraft.red_nether_brick_wall",
+    "english_translation": "Red Nether Brick Wall"
+  },
+  {
+    "key": "block.minecraft.sandstone_wall",
+    "english_translation": "Sandstone Wall"
+  },
+  {
+    "key": "block.minecraft.end_stone_brick_wall",
+    "english_translation": "End Stone Brick Wall"
+  },
+  {
+    "key": "block.minecraft.diorite_wall",
+    "english_translation": "Diorite Wall"
+  },
+  {
+    "key": "block.minecraft.barrel",
+    "english_translation": "Barrel"
+  },
+  {
+    "key": "block.minecraft.smoker",
+    "english_translation": "Smoker"
+  },
+  {
+    "key": "block.minecraft.blast_furnace",
+    "english_translation": "Blast Furnace"
+  },
+  {
+    "key": "block.minecraft.cartography_table",
+    "english_translation": "Cartography Table"
+  },
+  {
+    "key": "block.minecraft.fletching_table",
+    "english_translation": "Fletching Table"
+  },
+  {
+    "key": "block.minecraft.smithing_table",
+    "english_translation": "Smithing Table"
+  },
+  {
+    "key": "block.minecraft.grindstone",
+    "english_translation": "Grindstone"
+  },
+  {
+    "key": "block.minecraft.lectern",
+    "english_translation": "Lectern"
+  },
+  {
+    "key": "block.minecraft.stonecutter",
+    "english_translation": "Stonecutter"
+  },
+  {
+    "key": "block.minecraft.bell",
+    "english_translation": "Bell"
+  },
+  {
+    "key": "block.minecraft.ominous_banner",
+    "english_translation": "Ominous Banner"
+  },
+  {
+    "key": "block.minecraft.lantern",
+    "english_translation": "Lantern"
+  },
+  {
+    "key": "block.minecraft.soul_lantern",
+    "english_translation": "Soul Lantern"
+  },
+  {
+    "key": "block.minecraft.sweet_berry_bush",
+    "english_translation": "Sweet Berry Bush"
+  },
+  {
+    "key": "block.minecraft.campfire",
+    "english_translation": "Campfire"
+  },
+  {
+    "key": "block.minecraft.soul_campfire",
+    "english_translation": "Soul Campfire"
+  },
+  {
+    "key": "block.minecraft.beehive",
+    "english_translation": "Beehive"
+  },
+  {
+    "key": "block.minecraft.bee_nest",
+    "english_translation": "Bee Nest"
+  },
+  {
+    "key": "block.minecraft.honey_block",
+    "english_translation": "Honey Block"
+  },
+  {
+    "key": "block.minecraft.honeycomb_block",
+    "english_translation": "Honeycomb Block"
+  },
+  {
+    "key": "block.minecraft.lodestone",
+    "english_translation": "Lodestone"
+  },
+  {
+    "key": "block.minecraft.netherite_block",
+    "english_translation": "Block of Netherite"
+  },
+  {
+    "key": "block.minecraft.ancient_debris",
+    "english_translation": "Ancient Debris"
+  },
+  {
+    "key": "block.minecraft.crying_obsidian",
+    "english_translation": "Crying Obsidian"
+  },
+  {
+    "key": "block.minecraft.blackstone",
+    "english_translation": "Blackstone"
+  },
+  {
+    "key": "block.minecraft.blackstone_slab",
+    "english_translation": "Blackstone Slab"
+  },
+  {
+    "key": "block.minecraft.blackstone_stairs",
+    "english_translation": "Blackstone Stairs"
+  },
+  {
+    "key": "block.minecraft.blackstone_wall",
+    "english_translation": "Blackstone Wall"
+  },
+  {
+    "key": "block.minecraft.polished_blackstone_bricks",
+    "english_translation": "Polished Blackstone Bricks"
+  },
+  {
+    "key": "block.minecraft.polished_blackstone_brick_slab",
+    "english_translation": "Polished Blackstone Brick Slab"
+  },
+  {
+    "key": "block.minecraft.polished_blackstone_brick_stairs",
+    "english_translation": "Polished Blackstone Brick Stairs"
+  },
+  {
+    "key": "block.minecraft.polished_blackstone_brick_wall",
+    "english_translation": "Polished Blackstone Brick Wall"
+  },
+  {
+    "key": "block.minecraft.chiseled_polished_blackstone",
+    "english_translation": "Chiseled Polished Blackstone"
+  },
+  {
+    "key": "block.minecraft.cracked_polished_blackstone_bricks",
+    "english_translation": "Cracked Polished Blackstone Bricks"
+  },
+  {
+    "key": "block.minecraft.gilded_blackstone",
+    "english_translation": "Gilded Blackstone"
+  },
+  {
+    "key": "block.minecraft.polished_blackstone",
+    "english_translation": "Polished Blackstone"
+  },
+  {
+    "key": "block.minecraft.polished_blackstone_wall",
+    "english_translation": "Polished Blackstone Wall"
+  },
+  {
+    "key": "block.minecraft.polished_blackstone_slab",
+    "english_translation": "Polished Blackstone Slab"
+  },
+  {
+    "key": "block.minecraft.polished_blackstone_stairs",
+    "english_translation": "Polished Blackstone Stairs"
+  },
+  {
+    "key": "block.minecraft.polished_blackstone_pressure_plate",
+    "english_translation": "Polished Blackstone Pressure Plate"
+  },
+  {
+    "key": "block.minecraft.polished_blackstone_button",
+    "english_translation": "Polished Blackstone Button"
+  },
+  {
+    "key": "block.minecraft.cracked_nether_bricks",
+    "english_translation": "Cracked Nether Bricks"
+  },
+  {
+    "key": "block.minecraft.chiseled_nether_bricks",
+    "english_translation": "Chiseled Nether Bricks"
+  },
+  {
+    "key": "block.minecraft.quartz_bricks",
+    "english_translation": "Quartz Bricks"
+  },
+  {
+    "key": "block.minecraft.chain",
+    "english_translation": "Chain"
+  },
+  {
+    "key": "block.minecraft.candle",
+    "english_translation": "Candle"
+  },
+  {
+    "key": "block.minecraft.white_candle",
+    "english_translation": "White Candle"
+  },
+  {
+    "key": "block.minecraft.orange_candle",
+    "english_translation": "Orange Candle"
+  },
+  {
+    "key": "block.minecraft.magenta_candle",
+    "english_translation": "Magenta Candle"
+  },
+  {
+    "key": "block.minecraft.light_blue_candle",
+    "english_translation": "Light Blue Candle"
+  },
+  {
+    "key": "block.minecraft.yellow_candle",
+    "english_translation": "Yellow Candle"
+  },
+  {
+    "key": "block.minecraft.lime_candle",
+    "english_translation": "Lime Candle"
+  },
+  {
+    "key": "block.minecraft.pink_candle",
+    "english_translation": "Pink Candle"
+  },
+  {
+    "key": "block.minecraft.gray_candle",
+    "english_translation": "Gray Candle"
+  },
+  {
+    "key": "block.minecraft.light_gray_candle",
+    "english_translation": "Light Gray Candle"
+  },
+  {
+    "key": "block.minecraft.cyan_candle",
+    "english_translation": "Cyan Candle"
+  },
+  {
+    "key": "block.minecraft.purple_candle",
+    "english_translation": "Purple Candle"
+  },
+  {
+    "key": "block.minecraft.blue_candle",
+    "english_translation": "Blue Candle"
+  },
+  {
+    "key": "block.minecraft.brown_candle",
+    "english_translation": "Brown Candle"
+  },
+  {
+    "key": "block.minecraft.green_candle",
+    "english_translation": "Green Candle"
+  },
+  {
+    "key": "block.minecraft.red_candle",
+    "english_translation": "Red Candle"
+  },
+  {
+    "key": "block.minecraft.black_candle",
+    "english_translation": "Black Candle"
+  },
+  {
+    "key": "block.minecraft.candle_cake",
+    "english_translation": "Cake with Candle"
+  },
+  {
+    "key": "block.minecraft.white_candle_cake",
+    "english_translation": "Cake with White Candle"
+  },
+  {
+    "key": "block.minecraft.orange_candle_cake",
+    "english_translation": "Cake with Orange Candle"
+  },
+  {
+    "key": "block.minecraft.magenta_candle_cake",
+    "english_translation": "Cake with Magenta Candle"
+  },
+  {
+    "key": "block.minecraft.light_blue_candle_cake",
+    "english_translation": "Cake with Light Blue Candle"
+  },
+  {
+    "key": "block.minecraft.yellow_candle_cake",
+    "english_translation": "Cake with Yellow Candle"
+  },
+  {
+    "key": "block.minecraft.lime_candle_cake",
+    "english_translation": "Cake with Lime Candle"
+  },
+  {
+    "key": "block.minecraft.pink_candle_cake",
+    "english_translation": "Cake with Pink Candle"
+  },
+  {
+    "key": "block.minecraft.gray_candle_cake",
+    "english_translation": "Cake with Gray Candle"
+  },
+  {
+    "key": "block.minecraft.light_gray_candle_cake",
+    "english_translation": "Cake with Light Gray Candle"
+  },
+  {
+    "key": "block.minecraft.cyan_candle_cake",
+    "english_translation": "Cake with Cyan Candle"
+  },
+  {
+    "key": "block.minecraft.purple_candle_cake",
+    "english_translation": "Cake with Purple Candle"
+  },
+  {
+    "key": "block.minecraft.blue_candle_cake",
+    "english_translation": "Cake with Blue Candle"
+  },
+  {
+    "key": "block.minecraft.brown_candle_cake",
+    "english_translation": "Cake with Brown Candle"
+  },
+  {
+    "key": "block.minecraft.green_candle_cake",
+    "english_translation": "Cake with Green Candle"
+  },
+  {
+    "key": "block.minecraft.red_candle_cake",
+    "english_translation": "Cake with Red Candle"
+  },
+  {
+    "key": "block.minecraft.black_candle_cake",
+    "english_translation": "Cake with Black Candle"
+  },
+  {
+    "key": "block.minecraft.amethyst_block",
+    "english_translation": "Block of Amethyst"
+  },
+  {
+    "key": "block.minecraft.small_amethyst_bud",
+    "english_translation": "Small Amethyst Bud"
+  },
+  {
+    "key": "block.minecraft.medium_amethyst_bud",
+    "english_translation": "Medium Amethyst Bud"
+  },
+  {
+    "key": "block.minecraft.large_amethyst_bud",
+    "english_translation": "Large Amethyst Bud"
+  },
+  {
+    "key": "block.minecraft.amethyst_cluster",
+    "english_translation": "Amethyst Cluster"
+  },
+  {
+    "key": "block.minecraft.budding_amethyst",
+    "english_translation": "Budding Amethyst"
+  },
+  {
+    "key": "block.minecraft.calcite",
+    "english_translation": "Calcite"
+  },
+  {
+    "key": "block.minecraft.tuff",
+    "english_translation": "Tuff"
+  },
+  {
+    "key": "block.minecraft.tinted_glass",
+    "english_translation": "Tinted Glass"
+  },
+  {
+    "key": "block.minecraft.dripstone_block",
+    "english_translation": "Dripstone Block"
+  },
+  {
+    "key": "block.minecraft.pointed_dripstone",
+    "english_translation": "Pointed Dripstone"
+  },
+  {
+    "key": "block.minecraft.copper_ore",
+    "english_translation": "Copper Ore"
+  },
+  {
+    "key": "block.minecraft.deepslate_copper_ore",
+    "english_translation": "Deepslate Copper Ore"
+  },
+  {
+    "key": "block.minecraft.copper_block",
+    "english_translation": "Block of Copper"
+  },
+  {
+    "key": "block.minecraft.exposed_copper",
+    "english_translation": "Exposed Copper"
+  },
+  {
+    "key": "block.minecraft.weathered_copper",
+    "english_translation": "Weathered Copper"
+  },
+  {
+    "key": "block.minecraft.oxidized_copper",
+    "english_translation": "Oxidized Copper"
+  },
+  {
+    "key": "block.minecraft.cut_copper",
+    "english_translation": "Cut Copper"
+  },
+  {
+    "key": "block.minecraft.exposed_cut_copper",
+    "english_translation": "Exposed Cut Copper"
+  },
+  {
+    "key": "block.minecraft.weathered_cut_copper",
+    "english_translation": "Weathered Cut Copper"
+  },
+  {
+    "key": "block.minecraft.oxidized_cut_copper",
+    "english_translation": "Oxidized Cut Copper"
+  },
+  {
+    "key": "block.minecraft.cut_copper_stairs",
+    "english_translation": "Cut Copper Stairs"
+  },
+  {
+    "key": "block.minecraft.exposed_cut_copper_stairs",
+    "english_translation": "Exposed Cut Copper Stairs"
+  },
+  {
+    "key": "block.minecraft.weathered_cut_copper_stairs",
+    "english_translation": "Weathered Cut Copper Stairs"
+  },
+  {
+    "key": "block.minecraft.oxidized_cut_copper_stairs",
+    "english_translation": "Oxidized Cut Copper Stairs"
+  },
+  {
+    "key": "block.minecraft.cut_copper_slab",
+    "english_translation": "Cut Copper Slab"
+  },
+  {
+    "key": "block.minecraft.exposed_cut_copper_slab",
+    "english_translation": "Exposed Cut Copper Slab"
+  },
+  {
+    "key": "block.minecraft.weathered_cut_copper_slab",
+    "english_translation": "Weathered Cut Copper Slab"
+  },
+  {
+    "key": "block.minecraft.oxidized_cut_copper_slab",
+    "english_translation": "Oxidized Cut Copper Slab"
+  },
+  {
+    "key": "block.minecraft.waxed_copper_block",
+    "english_translation": "Waxed Block of Copper"
+  },
+  {
+    "key": "block.minecraft.waxed_exposed_copper",
+    "english_translation": "Waxed Exposed Copper"
+  },
+  {
+    "key": "block.minecraft.waxed_weathered_copper",
+    "english_translation": "Waxed Weathered Copper"
+  },
+  {
+    "key": "block.minecraft.waxed_oxidized_copper",
+    "english_translation": "Waxed Oxidized Copper"
+  },
+  {
+    "key": "block.minecraft.waxed_cut_copper",
+    "english_translation": "Waxed Cut Copper"
+  },
+  {
+    "key": "block.minecraft.waxed_exposed_cut_copper",
+    "english_translation": "Waxed Exposed Cut Copper"
+  },
+  {
+    "key": "block.minecraft.waxed_weathered_cut_copper",
+    "english_translation": "Waxed Weathered Cut Copper"
+  },
+  {
+    "key": "block.minecraft.waxed_oxidized_cut_copper",
+    "english_translation": "Waxed Oxidized Cut Copper"
+  },
+  {
+    "key": "block.minecraft.waxed_cut_copper_stairs",
+    "english_translation": "Waxed Cut Copper Stairs"
+  },
+  {
+    "key": "block.minecraft.waxed_exposed_cut_copper_stairs",
+    "english_translation": "Waxed Exposed Cut Copper Stairs"
+  },
+  {
+    "key": "block.minecraft.waxed_weathered_cut_copper_stairs",
+    "english_translation": "Waxed Weathered Cut Copper Stairs"
+  },
+  {
+    "key": "block.minecraft.waxed_oxidized_cut_copper_stairs",
+    "english_translation": "Waxed Oxidized Cut Copper Stairs"
+  },
+  {
+    "key": "block.minecraft.waxed_cut_copper_slab",
+    "english_translation": "Waxed Cut Copper Slab"
+  },
+  {
+    "key": "block.minecraft.waxed_exposed_cut_copper_slab",
+    "english_translation": "Waxed Exposed Cut Copper Slab"
+  },
+  {
+    "key": "block.minecraft.waxed_weathered_cut_copper_slab",
+    "english_translation": "Waxed Weathered Cut Copper Slab"
+  },
+  {
+    "key": "block.minecraft.waxed_oxidized_cut_copper_slab",
+    "english_translation": "Waxed Oxidized Cut Copper Slab"
+  },
+  {
+    "key": "block.minecraft.lightning_rod",
+    "english_translation": "Lightning Rod"
+  },
+  {
+    "key": "block.minecraft.cave_vines",
+    "english_translation": "Cave Vines"
+  },
+  {
+    "key": "block.minecraft.cave_vines_plant",
+    "english_translation": "Cave Vines Plant"
+  },
+  {
+    "key": "block.minecraft.spore_blossom",
+    "english_translation": "Spore Blossom"
+  },
+  {
+    "key": "block.minecraft.azalea",
+    "english_translation": "Azalea"
+  },
+  {
+    "key": "block.minecraft.flowering_azalea",
+    "english_translation": "Flowering Azalea"
+  },
+  {
+    "key": "block.minecraft.azalea_leaves",
+    "english_translation": "Azalea Leaves"
+  },
+  {
+    "key": "block.minecraft.flowering_azalea_leaves",
+    "english_translation": "Flowering Azalea Leaves"
+  },
+  {
+    "key": "block.minecraft.moss_carpet",
+    "english_translation": "Moss Carpet"
+  },
+  {
+    "key": "block.minecraft.moss_block",
+    "english_translation": "Moss Block"
+  },
+  {
+    "key": "block.minecraft.big_dripleaf",
+    "english_translation": "Big Dripleaf"
+  },
+  {
+    "key": "block.minecraft.big_dripleaf_stem",
+    "english_translation": "Big Dripleaf Stem"
+  },
+  {
+    "key": "block.minecraft.small_dripleaf",
+    "english_translation": "Small Dripleaf"
+  },
+  {
+    "key": "block.minecraft.rooted_dirt",
+    "english_translation": "Rooted Dirt"
+  },
+  {
+    "key": "block.minecraft.mud",
+    "english_translation": "Mud"
+  },
+  {
+    "key": "block.minecraft.hanging_roots",
+    "english_translation": "Hanging Roots"
+  },
+  {
+    "key": "block.minecraft.powder_snow",
+    "english_translation": "Powder Snow"
+  },
+  {
+    "key": "block.minecraft.glow_lichen",
+    "english_translation": "Glow Lichen"
+  },
+  {
+    "key": "block.minecraft.sculk_sensor",
+    "english_translation": "Sculk Sensor"
+  },
+  {
+    "key": "block.minecraft.deepslate",
+    "english_translation": "Deepslate"
+  },
+  {
+    "key": "block.minecraft.cobbled_deepslate",
+    "english_translation": "Cobbled Deepslate"
+  },
+  {
+    "key": "block.minecraft.cobbled_deepslate_slab",
+    "english_translation": "Cobbled Deepslate Slab"
+  },
+  {
+    "key": "block.minecraft.cobbled_deepslate_stairs",
+    "english_translation": "Cobbled Deepslate Stairs"
+  },
+  {
+    "key": "block.minecraft.cobbled_deepslate_wall",
+    "english_translation": "Cobbled Deepslate Wall"
+  },
+  {
+    "key": "block.minecraft.chiseled_deepslate",
+    "english_translation": "Chiseled Deepslate"
+  },
+  {
+    "key": "block.minecraft.polished_deepslate",
+    "english_translation": "Polished Deepslate"
+  },
+  {
+    "key": "block.minecraft.polished_deepslate_slab",
+    "english_translation": "Polished Deepslate Slab"
+  },
+  {
+    "key": "block.minecraft.polished_deepslate_stairs",
+    "english_translation": "Polished Deepslate Stairs"
+  },
+  {
+    "key": "block.minecraft.polished_deepslate_wall",
+    "english_translation": "Polished Deepslate Wall"
+  },
+  {
+    "key": "block.minecraft.deepslate_bricks",
+    "english_translation": "Deepslate Bricks"
+  },
+  {
+    "key": "block.minecraft.deepslate_brick_slab",
+    "english_translation": "Deepslate Brick Slab"
+  },
+  {
+    "key": "block.minecraft.deepslate_brick_stairs",
+    "english_translation": "Deepslate Brick Stairs"
+  },
+  {
+    "key": "block.minecraft.deepslate_brick_wall",
+    "english_translation": "Deepslate Brick Wall"
+  },
+  {
+    "key": "block.minecraft.deepslate_tiles",
+    "english_translation": "Deepslate Tiles"
+  },
+  {
+    "key": "block.minecraft.deepslate_tile_slab",
+    "english_translation": "Deepslate Tile Slab"
+  },
+  {
+    "key": "block.minecraft.deepslate_tile_stairs",
+    "english_translation": "Deepslate Tile Stairs"
+  },
+  {
+    "key": "block.minecraft.deepslate_tile_wall",
+    "english_translation": "Deepslate Tile Wall"
+  },
+  {
+    "key": "block.minecraft.cracked_deepslate_bricks",
+    "english_translation": "Cracked Deepslate Bricks"
+  },
+  {
+    "key": "block.minecraft.cracked_deepslate_tiles",
+    "english_translation": "Cracked Deepslate Tiles"
+  },
+  {
+    "key": "block.minecraft.infested_deepslate",
+    "english_translation": "Infested Deepslate"
+  },
+  {
+    "key": "block.minecraft.smooth_basalt",
+    "english_translation": "Smooth Basalt"
+  },
+  {
+    "key": "block.minecraft.raw_iron_block",
+    "english_translation": "Block of Raw Iron"
+  },
+  {
+    "key": "block.minecraft.raw_copper_block",
+    "english_translation": "Block of Raw Copper"
+  },
+  {
+    "key": "block.minecraft.raw_gold_block",
+    "english_translation": "Block of Raw Gold"
+  },
+  {
+    "key": "block.minecraft.sculk",
+    "english_translation": "Sculk"
+  },
+  {
+    "key": "block.minecraft.sculk_catalyst",
+    "english_translation": "Sculk Catalyst"
+  },
+  {
+    "key": "block.minecraft.sculk_shrieker",
+    "english_translation": "Sculk Shrieker"
+  },
+  {
+    "key": "block.minecraft.sculk_vein",
+    "english_translation": "Sculk Vein"
+  },
+  {
+    "key": "block.minecraft.ochre_froglight",
+    "english_translation": "Ochre Froglight"
+  },
+  {
+    "key": "block.minecraft.verdant_froglight",
+    "english_translation": "Verdant Froglight"
+  },
+  {
+    "key": "block.minecraft.pearlescent_froglight",
+    "english_translation": "Pearlescent Froglight"
+  },
+  {
+    "key": "block.minecraft.frogspawn",
+    "english_translation": "Frogspawn"
+  },
+  {
+    "key": "block.minecraft.reinforced_deepslate",
+    "english_translation": "Reinforced Deepslate"
+  },
+  {
+    "key": "item.minecraft.name_tag",
+    "english_translation": "Name Tag"
+  },
+  {
+    "key": "item.minecraft.lead",
+    "english_translation": "Lead"
+  },
+  {
+    "key": "item.minecraft.iron_shovel",
+    "english_translation": "Iron Shovel"
+  },
+  {
+    "key": "item.minecraft.iron_pickaxe",
+    "english_translation": "Iron Pickaxe"
+  },
+  {
+    "key": "item.minecraft.iron_axe",
+    "english_translation": "Iron Axe"
+  },
+  {
+    "key": "item.minecraft.flint_and_steel",
+    "english_translation": "Flint and Steel"
+  },
+  {
+    "key": "item.minecraft.apple",
+    "english_translation": "Apple"
+  },
+  {
+    "key": "item.minecraft.cookie",
+    "english_translation": "Cookie"
+  },
+  {
+    "key": "item.minecraft.bow",
+    "english_translation": "Bow"
+  },
+  {
+    "key": "item.minecraft.bundle",
+    "english_translation": "Bundle"
+  },
+  {
+    "key": "item.minecraft.bundle.fullness",
+    "english_translation": "%s/%s"
+  },
+  {
+    "key": "item.minecraft.arrow",
+    "english_translation": "Arrow"
+  },
+  {
+    "key": "item.minecraft.spectral_arrow",
+    "english_translation": "Spectral Arrow"
+  },
+  {
+    "key": "item.minecraft.tipped_arrow",
+    "english_translation": "Tipped Arrow"
+  },
+  {
+    "key": "item.minecraft.dried_kelp",
+    "english_translation": "Dried Kelp"
+  },
+  {
+    "key": "item.minecraft.coal",
+    "english_translation": "Coal"
+  },
+  {
+    "key": "item.minecraft.charcoal",
+    "english_translation": "Charcoal"
+  },
+  {
+    "key": "item.minecraft.raw_copper",
+    "english_translation": "Raw Copper"
+  },
+  {
+    "key": "item.minecraft.raw_iron",
+    "english_translation": "Raw Iron"
+  },
+  {
+    "key": "item.minecraft.raw_gold",
+    "english_translation": "Raw Gold"
+  },
+  {
+    "key": "item.minecraft.diamond",
+    "english_translation": "Diamond"
+  },
+  {
+    "key": "item.minecraft.emerald",
+    "english_translation": "Emerald"
+  },
+  {
+    "key": "item.minecraft.iron_ingot",
+    "english_translation": "Iron Ingot"
+  },
+  {
+    "key": "item.minecraft.copper_ingot",
+    "english_translation": "Copper Ingot"
+  },
+  {
+    "key": "item.minecraft.gold_ingot",
+    "english_translation": "Gold Ingot"
+  },
+  {
+    "key": "item.minecraft.iron_sword",
+    "english_translation": "Iron Sword"
+  },
+  {
+    "key": "item.minecraft.wooden_sword",
+    "english_translation": "Wooden Sword"
+  },
+  {
+    "key": "item.minecraft.wooden_shovel",
+    "english_translation": "Wooden Shovel"
+  },
+  {
+    "key": "item.minecraft.wooden_pickaxe",
+    "english_translation": "Wooden Pickaxe"
+  },
+  {
+    "key": "item.minecraft.wooden_axe",
+    "english_translation": "Wooden Axe"
+  },
+  {
+    "key": "item.minecraft.stone_sword",
+    "english_translation": "Stone Sword"
+  },
+  {
+    "key": "item.minecraft.stone_shovel",
+    "english_translation": "Stone Shovel"
+  },
+  {
+    "key": "item.minecraft.stone_pickaxe",
+    "english_translation": "Stone Pickaxe"
+  },
+  {
+    "key": "item.minecraft.stone_axe",
+    "english_translation": "Stone Axe"
+  },
+  {
+    "key": "item.minecraft.diamond_sword",
+    "english_translation": "Diamond Sword"
+  },
+  {
+    "key": "item.minecraft.diamond_shovel",
+    "english_translation": "Diamond Shovel"
+  },
+  {
+    "key": "item.minecraft.diamond_pickaxe",
+    "english_translation": "Diamond Pickaxe"
+  },
+  {
+    "key": "item.minecraft.diamond_axe",
+    "english_translation": "Diamond Axe"
+  },
+  {
+    "key": "item.minecraft.stick",
+    "english_translation": "Stick"
+  },
+  {
+    "key": "item.minecraft.bowl",
+    "english_translation": "Bowl"
+  },
+  {
+    "key": "item.minecraft.mushroom_stew",
+    "english_translation": "Mushroom Stew"
+  },
+  {
+    "key": "item.minecraft.golden_sword",
+    "english_translation": "Golden Sword"
+  },
+  {
+    "key": "item.minecraft.golden_shovel",
+    "english_translation": "Golden Shovel"
+  },
+  {
+    "key": "item.minecraft.golden_pickaxe",
+    "english_translation": "Golden Pickaxe"
+  },
+  {
+    "key": "item.minecraft.golden_axe",
+    "english_translation": "Golden Axe"
+  },
+  {
+    "key": "item.minecraft.string",
+    "english_translation": "String"
+  },
+  {
+    "key": "item.minecraft.feather",
+    "english_translation": "Feather"
+  },
+  {
+    "key": "item.minecraft.gunpowder",
+    "english_translation": "Gunpowder"
+  },
+  {
+    "key": "item.minecraft.wooden_hoe",
+    "english_translation": "Wooden Hoe"
+  },
+  {
+    "key": "item.minecraft.stone_hoe",
+    "english_translation": "Stone Hoe"
+  },
+  {
+    "key": "item.minecraft.iron_hoe",
+    "english_translation": "Iron Hoe"
+  },
+  {
+    "key": "item.minecraft.diamond_hoe",
+    "english_translation": "Diamond Hoe"
+  },
+  {
+    "key": "item.minecraft.golden_hoe",
+    "english_translation": "Golden Hoe"
+  },
+  {
+    "key": "item.minecraft.wheat_seeds",
+    "english_translation": "Wheat Seeds"
+  },
+  {
+    "key": "item.minecraft.pumpkin_seeds",
+    "english_translation": "Pumpkin Seeds"
+  },
+  {
+    "key": "item.minecraft.melon_seeds",
+    "english_translation": "Melon Seeds"
+  },
+  {
+    "key": "item.minecraft.melon_slice",
+    "english_translation": "Melon Slice"
+  },
+  {
+    "key": "item.minecraft.wheat",
+    "english_translation": "Wheat"
+  },
+  {
+    "key": "item.minecraft.bread",
+    "english_translation": "Bread"
+  },
+  {
+    "key": "item.minecraft.leather_helmet",
+    "english_translation": "Leather Cap"
+  },
+  {
+    "key": "item.minecraft.leather_chestplate",
+    "english_translation": "Leather Tunic"
+  },
+  {
+    "key": "item.minecraft.leather_leggings",
+    "english_translation": "Leather Pants"
+  },
+  {
+    "key": "item.minecraft.leather_boots",
+    "english_translation": "Leather Boots"
+  },
+  {
+    "key": "item.minecraft.chainmail_helmet",
+    "english_translation": "Chainmail Helmet"
+  },
+  {
+    "key": "item.minecraft.chainmail_chestplate",
+    "english_translation": "Chainmail Chestplate"
+  },
+  {
+    "key": "item.minecraft.chainmail_leggings",
+    "english_translation": "Chainmail Leggings"
+  },
+  {
+    "key": "item.minecraft.chainmail_boots",
+    "english_translation": "Chainmail Boots"
+  },
+  {
+    "key": "item.minecraft.iron_helmet",
+    "english_translation": "Iron Helmet"
+  },
+  {
+    "key": "item.minecraft.iron_chestplate",
+    "english_translation": "Iron Chestplate"
+  },
+  {
+    "key": "item.minecraft.iron_leggings",
+    "english_translation": "Iron Leggings"
+  },
+  {
+    "key": "item.minecraft.iron_boots",
+    "english_translation": "Iron Boots"
+  },
+  {
+    "key": "item.minecraft.diamond_helmet",
+    "english_translation": "Diamond Helmet"
+  },
+  {
+    "key": "item.minecraft.diamond_chestplate",
+    "english_translation": "Diamond Chestplate"
+  },
+  {
+    "key": "item.minecraft.diamond_leggings",
+    "english_translation": "Diamond Leggings"
+  },
+  {
+    "key": "item.minecraft.diamond_boots",
+    "english_translation": "Diamond Boots"
+  },
+  {
+    "key": "item.minecraft.golden_helmet",
+    "english_translation": "Golden Helmet"
+  },
+  {
+    "key": "item.minecraft.golden_chestplate",
+    "english_translation": "Golden Chestplate"
+  },
+  {
+    "key": "item.minecraft.golden_leggings",
+    "english_translation": "Golden Leggings"
+  },
+  {
+    "key": "item.minecraft.golden_boots",
+    "english_translation": "Golden Boots"
+  },
+  {
+    "key": "item.minecraft.flint",
+    "english_translation": "Flint"
+  },
+  {
+    "key": "item.minecraft.porkchop",
+    "english_translation": "Raw Porkchop"
+  },
+  {
+    "key": "item.minecraft.cooked_porkchop",
+    "english_translation": "Cooked Porkchop"
+  },
+  {
+    "key": "item.minecraft.chicken",
+    "english_translation": "Raw Chicken"
+  },
+  {
+    "key": "item.minecraft.cooked_chicken",
+    "english_translation": "Cooked Chicken"
+  },
+  {
+    "key": "item.minecraft.mutton",
+    "english_translation": "Raw Mutton"
+  },
+  {
+    "key": "item.minecraft.cooked_mutton",
+    "english_translation": "Cooked Mutton"
+  },
+  {
+    "key": "item.minecraft.rabbit",
+    "english_translation": "Raw Rabbit"
+  },
+  {
+    "key": "item.minecraft.cooked_rabbit",
+    "english_translation": "Cooked Rabbit"
+  },
+  {
+    "key": "item.minecraft.rabbit_stew",
+    "english_translation": "Rabbit Stew"
+  },
+  {
+    "key": "item.minecraft.rabbit_foot",
+    "english_translation": "Rabbit's Foot"
+  },
+  {
+    "key": "item.minecraft.rabbit_hide",
+    "english_translation": "Rabbit Hide"
+  },
+  {
+    "key": "item.minecraft.beef",
+    "english_translation": "Raw Beef"
+  },
+  {
+    "key": "item.minecraft.cooked_beef",
+    "english_translation": "Steak"
+  },
+  {
+    "key": "item.minecraft.painting",
+    "english_translation": "Painting"
+  },
+  {
+    "key": "item.minecraft.item_frame",
+    "english_translation": "Item Frame"
+  },
+  {
+    "key": "item.minecraft.golden_apple",
+    "english_translation": "Golden Apple"
+  },
+  {
+    "key": "item.minecraft.enchanted_golden_apple",
+    "english_translation": "Enchanted Golden Apple"
+  },
+  {
+    "key": "item.minecraft.sign",
+    "english_translation": "Sign"
+  },
+  {
+    "key": "item.minecraft.bucket",
+    "english_translation": "Bucket"
+  },
+  {
+    "key": "item.minecraft.water_bucket",
+    "english_translation": "Water Bucket"
+  },
+  {
+    "key": "item.minecraft.lava_bucket",
+    "english_translation": "Lava Bucket"
+  },
+  {
+    "key": "item.minecraft.pufferfish_bucket",
+    "english_translation": "Bucket of Pufferfish"
+  },
+  {
+    "key": "item.minecraft.salmon_bucket",
+    "english_translation": "Bucket of Salmon"
+  },
+  {
+    "key": "item.minecraft.cod_bucket",
+    "english_translation": "Bucket of Cod"
+  },
+  {
+    "key": "item.minecraft.tropical_fish_bucket",
+    "english_translation": "Bucket of Tropical Fish"
+  },
+  {
+    "key": "item.minecraft.powder_snow_bucket",
+    "english_translation": "Powder Snow Bucket"
+  },
+  {
+    "key": "item.minecraft.axolotl_bucket",
+    "english_translation": "Bucket of Axolotl"
+  },
+  {
+    "key": "item.minecraft.tadpole_bucket",
+    "english_translation": "Bucket of Tadpole"
+  },
+  {
+    "key": "item.minecraft.minecart",
+    "english_translation": "Minecart"
+  },
+  {
+    "key": "item.minecraft.saddle",
+    "english_translation": "Saddle"
+  },
+  {
+    "key": "item.minecraft.redstone",
+    "english_translation": "Redstone Dust"
+  },
+  {
+    "key": "item.minecraft.snowball",
+    "english_translation": "Snowball"
+  },
+  {
+    "key": "item.minecraft.oak_boat",
+    "english_translation": "Oak Boat"
+  },
+  {
+    "key": "item.minecraft.oak_chest_boat",
+    "english_translation": "Oak Boat with Chest"
+  },
+  {
+    "key": "item.minecraft.spruce_boat",
+    "english_translation": "Spruce Boat"
+  },
+  {
+    "key": "item.minecraft.spruce_chest_boat",
+    "english_translation": "Spruce Boat with Chest"
+  },
+  {
+    "key": "item.minecraft.birch_boat",
+    "english_translation": "Birch Boat"
+  },
+  {
+    "key": "item.minecraft.birch_chest_boat",
+    "english_translation": "Birch Boat with Chest"
+  },
+  {
+    "key": "item.minecraft.jungle_boat",
+    "english_translation": "Jungle Boat"
+  },
+  {
+    "key": "item.minecraft.jungle_chest_boat",
+    "english_translation": "Jungle Boat with Chest"
+  },
+  {
+    "key": "item.minecraft.acacia_boat",
+    "english_translation": "Acacia Boat"
+  },
+  {
+    "key": "item.minecraft.acacia_chest_boat",
+    "english_translation": "Acacia Boat with Chest"
+  },
+  {
+    "key": "item.minecraft.dark_oak_boat",
+    "english_translation": "Dark Oak Boat"
+  },
+  {
+    "key": "item.minecraft.dark_oak_chest_boat",
+    "english_translation": "Dark Oak Boat with Chest"
+  },
+  {
+    "key": "item.minecraft.mangrove_boat",
+    "english_translation": "Mangrove Boat"
+  },
+  {
+    "key": "item.minecraft.mangrove_chest_boat",
+    "english_translation": "Mangrove Boat with Chest"
+  },
+  {
+    "key": "item.minecraft.leather",
+    "english_translation": "Leather"
+  },
+  {
+    "key": "item.minecraft.milk_bucket",
+    "english_translation": "Milk Bucket"
+  },
+  {
+    "key": "item.minecraft.brick",
+    "english_translation": "Brick"
+  },
+  {
+    "key": "item.minecraft.clay_ball",
+    "english_translation": "Clay Ball"
+  },
+  {
+    "key": "item.minecraft.paper",
+    "english_translation": "Paper"
+  },
+  {
+    "key": "item.minecraft.book",
+    "english_translation": "Book"
+  },
+  {
+    "key": "item.minecraft.slime_ball",
+    "english_translation": "Slimeball"
+  },
+  {
+    "key": "item.minecraft.chest_minecart",
+    "english_translation": "Minecart with Chest"
+  },
+  {
+    "key": "item.minecraft.furnace_minecart",
+    "english_translation": "Minecart with Furnace"
+  },
+  {
+    "key": "item.minecraft.tnt_minecart",
+    "english_translation": "Minecart with TNT"
+  },
+  {
+    "key": "item.minecraft.hopper_minecart",
+    "english_translation": "Minecart with Hopper"
+  },
+  {
+    "key": "item.minecraft.command_block_minecart",
+    "english_translation": "Minecart with Command Block"
+  },
+  {
+    "key": "item.minecraft.egg",
+    "english_translation": "Egg"
+  },
+  {
+    "key": "item.minecraft.compass",
+    "english_translation": "Compass"
+  },
+  {
+    "key": "item.minecraft.recovery_compass",
+    "english_translation": "Recovery Compass"
+  },
+  {
+    "key": "item.minecraft.fishing_rod",
+    "english_translation": "Fishing Rod"
+  },
+  {
+    "key": "item.minecraft.clock",
+    "english_translation": "Clock"
+  },
+  {
+    "key": "item.minecraft.glowstone_dust",
+    "english_translation": "Glowstone Dust"
+  },
+  {
+    "key": "item.minecraft.cod",
+    "english_translation": "Raw Cod"
+  },
+  {
+    "key": "item.minecraft.salmon",
+    "english_translation": "Raw Salmon"
+  },
+  {
+    "key": "item.minecraft.pufferfish",
+    "english_translation": "Pufferfish"
+  },
+  {
+    "key": "item.minecraft.tropical_fish",
+    "english_translation": "Tropical Fish"
+  },
+  {
+    "key": "item.minecraft.cooked_cod",
+    "english_translation": "Cooked Cod"
+  },
+  {
+    "key": "item.minecraft.cooked_salmon",
+    "english_translation": "Cooked Salmon"
+  },
+  {
+    "key": "item.minecraft.music_disc_13",
+    "english_translation": "Music Disc"
+  },
+  {
+    "key": "item.minecraft.music_disc_cat",
+    "english_translation": "Music Disc"
+  },
+  {
+    "key": "item.minecraft.music_disc_blocks",
+    "english_translation": "Music Disc"
+  },
+  {
+    "key": "item.minecraft.music_disc_chirp",
+    "english_translation": "Music Disc"
+  },
+  {
+    "key": "item.minecraft.music_disc_far",
+    "english_translation": "Music Disc"
+  },
+  {
+    "key": "item.minecraft.music_disc_mall",
+    "english_translation": "Music Disc"
+  },
+  {
+    "key": "item.minecraft.music_disc_mellohi",
+    "english_translation": "Music Disc"
+  },
+  {
+    "key": "item.minecraft.music_disc_stal",
+    "english_translation": "Music Disc"
+  },
+  {
+    "key": "item.minecraft.music_disc_strad",
+    "english_translation": "Music Disc"
+  },
+  {
+    "key": "item.minecraft.music_disc_ward",
+    "english_translation": "Music Disc"
+  },
+  {
+    "key": "item.minecraft.music_disc_11",
+    "english_translation": "Music Disc"
+  },
+  {
+    "key": "item.minecraft.music_disc_wait",
+    "english_translation": "Music Disc"
+  },
+  {
+    "key": "item.minecraft.music_disc_pigstep",
+    "english_translation": "Music Disc"
+  },
+  {
+    "key": "item.minecraft.music_disc_otherside",
+    "english_translation": "Music Disc"
+  },
+  {
+    "key": "item.minecraft.music_disc_5",
+    "english_translation": "Music Disc"
+  },
+  {
+    "key": "item.minecraft.music_disc_13.desc",
+    "english_translation": "C418 - 13"
+  },
+  {
+    "key": "item.minecraft.music_disc_cat.desc",
+    "english_translation": "C418 - cat"
+  },
+  {
+    "key": "item.minecraft.music_disc_blocks.desc",
+    "english_translation": "C418 - blocks"
+  },
+  {
+    "key": "item.minecraft.music_disc_chirp.desc",
+    "english_translation": "C418 - chirp"
+  },
+  {
+    "key": "item.minecraft.music_disc_far.desc",
+    "english_translation": "C418 - far"
+  },
+  {
+    "key": "item.minecraft.music_disc_mall.desc",
+    "english_translation": "C418 - mall"
+  },
+  {
+    "key": "item.minecraft.music_disc_mellohi.desc",
+    "english_translation": "C418 - mellohi"
+  },
+  {
+    "key": "item.minecraft.music_disc_stal.desc",
+    "english_translation": "C418 - stal"
+  },
+  {
+    "key": "item.minecraft.music_disc_strad.desc",
+    "english_translation": "C418 - strad"
+  },
+  {
+    "key": "item.minecraft.music_disc_ward.desc",
+    "english_translation": "C418 - ward"
+  },
+  {
+    "key": "item.minecraft.music_disc_11.desc",
+    "english_translation": "C418 - 11"
+  },
+  {
+    "key": "item.minecraft.music_disc_wait.desc",
+    "english_translation": "C418 - wait"
+  },
+  {
+    "key": "item.minecraft.music_disc_pigstep.desc",
+    "english_translation": "Lena Raine - Pigstep"
+  },
+  {
+    "key": "item.minecraft.music_disc_otherside.desc",
+    "english_translation": "Lena Raine - otherside"
+  },
+  {
+    "key": "item.minecraft.music_disc_5.desc",
+    "english_translation": "Samuel Åberg - 5"
+  },
+  {
+    "key": "item.minecraft.bone",
+    "english_translation": "Bone"
+  },
+  {
+    "key": "item.minecraft.ink_sac",
+    "english_translation": "Ink Sac"
+  },
+  {
+    "key": "item.minecraft.red_dye",
+    "english_translation": "Red Dye"
+  },
+  {
+    "key": "item.minecraft.green_dye",
+    "english_translation": "Green Dye"
+  },
+  {
+    "key": "item.minecraft.cocoa_beans",
+    "english_translation": "Cocoa Beans"
+  },
+  {
+    "key": "item.minecraft.lapis_lazuli",
+    "english_translation": "Lapis Lazuli"
+  },
+  {
+    "key": "item.minecraft.purple_dye",
+    "english_translation": "Purple Dye"
+  },
+  {
+    "key": "item.minecraft.cyan_dye",
+    "english_translation": "Cyan Dye"
+  },
+  {
+    "key": "item.minecraft.light_gray_dye",
+    "english_translation": "Light Gray Dye"
+  },
+  {
+    "key": "item.minecraft.gray_dye",
+    "english_translation": "Gray Dye"
+  },
+  {
+    "key": "item.minecraft.pink_dye",
+    "english_translation": "Pink Dye"
+  },
+  {
+    "key": "item.minecraft.lime_dye",
+    "english_translation": "Lime Dye"
+  },
+  {
+    "key": "item.minecraft.yellow_dye",
+    "english_translation": "Yellow Dye"
+  },
+  {
+    "key": "item.minecraft.light_blue_dye",
+    "english_translation": "Light Blue Dye"
+  },
+  {
+    "key": "item.minecraft.magenta_dye",
+    "english_translation": "Magenta Dye"
+  },
+  {
+    "key": "item.minecraft.orange_dye",
+    "english_translation": "Orange Dye"
+  },
+  {
+    "key": "item.minecraft.bone_meal",
+    "english_translation": "Bone Meal"
+  },
+  {
+    "key": "item.minecraft.blue_dye",
+    "english_translation": "Blue Dye"
+  },
+  {
+    "key": "item.minecraft.black_dye",
+    "english_translation": "Black Dye"
+  },
+  {
+    "key": "item.minecraft.brown_dye",
+    "english_translation": "Brown Dye"
+  },
+  {
+    "key": "item.minecraft.white_dye",
+    "english_translation": "White Dye"
+  },
+  {
+    "key": "item.minecraft.sugar",
+    "english_translation": "Sugar"
+  },
+  {
+    "key": "item.minecraft.amethyst_shard",
+    "english_translation": "Amethyst Shard"
+  },
+  {
+    "key": "item.minecraft.spyglass",
+    "english_translation": "Spyglass"
+  },
+  {
+    "key": "item.minecraft.glow_berries",
+    "english_translation": "Glow Berries"
+  },
+  {
+    "key": "item.minecraft.disc_fragment_5",
+    "english_translation": "Disc Fragment"
+  },
+  {
+    "key": "item.minecraft.disc_fragment_5.desc",
+    "english_translation": "Music Disc - 5"
+  },
+  {
+    "key": "block.minecraft.black_bed",
+    "english_translation": "Black Bed"
+  },
+  {
+    "key": "block.minecraft.red_bed",
+    "english_translation": "Red Bed"
+  },
+  {
+    "key": "block.minecraft.green_bed",
+    "english_translation": "Green Bed"
+  },
+  {
+    "key": "block.minecraft.brown_bed",
+    "english_translation": "Brown Bed"
+  },
+  {
+    "key": "block.minecraft.blue_bed",
+    "english_translation": "Blue Bed"
+  },
+  {
+    "key": "block.minecraft.purple_bed",
+    "english_translation": "Purple Bed"
+  },
+  {
+    "key": "block.minecraft.cyan_bed",
+    "english_translation": "Cyan Bed"
+  },
+  {
+    "key": "block.minecraft.light_gray_bed",
+    "english_translation": "Light Gray Bed"
+  },
+  {
+    "key": "block.minecraft.gray_bed",
+    "english_translation": "Gray Bed"
+  },
+  {
+    "key": "block.minecraft.pink_bed",
+    "english_translation": "Pink Bed"
+  },
+  {
+    "key": "block.minecraft.lime_bed",
+    "english_translation": "Lime Bed"
+  },
+  {
+    "key": "block.minecraft.yellow_bed",
+    "english_translation": "Yellow Bed"
+  },
+  {
+    "key": "block.minecraft.light_blue_bed",
+    "english_translation": "Light Blue Bed"
+  },
+  {
+    "key": "block.minecraft.magenta_bed",
+    "english_translation": "Magenta Bed"
+  },
+  {
+    "key": "block.minecraft.orange_bed",
+    "english_translation": "Orange Bed"
+  },
+  {
+    "key": "block.minecraft.white_bed",
+    "english_translation": "White Bed"
+  },
+  {
+    "key": "block.minecraft.repeater",
+    "english_translation": "Redstone Repeater"
+  },
+  {
+    "key": "block.minecraft.comparator",
+    "english_translation": "Redstone Comparator"
+  },
+  {
+    "key": "item.minecraft.filled_map",
+    "english_translation": "Map"
+  },
+  {
+    "key": "item.minecraft.shears",
+    "english_translation": "Shears"
+  },
+  {
+    "key": "item.minecraft.rotten_flesh",
+    "english_translation": "Rotten Flesh"
+  },
+  {
+    "key": "item.minecraft.ender_pearl",
+    "english_translation": "Ender Pearl"
+  },
+  {
+    "key": "item.minecraft.blaze_rod",
+    "english_translation": "Blaze Rod"
+  },
+  {
+    "key": "item.minecraft.ghast_tear",
+    "english_translation": "Ghast Tear"
+  },
+  {
+    "key": "item.minecraft.nether_wart",
+    "english_translation": "Nether Wart"
+  },
+  {
+    "key": "item.minecraft.potion",
+    "english_translation": "Potion"
+  },
+  {
+    "key": "item.minecraft.splash_potion",
+    "english_translation": "Splash Potion"
+  },
+  {
+    "key": "item.minecraft.lingering_potion",
+    "english_translation": "Lingering Potion"
+  },
+  {
+    "key": "item.minecraft.end_crystal",
+    "english_translation": "End Crystal"
+  },
+  {
+    "key": "item.minecraft.gold_nugget",
+    "english_translation": "Gold Nugget"
+  },
+  {
+    "key": "item.minecraft.glass_bottle",
+    "english_translation": "Glass Bottle"
+  },
+  {
+    "key": "item.minecraft.spider_eye",
+    "english_translation": "Spider Eye"
+  },
+  {
+    "key": "item.minecraft.fermented_spider_eye",
+    "english_translation": "Fermented Spider Eye"
+  },
+  {
+    "key": "item.minecraft.blaze_powder",
+    "english_translation": "Blaze Powder"
+  },
+  {
+    "key": "item.minecraft.magma_cream",
+    "english_translation": "Magma Cream"
+  },
+  {
+    "key": "item.minecraft.cauldron",
+    "english_translation": "Cauldron"
+  },
+  {
+    "key": "item.minecraft.brewing_stand",
+    "english_translation": "Brewing Stand"
+  },
+  {
+    "key": "item.minecraft.ender_eye",
+    "english_translation": "Eye of Ender"
+  },
+  {
+    "key": "item.minecraft.glistering_melon_slice",
+    "english_translation": "Glistering Melon Slice"
+  },
+  {
+    "key": "item.minecraft.allay_spawn_egg",
+    "english_translation": "Allay Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.axolotl_spawn_egg",
+    "english_translation": "Axolotl Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.bat_spawn_egg",
+    "english_translation": "Bat Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.bee_spawn_egg",
+    "english_translation": "Bee Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.blaze_spawn_egg",
+    "english_translation": "Blaze Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.cat_spawn_egg",
+    "english_translation": "Cat Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.cave_spider_spawn_egg",
+    "english_translation": "Cave Spider Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.chicken_spawn_egg",
+    "english_translation": "Chicken Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.cod_spawn_egg",
+    "english_translation": "Cod Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.cow_spawn_egg",
+    "english_translation": "Cow Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.creeper_spawn_egg",
+    "english_translation": "Creeper Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.dolphin_spawn_egg",
+    "english_translation": "Dolphin Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.donkey_spawn_egg",
+    "english_translation": "Donkey Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.drowned_spawn_egg",
+    "english_translation": "Drowned Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.elder_guardian_spawn_egg",
+    "english_translation": "Elder Guardian Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.enderman_spawn_egg",
+    "english_translation": "Enderman Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.endermite_spawn_egg",
+    "english_translation": "Endermite Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.evoker_spawn_egg",
+    "english_translation": "Evoker Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.ghast_spawn_egg",
+    "english_translation": "Ghast Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.glow_squid_spawn_egg",
+    "english_translation": "Glow Squid Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.guardian_spawn_egg",
+    "english_translation": "Guardian Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.hoglin_spawn_egg",
+    "english_translation": "Hoglin Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.horse_spawn_egg",
+    "english_translation": "Horse Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.husk_spawn_egg",
+    "english_translation": "Husk Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.ravager_spawn_egg",
+    "english_translation": "Ravager Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.llama_spawn_egg",
+    "english_translation": "Llama Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.magma_cube_spawn_egg",
+    "english_translation": "Magma Cube Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.mooshroom_spawn_egg",
+    "english_translation": "Mooshroom Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.mule_spawn_egg",
+    "english_translation": "Mule Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.ocelot_spawn_egg",
+    "english_translation": "Ocelot Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.panda_spawn_egg",
+    "english_translation": "Panda Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.parrot_spawn_egg",
+    "english_translation": "Parrot Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.pig_spawn_egg",
+    "english_translation": "Pig Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.piglin_spawn_egg",
+    "english_translation": "Piglin Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.piglin_brute_spawn_egg",
+    "english_translation": "Piglin Brute Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.pillager_spawn_egg",
+    "english_translation": "Pillager Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.phantom_spawn_egg",
+    "english_translation": "Phantom Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.polar_bear_spawn_egg",
+    "english_translation": "Polar Bear Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.pufferfish_spawn_egg",
+    "english_translation": "Pufferfish Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.rabbit_spawn_egg",
+    "english_translation": "Rabbit Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.fox_spawn_egg",
+    "english_translation": "Fox Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.frog_spawn_egg",
+    "english_translation": "Frog Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.salmon_spawn_egg",
+    "english_translation": "Salmon Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.sheep_spawn_egg",
+    "english_translation": "Sheep Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.shulker_spawn_egg",
+    "english_translation": "Shulker Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.silverfish_spawn_egg",
+    "english_translation": "Silverfish Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.skeleton_spawn_egg",
+    "english_translation": "Skeleton Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.skeleton_horse_spawn_egg",
+    "english_translation": "Skeleton Horse Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.slime_spawn_egg",
+    "english_translation": "Slime Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.spider_spawn_egg",
+    "english_translation": "Spider Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.squid_spawn_egg",
+    "english_translation": "Squid Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.stray_spawn_egg",
+    "english_translation": "Stray Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.strider_spawn_egg",
+    "english_translation": "Strider Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.tadpole_spawn_egg",
+    "english_translation": "Tadpole Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.trader_llama_spawn_egg",
+    "english_translation": "Trader Llama Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.tropical_fish_spawn_egg",
+    "english_translation": "Tropical Fish Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.turtle_spawn_egg",
+    "english_translation": "Turtle Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.vex_spawn_egg",
+    "english_translation": "Vex Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.villager_spawn_egg",
+    "english_translation": "Villager Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.wandering_trader_spawn_egg",
+    "english_translation": "Wandering Trader Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.vindicator_spawn_egg",
+    "english_translation": "Vindicator Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.warden_spawn_egg",
+    "english_translation": "Warden Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.witch_spawn_egg",
+    "english_translation": "Witch Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.wither_skeleton_spawn_egg",
+    "english_translation": "Wither Skeleton Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.wolf_spawn_egg",
+    "english_translation": "Wolf Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.zoglin_spawn_egg",
+    "english_translation": "Zoglin Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.zombie_spawn_egg",
+    "english_translation": "Zombie Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.zombie_horse_spawn_egg",
+    "english_translation": "Zombie Horse Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.zombified_piglin_spawn_egg",
+    "english_translation": "Zombified Piglin Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.zombie_villager_spawn_egg",
+    "english_translation": "Zombie Villager Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.goat_spawn_egg",
+    "english_translation": "Goat Spawn Egg"
+  },
+  {
+    "key": "item.minecraft.experience_bottle",
+    "english_translation": "Bottle o' Enchanting"
+  },
+  {
+    "key": "item.minecraft.fire_charge",
+    "english_translation": "Fire Charge"
+  },
+  {
+    "key": "item.minecraft.writable_book",
+    "english_translation": "Book and Quill"
+  },
+  {
+    "key": "item.minecraft.written_book",
+    "english_translation": "Written Book"
+  },
+  {
+    "key": "item.minecraft.flower_pot",
+    "english_translation": "Flower Pot"
+  },
+  {
+    "key": "item.minecraft.map",
+    "english_translation": "Empty Map"
+  },
+  {
+    "key": "item.minecraft.carrot",
+    "english_translation": "Carrot"
+  },
+  {
+    "key": "item.minecraft.golden_carrot",
+    "english_translation": "Golden Carrot"
+  },
+  {
+    "key": "item.minecraft.potato",
+    "english_translation": "Potato"
+  },
+  {
+    "key": "item.minecraft.baked_potato",
+    "english_translation": "Baked Potato"
+  },
+  {
+    "key": "item.minecraft.poisonous_potato",
+    "english_translation": "Poisonous Potato"
+  },
+  {
+    "key": "item.minecraft.carrot_on_a_stick",
+    "english_translation": "Carrot on a Stick"
+  },
+  {
+    "key": "item.minecraft.nether_star",
+    "english_translation": "Nether Star"
+  },
+  {
+    "key": "item.minecraft.pumpkin_pie",
+    "english_translation": "Pumpkin Pie"
+  },
+  {
+    "key": "item.minecraft.enchanted_book",
+    "english_translation": "Enchanted Book"
+  },
+  {
+    "key": "item.minecraft.firework_rocket",
+    "english_translation": "Firework Rocket"
+  },
+  {
+    "key": "item.minecraft.firework_rocket.flight",
+    "english_translation": "Flight Duration:"
+  },
+  {
+    "key": "item.minecraft.firework_star",
+    "english_translation": "Firework Star"
+  },
+  {
+    "key": "item.minecraft.firework_star.black",
+    "english_translation": "Black"
+  },
+  {
+    "key": "item.minecraft.firework_star.red",
+    "english_translation": "Red"
+  },
+  {
+    "key": "item.minecraft.firework_star.green",
+    "english_translation": "Green"
+  },
+  {
+    "key": "item.minecraft.firework_star.brown",
+    "english_translation": "Brown"
+  },
+  {
+    "key": "item.minecraft.firework_star.blue",
+    "english_translation": "Blue"
+  },
+  {
+    "key": "item.minecraft.firework_star.purple",
+    "english_translation": "Purple"
+  },
+  {
+    "key": "item.minecraft.firework_star.cyan",
+    "english_translation": "Cyan"
+  },
+  {
+    "key": "item.minecraft.firework_star.light_gray",
+    "english_translation": "Light Gray"
+  },
+  {
+    "key": "item.minecraft.firework_star.gray",
+    "english_translation": "Gray"
+  },
+  {
+    "key": "item.minecraft.firework_star.pink",
+    "english_translation": "Pink"
+  },
+  {
+    "key": "item.minecraft.firework_star.lime",
+    "english_translation": "Lime"
+  },
+  {
+    "key": "item.minecraft.firework_star.yellow",
+    "english_translation": "Yellow"
+  },
+  {
+    "key": "item.minecraft.firework_star.light_blue",
+    "english_translation": "Light Blue"
+  },
+  {
+    "key": "item.minecraft.firework_star.magenta",
+    "english_translation": "Magenta"
+  },
+  {
+    "key": "item.minecraft.firework_star.orange",
+    "english_translation": "Orange"
+  },
+  {
+    "key": "item.minecraft.firework_star.white",
+    "english_translation": "White"
+  },
+  {
+    "key": "item.minecraft.firework_star.custom_color",
+    "english_translation": "Custom"
+  },
+  {
+    "key": "item.minecraft.firework_star.fade_to",
+    "english_translation": "Fade to"
+  },
+  {
+    "key": "item.minecraft.firework_star.flicker",
+    "english_translation": "Twinkle"
+  },
+  {
+    "key": "item.minecraft.firework_star.trail",
+    "english_translation": "Trail"
+  },
+  {
+    "key": "item.minecraft.firework_star.shape.small_ball",
+    "english_translation": "Small Ball"
+  },
+  {
+    "key": "item.minecraft.firework_star.shape.large_ball",
+    "english_translation": "Large Ball"
+  },
+  {
+    "key": "item.minecraft.firework_star.shape.star",
+    "english_translation": "Star-shaped"
+  },
+  {
+    "key": "item.minecraft.firework_star.shape.creeper",
+    "english_translation": "Creeper-shaped"
+  },
+  {
+    "key": "item.minecraft.firework_star.shape.burst",
+    "english_translation": "Burst"
+  },
+  {
+    "key": "item.minecraft.firework_star.shape",
+    "english_translation": "Unknown Shape"
+  },
+  {
+    "key": "item.minecraft.nether_brick",
+    "english_translation": "Nether Brick"
+  },
+  {
+    "key": "item.minecraft.quartz",
+    "english_translation": "Nether Quartz"
+  },
+  {
+    "key": "item.minecraft.armor_stand",
+    "english_translation": "Armor Stand"
+  },
+  {
+    "key": "item.minecraft.iron_horse_armor",
+    "english_translation": "Iron Horse Armor"
+  },
+  {
+    "key": "item.minecraft.golden_horse_armor",
+    "english_translation": "Golden Horse Armor"
+  },
+  {
+    "key": "item.minecraft.diamond_horse_armor",
+    "english_translation": "Diamond Horse Armor"
+  },
+  {
+    "key": "item.minecraft.leather_horse_armor",
+    "english_translation": "Leather Horse Armor"
+  },
+  {
+    "key": "item.minecraft.prismarine_shard",
+    "english_translation": "Prismarine Shard"
+  },
+  {
+    "key": "item.minecraft.prismarine_crystals",
+    "english_translation": "Prismarine Crystals"
+  },
+  {
+    "key": "item.minecraft.chorus_fruit",
+    "english_translation": "Chorus Fruit"
+  },
+  {
+    "key": "item.minecraft.popped_chorus_fruit",
+    "english_translation": "Popped Chorus Fruit"
+  },
+  {
+    "key": "item.minecraft.beetroot",
+    "english_translation": "Beetroot"
+  },
+  {
+    "key": "item.minecraft.beetroot_seeds",
+    "english_translation": "Beetroot Seeds"
+  },
+  {
+    "key": "item.minecraft.beetroot_soup",
+    "english_translation": "Beetroot Soup"
+  },
+  {
+    "key": "item.minecraft.dragon_breath",
+    "english_translation": "Dragon's Breath"
+  },
+  {
+    "key": "item.minecraft.elytra",
+    "english_translation": "Elytra"
+  },
+  {
+    "key": "item.minecraft.totem_of_undying",
+    "english_translation": "Totem of Undying"
+  },
+  {
+    "key": "item.minecraft.shulker_shell",
+    "english_translation": "Shulker Shell"
+  },
+  {
+    "key": "item.minecraft.iron_nugget",
+    "english_translation": "Iron Nugget"
+  },
+  {
+    "key": "item.minecraft.knowledge_book",
+    "english_translation": "Knowledge Book"
+  },
+  {
+    "key": "item.minecraft.debug_stick",
+    "english_translation": "Debug Stick"
+  },
+  {
+    "key": "item.minecraft.debug_stick.empty",
+    "english_translation": "%s has no properties"
+  },
+  {
+    "key": "item.minecraft.debug_stick.update",
+    "english_translation": "\"%s\" to %s"
+  },
+  {
+    "key": "item.minecraft.debug_stick.select",
+    "english_translation": "selected \"%s\" (%s)"
+  },
+  {
+    "key": "item.minecraft.trident",
+    "english_translation": "Trident"
+  },
+  {
+    "key": "item.minecraft.scute",
+    "english_translation": "Scute"
+  },
+  {
+    "key": "item.minecraft.turtle_helmet",
+    "english_translation": "Turtle Shell"
+  },
+  {
+    "key": "item.minecraft.phantom_membrane",
+    "english_translation": "Phantom Membrane"
+  },
+  {
+    "key": "item.minecraft.nautilus_shell",
+    "english_translation": "Nautilus Shell"
+  },
+  {
+    "key": "item.minecraft.heart_of_the_sea",
+    "english_translation": "Heart of the Sea"
+  },
+  {
+    "key": "item.minecraft.crossbow",
+    "english_translation": "Crossbow"
+  },
+  {
+    "key": "item.minecraft.crossbow.projectile",
+    "english_translation": "Projectile:"
+  },
+  {
+    "key": "item.minecraft.suspicious_stew",
+    "english_translation": "Suspicious Stew"
+  },
+  {
+    "key": "item.minecraft.creeper_banner_pattern",
+    "english_translation": "Banner Pattern"
+  },
+  {
+    "key": "item.minecraft.skull_banner_pattern",
+    "english_translation": "Banner Pattern"
+  },
+  {
+    "key": "item.minecraft.flower_banner_pattern",
+    "english_translation": "Banner Pattern"
+  },
+  {
+    "key": "item.minecraft.mojang_banner_pattern",
+    "english_translation": "Banner Pattern"
+  },
+  {
+    "key": "item.minecraft.globe_banner_pattern",
+    "english_translation": "Banner Pattern"
+  },
+  {
+    "key": "item.minecraft.creeper_banner_pattern.desc",
+    "english_translation": "Creeper Charge"
+  },
+  {
+    "key": "item.minecraft.skull_banner_pattern.desc",
+    "english_translation": "Skull Charge"
+  },
+  {
+    "key": "item.minecraft.flower_banner_pattern.desc",
+    "english_translation": "Flower Charge"
+  },
+  {
+    "key": "item.minecraft.mojang_banner_pattern.desc",
+    "english_translation": "Thing"
+  },
+  {
+    "key": "item.minecraft.globe_banner_pattern.desc",
+    "english_translation": "Globe"
+  },
+  {
+    "key": "item.minecraft.piglin_banner_pattern",
+    "english_translation": "Banner Pattern"
+  },
+  {
+    "key": "item.minecraft.piglin_banner_pattern.desc",
+    "english_translation": "Snout"
+  },
+  {
+    "key": "item.minecraft.sweet_berries",
+    "english_translation": "Sweet Berries"
+  },
+  {
+    "key": "item.minecraft.honey_bottle",
+    "english_translation": "Honey Bottle"
+  },
+  {
+    "key": "item.minecraft.honeycomb",
+    "english_translation": "Honeycomb"
+  },
+  {
+    "key": "item.minecraft.lodestone_compass",
+    "english_translation": "Lodestone Compass"
+  },
+  {
+    "key": "item.minecraft.netherite_scrap",
+    "english_translation": "Netherite Scrap"
+  },
+  {
+    "key": "item.minecraft.netherite_ingot",
+    "english_translation": "Netherite Ingot"
+  },
+  {
+    "key": "item.minecraft.netherite_helmet",
+    "english_translation": "Netherite Helmet"
+  },
+  {
+    "key": "item.minecraft.netherite_chestplate",
+    "english_translation": "Netherite Chestplate"
+  },
+  {
+    "key": "item.minecraft.netherite_leggings",
+    "english_translation": "Netherite Leggings"
+  },
+  {
+    "key": "item.minecraft.netherite_boots",
+    "english_translation": "Netherite Boots"
+  },
+  {
+    "key": "item.minecraft.netherite_axe",
+    "english_translation": "Netherite Axe"
+  },
+  {
+    "key": "item.minecraft.netherite_pickaxe",
+    "english_translation": "Netherite Pickaxe"
+  },
+  {
+    "key": "item.minecraft.netherite_hoe",
+    "english_translation": "Netherite Hoe"
+  },
+  {
+    "key": "item.minecraft.netherite_shovel",
+    "english_translation": "Netherite Shovel"
+  },
+  {
+    "key": "item.minecraft.netherite_sword",
+    "english_translation": "Netherite Sword"
+  },
+  {
+    "key": "item.minecraft.warped_fungus_on_a_stick",
+    "english_translation": "Warped Fungus on a Stick"
+  },
+  {
+    "key": "item.minecraft.glow_ink_sac",
+    "english_translation": "Glow Ink Sac"
+  },
+  {
+    "key": "item.minecraft.glow_item_frame",
+    "english_translation": "Glow Item Frame"
+  },
+  {
+    "key": "item.minecraft.echo_shard",
+    "english_translation": "Echo Shard"
+  },
+  {
+    "key": "item.minecraft.goat_horn",
+    "english_translation": "Goat Horn"
+  },
+  {
+    "key": "instrument.minecraft.ponder_goat_horn",
+    "english_translation": "Ponder"
+  },
+  {
+    "key": "instrument.minecraft.sing_goat_horn",
+    "english_translation": "Sing"
+  },
+  {
+    "key": "instrument.minecraft.seek_goat_horn",
+    "english_translation": "Seek"
+  },
+  {
+    "key": "instrument.minecraft.feel_goat_horn",
+    "english_translation": "Feel"
+  },
+  {
+    "key": "instrument.minecraft.admire_goat_horn",
+    "english_translation": "Admire"
+  },
+  {
+    "key": "instrument.minecraft.call_goat_horn",
+    "english_translation": "Call"
+  },
+  {
+    "key": "instrument.minecraft.yearn_goat_horn",
+    "english_translation": "Yearn"
+  },
+  {
+    "key": "instrument.minecraft.dream_goat_horn",
+    "english_translation": "Dream"
+  },
+  {
+    "key": "container.inventory",
+    "english_translation": "Inventory"
+  },
+  {
+    "key": "container.hopper",
+    "english_translation": "Item Hopper"
+  },
+  {
+    "key": "container.crafting",
+    "english_translation": "Crafting"
+  },
+  {
+    "key": "container.dispenser",
+    "english_translation": "Dispenser"
+  },
+  {
+    "key": "container.dropper",
+    "english_translation": "Dropper"
+  },
+  {
+    "key": "container.furnace",
+    "english_translation": "Furnace"
+  },
+  {
+    "key": "container.enchant",
+    "english_translation": "Enchant"
+  },
+  {
+    "key": "container.smoker",
+    "english_translation": "Smoker"
+  },
+  {
+    "key": "container.lectern",
+    "english_translation": "Lectern"
+  },
+  {
+    "key": "container.blast_furnace",
+    "english_translation": "Blast Furnace"
+  },
+  {
+    "key": "container.enchant.lapis.one",
+    "english_translation": "1 Lapis Lazuli"
+  },
+  {
+    "key": "container.enchant.lapis.many",
+    "english_translation": "%s Lapis Lazuli"
+  },
+  {
+    "key": "container.enchant.level.one",
+    "english_translation": "1 Enchantment Level"
+  },
+  {
+    "key": "container.enchant.level.many",
+    "english_translation": "%s Enchantment Levels"
+  },
+  {
+    "key": "container.enchant.level.requirement",
+    "english_translation": "Level Requirement: %s"
+  },
+  {
+    "key": "container.enchant.clue",
+    "english_translation": "%s . . . ?"
+  },
+  {
+    "key": "container.repair",
+    "english_translation": "Repair & Name"
+  },
+  {
+    "key": "container.repair.cost",
+    "english_translation": "Enchantment Cost: %1$s"
+  },
+  {
+    "key": "container.repair.expensive",
+    "english_translation": "Too Expensive!"
+  },
+  {
+    "key": "container.creative",
+    "english_translation": "Item Selection"
+  },
+  {
+    "key": "container.brewing",
+    "english_translation": "Brewing Stand"
+  },
+  {
+    "key": "container.chest",
+    "english_translation": "Chest"
+  },
+  {
+    "key": "container.chestDouble",
+    "english_translation": "Large Chest"
+  },
+  {
+    "key": "container.enderchest",
+    "english_translation": "Ender Chest"
+  },
+  {
+    "key": "container.beacon",
+    "english_translation": "Beacon"
+  },
+  {
+    "key": "container.shulkerBox",
+    "english_translation": "Shulker Box"
+  },
+  {
+    "key": "container.shulkerBox.more",
+    "english_translation": "and %s more..."
+  },
+  {
+    "key": "container.barrel",
+    "english_translation": "Barrel"
+  },
+  {
+    "key": "container.spectatorCantOpen",
+    "english_translation": "Unable to open. Loot not generated yet."
+  },
+  {
+    "key": "container.isLocked",
+    "english_translation": "%s is locked!"
+  },
+  {
+    "key": "container.loom",
+    "english_translation": "Loom"
+  },
+  {
+    "key": "container.grindstone_title",
+    "english_translation": "Repair & Disenchant"
+  },
+  {
+    "key": "container.cartography_table",
+    "english_translation": "Cartography Table"
+  },
+  {
+    "key": "container.stonecutter",
+    "english_translation": "Stonecutter"
+  },
+  {
+    "key": "container.upgrade",
+    "english_translation": "Upgrade Gear"
+  },
+  {
+    "key": "structure_block.invalid_structure_name",
+    "english_translation": "Invalid structure name '%s'"
+  },
+  {
+    "key": "structure_block.save_success",
+    "english_translation": "Structure saved as '%s'"
+  },
+  {
+    "key": "structure_block.save_failure",
+    "english_translation": "Unable to save structure '%s'"
+  },
+  {
+    "key": "structure_block.load_success",
+    "english_translation": "Structure loaded from '%s'"
+  },
+  {
+    "key": "structure_block.load_prepare",
+    "english_translation": "Structure '%s' position prepared"
+  },
+  {
+    "key": "structure_block.load_not_found",
+    "english_translation": "Structure '%s' is not available"
+  },
+  {
+    "key": "structure_block.size_success",
+    "english_translation": "Size successfully detected for '%s'"
+  },
+  {
+    "key": "structure_block.size_failure",
+    "english_translation": "Unable to detect structure size. Add corners with matching structure names"
+  },
+  {
+    "key": "structure_block.mode.save",
+    "english_translation": "Save"
+  },
+  {
+    "key": "structure_block.mode.load",
+    "english_translation": "Load"
+  },
+  {
+    "key": "structure_block.mode.data",
+    "english_translation": "Data"
+  },
+  {
+    "key": "structure_block.mode.corner",
+    "english_translation": "Corner"
+  },
+  {
+    "key": "structure_block.hover.save",
+    "english_translation": "Save: %s"
+  },
+  {
+    "key": "structure_block.hover.load",
+    "english_translation": "Load: %s"
+  },
+  {
+    "key": "structure_block.hover.data",
+    "english_translation": "Data: %s"
+  },
+  {
+    "key": "structure_block.hover.corner",
+    "english_translation": "Corner: %s"
+  },
+  {
+    "key": "structure_block.mode_info.save",
+    "english_translation": "Save Mode - Write to File"
+  },
+  {
+    "key": "structure_block.mode_info.load",
+    "english_translation": "Load mode - Load from File"
+  },
+  {
+    "key": "structure_block.mode_info.data",
+    "english_translation": "Data mode - Game Logic Marker"
+  },
+  {
+    "key": "structure_block.mode_info.corner",
+    "english_translation": "Corner Mode - Placement and Size Marker"
+  },
+  {
+    "key": "structure_block.structure_name",
+    "english_translation": "Structure Name"
+  },
+  {
+    "key": "structure_block.custom_data",
+    "english_translation": "Custom Data Tag Name"
+  },
+  {
+    "key": "structure_block.position",
+    "english_translation": "Relative Position"
+  },
+  {
+    "key": "structure_block.position.x",
+    "english_translation": "relative Position x"
+  },
+  {
+    "key": "structure_block.position.y",
+    "english_translation": "relative position y"
+  },
+  {
+    "key": "structure_block.position.z",
+    "english_translation": "relative position z"
+  },
+  {
+    "key": "structure_block.size",
+    "english_translation": "Structure Size"
+  },
+  {
+    "key": "structure_block.size.x",
+    "english_translation": "structure size x"
+  },
+  {
+    "key": "structure_block.size.y",
+    "english_translation": "structure size y"
+  },
+  {
+    "key": "structure_block.size.z",
+    "english_translation": "structure size z"
+  },
+  {
+    "key": "structure_block.integrity",
+    "english_translation": "Structure Integrity and Seed"
+  },
+  {
+    "key": "structure_block.integrity.integrity",
+    "english_translation": "Structure Integrity"
+  },
+  {
+    "key": "structure_block.integrity.seed",
+    "english_translation": "Structure Seed"
+  },
+  {
+    "key": "structure_block.include_entities",
+    "english_translation": "Include entities:"
+  },
+  {
+    "key": "structure_block.detect_size",
+    "english_translation": "Detect structure size and position:"
+  },
+  {
+    "key": "structure_block.button.detect_size",
+    "english_translation": "DETECT"
+  },
+  {
+    "key": "structure_block.button.save",
+    "english_translation": "SAVE"
+  },
+  {
+    "key": "structure_block.button.load",
+    "english_translation": "LOAD"
+  },
+  {
+    "key": "structure_block.show_air",
+    "english_translation": "Show Invisible Blocks:"
+  },
+  {
+    "key": "structure_block.show_boundingbox",
+    "english_translation": "Show Bounding Box:"
+  },
+  {
+    "key": "jigsaw_block.pool",
+    "english_translation": "Target Pool:"
+  },
+  {
+    "key": "jigsaw_block.name",
+    "english_translation": "Name:"
+  },
+  {
+    "key": "jigsaw_block.target",
+    "english_translation": "Target Name:"
+  },
+  {
+    "key": "jigsaw_block.final_state",
+    "english_translation": "Turns into:"
+  },
+  {
+    "key": "jigsaw_block.levels",
+    "english_translation": "Levels: %s"
+  },
+  {
+    "key": "jigsaw_block.keep_jigsaws",
+    "english_translation": "Keep Jigsaws"
+  },
+  {
+    "key": "jigsaw_block.generate",
+    "english_translation": "Generate"
+  },
+  {
+    "key": "jigsaw_block.joint_label",
+    "english_translation": "Joint Type:"
+  },
+  {
+    "key": "jigsaw_block.joint.rollable",
+    "english_translation": "Rollable"
+  },
+  {
+    "key": "jigsaw_block.joint.aligned",
+    "english_translation": "Aligned"
+  },
+  {
+    "key": "item.dyed",
+    "english_translation": "Dyed"
+  },
+  {
+    "key": "item.unbreakable",
+    "english_translation": "Unbreakable"
+  },
+  {
+    "key": "item.canBreak",
+    "english_translation": "Can break:"
+  },
+  {
+    "key": "item.canPlace",
+    "english_translation": "Can be placed on:"
+  },
+  {
+    "key": "item.color",
+    "english_translation": "Color: %s"
+  },
+  {
+    "key": "item.nbt_tags",
+    "english_translation": "NBT: %s tag(s)"
+  },
+  {
+    "key": "item.durability",
+    "english_translation": "Durability: %s / %s"
+  },
+  {
+    "key": "filled_map.mansion",
+    "english_translation": "Woodland Explorer Map"
+  },
+  {
+    "key": "filled_map.monument",
+    "english_translation": "Ocean Explorer Map"
+  },
+  {
+    "key": "filled_map.buried_treasure",
+    "english_translation": "Buried Treasure Map"
+  },
+  {
+    "key": "filled_map.unknown",
+    "english_translation": "Unknown Map"
+  },
+  {
+    "key": "filled_map.id",
+    "english_translation": "Id #%s"
+  },
+  {
+    "key": "filled_map.level",
+    "english_translation": "(Level %s/%s)"
+  },
+  {
+    "key": "filled_map.scale",
+    "english_translation": "Scaling at 1:%s"
+  },
+  {
+    "key": "filled_map.locked",
+    "english_translation": "Locked"
+  },
+  {
+    "key": "entity.minecraft.allay",
+    "english_translation": "Allay"
+  },
+  {
+    "key": "entity.minecraft.area_effect_cloud",
+    "english_translation": "Area Effect Cloud"
+  },
+  {
+    "key": "entity.minecraft.armor_stand",
+    "english_translation": "Armor Stand"
+  },
+  {
+    "key": "entity.minecraft.arrow",
+    "english_translation": "Arrow"
+  },
+  {
+    "key": "entity.minecraft.axolotl",
+    "english_translation": "Axolotl"
+  },
+  {
+    "key": "entity.minecraft.bat",
+    "english_translation": "Bat"
+  },
+  {
+    "key": "entity.minecraft.bee",
+    "english_translation": "Bee"
+  },
+  {
+    "key": "entity.minecraft.blaze",
+    "english_translation": "Blaze"
+  },
+  {
+    "key": "entity.minecraft.boat",
+    "english_translation": "Boat"
+  },
+  {
+    "key": "entity.minecraft.chest_boat",
+    "english_translation": "Boat with Chest"
+  },
+  {
+    "key": "entity.minecraft.cat",
+    "english_translation": "Cat"
+  },
+  {
+    "key": "entity.minecraft.cave_spider",
+    "english_translation": "Cave Spider"
+  },
+  {
+    "key": "entity.minecraft.chest_minecart",
+    "english_translation": "Minecart with Chest"
+  },
+  {
+    "key": "entity.minecraft.chicken",
+    "english_translation": "Chicken"
+  },
+  {
+    "key": "entity.minecraft.command_block_minecart",
+    "english_translation": "Minecart with Command Block"
+  },
+  {
+    "key": "entity.minecraft.cod",
+    "english_translation": "Cod"
+  },
+  {
+    "key": "entity.minecraft.cow",
+    "english_translation": "Cow"
+  },
+  {
+    "key": "entity.minecraft.creeper",
+    "english_translation": "Creeper"
+  },
+  {
+    "key": "entity.minecraft.dolphin",
+    "english_translation": "Dolphin"
+  },
+  {
+    "key": "entity.minecraft.donkey",
+    "english_translation": "Donkey"
+  },
+  {
+    "key": "entity.minecraft.drowned",
+    "english_translation": "Drowned"
+  },
+  {
+    "key": "entity.minecraft.dragon_fireball",
+    "english_translation": "Dragon Fireball"
+  },
+  {
+    "key": "entity.minecraft.egg",
+    "english_translation": "Thrown Egg"
+  },
+  {
+    "key": "entity.minecraft.elder_guardian",
+    "english_translation": "Elder Guardian"
+  },
+  {
+    "key": "entity.minecraft.end_crystal",
+    "english_translation": "End Crystal"
+  },
+  {
+    "key": "entity.minecraft.ender_dragon",
+    "english_translation": "Ender Dragon"
+  },
+  {
+    "key": "entity.minecraft.ender_pearl",
+    "english_translation": "Thrown Ender Pearl"
+  },
+  {
+    "key": "entity.minecraft.enderman",
+    "english_translation": "Enderman"
+  },
+  {
+    "key": "entity.minecraft.endermite",
+    "english_translation": "Endermite"
+  },
+  {
+    "key": "entity.minecraft.evoker_fangs",
+    "english_translation": "Evoker Fangs"
+  },
+  {
+    "key": "entity.minecraft.evoker",
+    "english_translation": "Evoker"
+  },
+  {
+    "key": "entity.minecraft.eye_of_ender",
+    "english_translation": "Eye of Ender"
+  },
+  {
+    "key": "entity.minecraft.falling_block",
+    "english_translation": "Falling Block"
+  },
+  {
+    "key": "entity.minecraft.fireball",
+    "english_translation": "Fireball"
+  },
+  {
+    "key": "entity.minecraft.firework_rocket",
+    "english_translation": "Firework Rocket"
+  },
+  {
+    "key": "entity.minecraft.fishing_bobber",
+    "english_translation": "Fishing Bobber"
+  },
+  {
+    "key": "entity.minecraft.fox",
+    "english_translation": "Fox"
+  },
+  {
+    "key": "entity.minecraft.frog",
+    "english_translation": "Frog"
+  },
+  {
+    "key": "entity.minecraft.furnace_minecart",
+    "english_translation": "Minecart with Furnace"
+  },
+  {
+    "key": "entity.minecraft.ghast",
+    "english_translation": "Ghast"
+  },
+  {
+    "key": "entity.minecraft.giant",
+    "english_translation": "Giant"
+  },
+  {
+    "key": "entity.minecraft.glow_item_frame",
+    "english_translation": "Glow Item Frame"
+  },
+  {
+    "key": "entity.minecraft.glow_squid",
+    "english_translation": "Glow Squid"
+  },
+  {
+    "key": "entity.minecraft.goat",
+    "english_translation": "Goat"
+  },
+  {
+    "key": "entity.minecraft.guardian",
+    "english_translation": "Guardian"
+  },
+  {
+    "key": "entity.minecraft.hoglin",
+    "english_translation": "Hoglin"
+  },
+  {
+    "key": "entity.minecraft.hopper_minecart",
+    "english_translation": "Minecart with Hopper"
+  },
+  {
+    "key": "entity.minecraft.horse",
+    "english_translation": "Horse"
+  },
+  {
+    "key": "entity.minecraft.husk",
+    "english_translation": "Husk"
+  },
+  {
+    "key": "entity.minecraft.ravager",
+    "english_translation": "Ravager"
+  },
+  {
+    "key": "entity.minecraft.illusioner",
+    "english_translation": "Illusioner"
+  },
+  {
+    "key": "entity.minecraft.item",
+    "english_translation": "Item"
+  },
+  {
+    "key": "entity.minecraft.item_frame",
+    "english_translation": "Item Frame"
+  },
+  {
+    "key": "entity.minecraft.killer_bunny",
+    "english_translation": "The Killer Bunny"
+  },
+  {
+    "key": "entity.minecraft.leash_knot",
+    "english_translation": "Leash Knot"
+  },
+  {
+    "key": "entity.minecraft.lightning_bolt",
+    "english_translation": "Lightning Bolt"
+  },
+  {
+    "key": "entity.minecraft.llama",
+    "english_translation": "Llama"
+  },
+  {
+    "key": "entity.minecraft.llama_spit",
+    "english_translation": "Llama Spit"
+  },
+  {
+    "key": "entity.minecraft.magma_cube",
+    "english_translation": "Magma Cube"
+  },
+  {
+    "key": "entity.minecraft.marker",
+    "english_translation": "Marker"
+  },
+  {
+    "key": "entity.minecraft.minecart",
+    "english_translation": "Minecart"
+  },
+  {
+    "key": "entity.minecraft.mooshroom",
+    "english_translation": "Mooshroom"
+  },
+  {
+    "key": "entity.minecraft.mule",
+    "english_translation": "Mule"
+  },
+  {
+    "key": "entity.minecraft.ocelot",
+    "english_translation": "Ocelot"
+  },
+  {
+    "key": "entity.minecraft.painting",
+    "english_translation": "Painting"
+  },
+  {
+    "key": "entity.minecraft.panda",
+    "english_translation": "Panda"
+  },
+  {
+    "key": "entity.minecraft.parrot",
+    "english_translation": "Parrot"
+  },
+  {
+    "key": "entity.minecraft.phantom",
+    "english_translation": "Phantom"
+  },
+  {
+    "key": "entity.minecraft.pig",
+    "english_translation": "Pig"
+  },
+  {
+    "key": "entity.minecraft.piglin",
+    "english_translation": "Piglin"
+  },
+  {
+    "key": "entity.minecraft.piglin_brute",
+    "english_translation": "Piglin Brute"
+  },
+  {
+    "key": "entity.minecraft.pillager",
+    "english_translation": "Pillager"
+  },
+  {
+    "key": "entity.minecraft.player",
+    "english_translation": "Player"
+  },
+  {
+    "key": "entity.minecraft.polar_bear",
+    "english_translation": "Polar Bear"
+  },
+  {
+    "key": "entity.minecraft.potion",
+    "english_translation": "Potion"
+  },
+  {
+    "key": "entity.minecraft.pufferfish",
+    "english_translation": "Pufferfish"
+  },
+  {
+    "key": "entity.minecraft.rabbit",
+    "english_translation": "Rabbit"
+  },
+  {
+    "key": "entity.minecraft.salmon",
+    "english_translation": "Salmon"
+  },
+  {
+    "key": "entity.minecraft.sheep",
+    "english_translation": "Sheep"
+  },
+  {
+    "key": "entity.minecraft.shulker",
+    "english_translation": "Shulker"
+  },
+  {
+    "key": "entity.minecraft.shulker_bullet",
+    "english_translation": "Shulker Bullet"
+  },
+  {
+    "key": "entity.minecraft.silverfish",
+    "english_translation": "Silverfish"
+  },
+  {
+    "key": "entity.minecraft.skeleton",
+    "english_translation": "Skeleton"
+  },
+  {
+    "key": "entity.minecraft.skeleton_horse",
+    "english_translation": "Skeleton Horse"
+  },
+  {
+    "key": "entity.minecraft.slime",
+    "english_translation": "Slime"
+  },
+  {
+    "key": "entity.minecraft.small_fireball",
+    "english_translation": "Small Fireball"
+  },
+  {
+    "key": "entity.minecraft.snowball",
+    "english_translation": "Snowball"
+  },
+  {
+    "key": "entity.minecraft.snow_golem",
+    "english_translation": "Snow Golem"
+  },
+  {
+    "key": "entity.minecraft.spawner_minecart",
+    "english_translation": "Minecart with Spawner"
+  },
+  {
+    "key": "entity.minecraft.spectral_arrow",
+    "english_translation": "Spectral Arrow"
+  },
+  {
+    "key": "entity.minecraft.spider",
+    "english_translation": "Spider"
+  },
+  {
+    "key": "entity.minecraft.squid",
+    "english_translation": "Squid"
+  },
+  {
+    "key": "entity.minecraft.stray",
+    "english_translation": "Stray"
+  },
+  {
+    "key": "entity.minecraft.strider",
+    "english_translation": "Strider"
+  },
+  {
+    "key": "entity.minecraft.tadpole",
+    "english_translation": "Tadpole"
+  },
+  {
+    "key": "entity.minecraft.tnt",
+    "english_translation": "Primed TNT"
+  },
+  {
+    "key": "entity.minecraft.tnt_minecart",
+    "english_translation": "Minecart with TNT"
+  },
+  {
+    "key": "entity.minecraft.trader_llama",
+    "english_translation": "Trader Llama"
+  },
+  {
+    "key": "entity.minecraft.trident",
+    "english_translation": "Trident"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish",
+    "english_translation": "Tropical Fish"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.predefined.0",
+    "english_translation": "Anemone"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.predefined.1",
+    "english_translation": "Black Tang"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.predefined.2",
+    "english_translation": "Blue Tang"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.predefined.3",
+    "english_translation": "Butterflyfish"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.predefined.4",
+    "english_translation": "Cichlid"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.predefined.5",
+    "english_translation": "Clownfish"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.predefined.6",
+    "english_translation": "Cotton Candy Betta"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.predefined.7",
+    "english_translation": "Dottyback"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.predefined.8",
+    "english_translation": "Emperor Red Snapper"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.predefined.9",
+    "english_translation": "Goatfish"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.predefined.10",
+    "english_translation": "Moorish Idol"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.predefined.11",
+    "english_translation": "Ornate Butterflyfish"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.predefined.12",
+    "english_translation": "Parrotfish"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.predefined.13",
+    "english_translation": "Queen Angelfish"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.predefined.14",
+    "english_translation": "Red Cichlid"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.predefined.15",
+    "english_translation": "Red Lipped Blenny"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.predefined.16",
+    "english_translation": "Red Snapper"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.predefined.17",
+    "english_translation": "Threadfin"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.predefined.18",
+    "english_translation": "Tomato Clownfish"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.predefined.19",
+    "english_translation": "Triggerfish"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.predefined.20",
+    "english_translation": "Yellowtail Parrotfish"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.predefined.21",
+    "english_translation": "Yellow Tang"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.type.flopper",
+    "english_translation": "Flopper"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.type.stripey",
+    "english_translation": "Stripey"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.type.glitter",
+    "english_translation": "Glitter"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.type.blockfish",
+    "english_translation": "Blockfish"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.type.betty",
+    "english_translation": "Betty"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.type.clayfish",
+    "english_translation": "Clayfish"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.type.kob",
+    "english_translation": "Kob"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.type.sunstreak",
+    "english_translation": "Sunstreak"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.type.snooper",
+    "english_translation": "Snooper"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.type.dasher",
+    "english_translation": "Dasher"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.type.brinely",
+    "english_translation": "Brinely"
+  },
+  {
+    "key": "entity.minecraft.tropical_fish.type.spotty",
+    "english_translation": "Spotty"
+  },
+  {
+    "key": "entity.minecraft.turtle",
+    "english_translation": "Turtle"
+  },
+  {
+    "key": "entity.minecraft.vex",
+    "english_translation": "Vex"
+  },
+  {
+    "key": "entity.minecraft.villager.armorer",
+    "english_translation": "Armorer"
+  },
+  {
+    "key": "entity.minecraft.villager.butcher",
+    "english_translation": "Butcher"
+  },
+  {
+    "key": "entity.minecraft.villager.cartographer",
+    "english_translation": "Cartographer"
+  },
+  {
+    "key": "entity.minecraft.villager.cleric",
+    "english_translation": "Cleric"
+  },
+  {
+    "key": "entity.minecraft.villager.farmer",
+    "english_translation": "Farmer"
+  },
+  {
+    "key": "entity.minecraft.villager.fisherman",
+    "english_translation": "Fisherman"
+  },
+  {
+    "key": "entity.minecraft.villager.fletcher",
+    "english_translation": "Fletcher"
+  },
+  {
+    "key": "entity.minecraft.villager.leatherworker",
+    "english_translation": "Leatherworker"
+  },
+  {
+    "key": "entity.minecraft.villager.librarian",
+    "english_translation": "Librarian"
+  },
+  {
+    "key": "entity.minecraft.villager.mason",
+    "english_translation": "Mason"
+  },
+  {
+    "key": "entity.minecraft.villager.none",
+    "english_translation": "Villager"
+  },
+  {
+    "key": "entity.minecraft.villager.nitwit",
+    "english_translation": "Nitwit"
+  },
+  {
+    "key": "entity.minecraft.villager.shepherd",
+    "english_translation": "Shepherd"
+  },
+  {
+    "key": "entity.minecraft.villager.toolsmith",
+    "english_translation": "Toolsmith"
+  },
+  {
+    "key": "entity.minecraft.villager.weaponsmith",
+    "english_translation": "Weaponsmith"
+  },
+  {
+    "key": "entity.minecraft.villager",
+    "english_translation": "Villager"
+  },
+  {
+    "key": "entity.minecraft.wandering_trader",
+    "english_translation": "Wandering Trader"
+  },
+  {
+    "key": "entity.minecraft.iron_golem",
+    "english_translation": "Iron Golem"
+  },
+  {
+    "key": "entity.minecraft.vindicator",
+    "english_translation": "Vindicator"
+  },
+  {
+    "key": "entity.minecraft.warden",
+    "english_translation": "Warden"
+  },
+  {
+    "key": "entity.minecraft.witch",
+    "english_translation": "Witch"
+  },
+  {
+    "key": "entity.minecraft.wither",
+    "english_translation": "Wither"
+  },
+  {
+    "key": "entity.minecraft.wither_skeleton",
+    "english_translation": "Wither Skeleton"
+  },
+  {
+    "key": "entity.minecraft.wither_skull",
+    "english_translation": "Wither Skull"
+  },
+  {
+    "key": "entity.minecraft.wolf",
+    "english_translation": "Wolf"
+  },
+  {
+    "key": "entity.minecraft.experience_bottle",
+    "english_translation": "Thrown Bottle o' Enchanting"
+  },
+  {
+    "key": "entity.minecraft.experience_orb",
+    "english_translation": "Experience Orb"
+  },
+  {
+    "key": "entity.minecraft.zoglin",
+    "english_translation": "Zoglin"
+  },
+  {
+    "key": "entity.minecraft.zombie",
+    "english_translation": "Zombie"
+  },
+  {
+    "key": "entity.minecraft.zombie_horse",
+    "english_translation": "Zombie Horse"
+  },
+  {
+    "key": "entity.minecraft.zombified_piglin",
+    "english_translation": "Zombified Piglin"
+  },
+  {
+    "key": "entity.minecraft.zombie_villager",
+    "english_translation": "Zombie Villager"
+  },
+  {
+    "key": "death.fell.accident.ladder",
+    "english_translation": "%1$s fell off a ladder"
+  },
+  {
+    "key": "death.fell.accident.vines",
+    "english_translation": "%1$s fell off some vines"
+  },
+  {
+    "key": "death.fell.accident.weeping_vines",
+    "english_translation": "%1$s fell off some weeping vines"
+  },
+  {
+    "key": "death.fell.accident.twisting_vines",
+    "english_translation": "%1$s fell off some twisting vines"
+  },
+  {
+    "key": "death.fell.accident.scaffolding",
+    "english_translation": "%1$s fell off scaffolding"
+  },
+  {
+    "key": "death.fell.accident.other_climbable",
+    "english_translation": "%1$s fell while climbing"
+  },
+  {
+    "key": "death.fell.accident.generic",
+    "english_translation": "%1$s fell from a high place"
+  },
+  {
+    "key": "death.fell.killer",
+    "english_translation": "%1$s was doomed to fall"
+  },
+  {
+    "key": "death.fell.assist",
+    "english_translation": "%1$s was doomed to fall by %2$s"
+  },
+  {
+    "key": "death.fell.assist.item",
+    "english_translation": "%1$s was doomed to fall by %2$s using %3$s"
+  },
+  {
+    "key": "death.fell.finish",
+    "english_translation": "%1$s fell too far and was finished by %2$s"
+  },
+  {
+    "key": "death.fell.finish.item",
+    "english_translation": "%1$s fell too far and was finished by %2$s using %3$s"
+  },
+  {
+    "key": "death.attack.lightningBolt",
+    "english_translation": "%1$s was struck by lightning"
+  },
+  {
+    "key": "death.attack.lightningBolt.player",
+    "english_translation": "%1$s was struck by lightning whilst fighting %2$s"
+  },
+  {
+    "key": "death.attack.inFire",
+    "english_translation": "%1$s went up in flames"
+  },
+  {
+    "key": "death.attack.inFire.player",
+    "english_translation": "%1$s walked into fire whilst fighting %2$s"
+  },
+  {
+    "key": "death.attack.onFire",
+    "english_translation": "%1$s burned to death"
+  },
+  {
+    "key": "death.attack.onFire.item",
+    "english_translation": "%1$s was burnt to a crisp whilst fighting %2$s wielding %3$s"
+  },
+  {
+    "key": "death.attack.onFire.player",
+    "english_translation": "%1$s was burnt to a crisp whilst fighting %2$s"
+  },
+  {
+    "key": "death.attack.lava",
+    "english_translation": "%1$s tried to swim in lava"
+  },
+  {
+    "key": "death.attack.lava.player",
+    "english_translation": "%1$s tried to swim in lava to escape %2$s"
+  },
+  {
+    "key": "death.attack.hotFloor",
+    "english_translation": "%1$s discovered the floor was lava"
+  },
+  {
+    "key": "death.attack.hotFloor.player",
+    "english_translation": "%1$s walked into danger zone due to %2$s"
+  },
+  {
+    "key": "death.attack.inWall",
+    "english_translation": "%1$s suffocated in a wall"
+  },
+  {
+    "key": "death.attack.inWall.player",
+    "english_translation": "%1$s suffocated in a wall whilst fighting %2$s"
+  },
+  {
+    "key": "death.attack.cramming",
+    "english_translation": "%1$s was squished too much"
+  },
+  {
+    "key": "death.attack.cramming.player",
+    "english_translation": "%1$s was squashed by %2$s"
+  },
+  {
+    "key": "death.attack.drown",
+    "english_translation": "%1$s drowned"
+  },
+  {
+    "key": "death.attack.drown.player",
+    "english_translation": "%1$s drowned whilst trying to escape %2$s"
+  },
+  {
+    "key": "death.attack.dryout",
+    "english_translation": "%1$s died from dehydration"
+  },
+  {
+    "key": "death.attack.dryout.player",
+    "english_translation": "%1$s died from dehydration whilst trying to escape %2$s"
+  },
+  {
+    "key": "death.attack.starve",
+    "english_translation": "%1$s starved to death"
+  },
+  {
+    "key": "death.attack.starve.player",
+    "english_translation": "%1$s starved to death whilst fighting %2$s"
+  },
+  {
+    "key": "death.attack.cactus",
+    "english_translation": "%1$s was pricked to death"
+  },
+  {
+    "key": "death.attack.cactus.player",
+    "english_translation": "%1$s walked into a cactus whilst trying to escape %2$s"
+  },
+  {
+    "key": "death.attack.generic",
+    "english_translation": "%1$s died"
+  },
+  {
+    "key": "death.attack.generic.player",
+    "english_translation": "%1$s died because of %2$s"
+  },
+  {
+    "key": "death.attack.explosion",
+    "english_translation": "%1$s blew up"
+  },
+  {
+    "key": "death.attack.explosion.player",
+    "english_translation": "%1$s was blown up by %2$s"
+  },
+  {
+    "key": "death.attack.explosion.player.item",
+    "english_translation": "%1$s was blown up by %2$s using %3$s"
+  },
+  {
+    "key": "death.attack.magic",
+    "english_translation": "%1$s was killed by magic"
+  },
+  {
+    "key": "death.attack.magic.player",
+    "english_translation": "%1$s was killed by magic whilst trying to escape %2$s"
+  },
+  {
+    "key": "death.attack.even_more_magic",
+    "english_translation": "%1$s was killed by even more magic"
+  },
+  {
+    "key": "death.attack.message_too_long",
+    "english_translation": "Actually, message was too long to deliver fully. Sorry! Here's stripped version: %s"
+  },
+  {
+    "key": "death.attack.wither",
+    "english_translation": "%1$s withered away"
+  },
+  {
+    "key": "death.attack.wither.player",
+    "english_translation": "%1$s withered away whilst fighting %2$s"
+  },
+  {
+    "key": "death.attack.witherSkull",
+    "english_translation": "%1$s was shot by a skull from %2$s"
+  },
+  {
+    "key": "death.attack.witherSkull.item",
+    "english_translation": "%1$s was shot by a skull from %2$s using %3$s"
+  },
+  {
+    "key": "death.attack.anvil",
+    "english_translation": "%1$s was squashed by a falling anvil"
+  },
+  {
+    "key": "death.attack.anvil.player",
+    "english_translation": "%1$s was squashed by a falling anvil whilst fighting %2$s"
+  },
+  {
+    "key": "death.attack.fallingBlock",
+    "english_translation": "%1$s was squashed by a falling block"
+  },
+  {
+    "key": "death.attack.fallingBlock.player",
+    "english_translation": "%1$s was squashed by a falling block whilst fighting %2$s"
+  },
+  {
+    "key": "death.attack.stalagmite",
+    "english_translation": "%1$s was impaled on a stalagmite"
+  },
+  {
+    "key": "death.attack.stalagmite.player",
+    "english_translation": "%1$s was impaled on a stalagmite whilst fighting %2$s"
+  },
+  {
+    "key": "death.attack.fallingStalactite",
+    "english_translation": "%1$s was skewered by a falling stalactite"
+  },
+  {
+    "key": "death.attack.fallingStalactite.player",
+    "english_translation": "%1$s was skewered by a falling stalactite whilst fighting %2$s"
+  },
+  {
+    "key": "death.attack.sonic_boom",
+    "english_translation": "%1$s was obliterated by a sonically-charged shriek"
+  },
+  {
+    "key": "death.attack.sonic_boom.item",
+    "english_translation": "%1$s was obliterated by a sonically-charged shriek whilst trying to escape %2$s wielding %3$s"
+  },
+  {
+    "key": "death.attack.sonic_boom.player",
+    "english_translation": "%1$s was obliterated by a sonically-charged shriek whilst trying to escape %2$s"
+  },
+  {
+    "key": "death.attack.mob",
+    "english_translation": "%1$s was slain by %2$s"
+  },
+  {
+    "key": "death.attack.mob.item",
+    "english_translation": "%1$s was slain by %2$s using %3$s"
+  },
+  {
+    "key": "death.attack.player",
+    "english_translation": "%1$s was slain by %2$s"
+  },
+  {
+    "key": "death.attack.player.item",
+    "english_translation": "%1$s was slain by %2$s using %3$s"
+  },
+  {
+    "key": "death.attack.arrow",
+    "english_translation": "%1$s was shot by %2$s"
+  },
+  {
+    "key": "death.attack.arrow.item",
+    "english_translation": "%1$s was shot by %2$s using %3$s"
+  },
+  {
+    "key": "death.attack.fireball",
+    "english_translation": "%1$s was fireballed by %2$s"
+  },
+  {
+    "key": "death.attack.fireball.item",
+    "english_translation": "%1$s was fireballed by %2$s using %3$s"
+  },
+  {
+    "key": "death.attack.thrown",
+    "english_translation": "%1$s was pummeled by %2$s"
+  },
+  {
+    "key": "death.attack.thrown.item",
+    "english_translation": "%1$s was pummeled by %2$s using %3$s"
+  },
+  {
+    "key": "death.attack.indirectMagic",
+    "english_translation": "%1$s was killed by %2$s using magic"
+  },
+  {
+    "key": "death.attack.indirectMagic.item",
+    "english_translation": "%1$s was killed by %2$s using %3$s"
+  },
+  {
+    "key": "death.attack.thorns",
+    "english_translation": "%1$s was killed trying to hurt %2$s"
+  },
+  {
+    "key": "death.attack.thorns.item",
+    "english_translation": "%1$s was killed by %3$s trying to hurt %2$s"
+  },
+  {
+    "key": "death.attack.trident",
+    "english_translation": "%1$s was impaled by %2$s"
+  },
+  {
+    "key": "death.attack.trident.item",
+    "english_translation": "%1$s was impaled by %2$s with %3$s"
+  },
+  {
+    "key": "death.attack.fall",
+    "english_translation": "%1$s hit the ground too hard"
+  },
+  {
+    "key": "death.attack.fall.player",
+    "english_translation": "%1$s hit the ground too hard whilst trying to escape %2$s"
+  },
+  {
+    "key": "death.attack.outOfWorld",
+    "english_translation": "%1$s fell out of the world"
+  },
+  {
+    "key": "death.attack.outOfWorld.player",
+    "english_translation": "%1$s didn't want to live in the same world as %2$s"
+  },
+  {
+    "key": "death.attack.dragonBreath",
+    "english_translation": "%1$s was roasted in dragon breath"
+  },
+  {
+    "key": "death.attack.dragonBreath.player",
+    "english_translation": "%1$s was roasted in dragon breath by %2$s"
+  },
+  {
+    "key": "death.attack.flyIntoWall",
+    "english_translation": "%1$s experienced kinetic energy"
+  },
+  {
+    "key": "death.attack.flyIntoWall.player",
+    "english_translation": "%1$s experienced kinetic energy whilst trying to escape %2$s"
+  },
+  {
+    "key": "death.attack.fireworks",
+    "english_translation": "%1$s went off with a bang"
+  },
+  {
+    "key": "death.attack.fireworks.player",
+    "english_translation": "%1$s went off with a bang whilst fighting %2$s"
+  },
+  {
+    "key": "death.attack.fireworks.item",
+    "english_translation": "%1$s went off with a bang due to a firework fired from %3$s by %2$s"
+  },
+  {
+    "key": "death.attack.badRespawnPoint.message",
+    "english_translation": "%1$s was killed by %2$s"
+  },
+  {
+    "key": "death.attack.badRespawnPoint.link",
+    "english_translation": "Intentional Game Design"
+  },
+  {
+    "key": "death.attack.sweetBerryBush",
+    "english_translation": "%1$s was poked to death by a sweet berry bush"
+  },
+  {
+    "key": "death.attack.sweetBerryBush.player",
+    "english_translation": "%1$s was poked to death by a sweet berry bush whilst trying to escape %2$s"
+  },
+  {
+    "key": "death.attack.sting",
+    "english_translation": "%1$s was stung to death"
+  },
+  {
+    "key": "death.attack.sting.item",
+    "english_translation": "%1$s was stung to death by %2$s using %3$s"
+  },
+  {
+    "key": "death.attack.sting.player",
+    "english_translation": "%1$s was stung to death by %2$s"
+  },
+  {
+    "key": "death.attack.freeze",
+    "english_translation": "%1$s froze to death"
+  },
+  {
+    "key": "death.attack.freeze.player",
+    "english_translation": "%1$s was frozen to death by %2$s"
+  },
+  {
+    "key": "deathScreen.respawn",
+    "english_translation": "Respawn"
+  },
+  {
+    "key": "deathScreen.spectate",
+    "english_translation": "Spectate World"
+  },
+  {
+    "key": "deathScreen.titleScreen",
+    "english_translation": "Title Screen"
+  },
+  {
+    "key": "deathScreen.score",
+    "english_translation": "Score"
+  },
+  {
+    "key": "deathScreen.title.hardcore",
+    "english_translation": "Game Over!"
+  },
+  {
+    "key": "deathScreen.title",
+    "english_translation": "You Died!"
+  },
+  {
+    "key": "deathScreen.quit.confirm",
+    "english_translation": "Are you sure you want to quit?"
+  },
+  {
+    "key": "effect.none",
+    "english_translation": "No Effects"
+  },
+  {
+    "key": "effect.minecraft.speed",
+    "english_translation": "Speed"
+  },
+  {
+    "key": "effect.minecraft.slowness",
+    "english_translation": "Slowness"
+  },
+  {
+    "key": "effect.minecraft.haste",
+    "english_translation": "Haste"
+  },
+  {
+    "key": "effect.minecraft.mining_fatigue",
+    "english_translation": "Mining Fatigue"
+  },
+  {
+    "key": "effect.minecraft.strength",
+    "english_translation": "Strength"
+  },
+  {
+    "key": "effect.minecraft.instant_health",
+    "english_translation": "Instant Health"
+  },
+  {
+    "key": "effect.minecraft.instant_damage",
+    "english_translation": "Instant Damage"
+  },
+  {
+    "key": "effect.minecraft.jump_boost",
+    "english_translation": "Jump Boost"
+  },
+  {
+    "key": "effect.minecraft.nausea",
+    "english_translation": "Nausea"
+  },
+  {
+    "key": "effect.minecraft.regeneration",
+    "english_translation": "Regeneration"
+  },
+  {
+    "key": "effect.minecraft.resistance",
+    "english_translation": "Resistance"
+  },
+  {
+    "key": "effect.minecraft.fire_resistance",
+    "english_translation": "Fire Resistance"
+  },
+  {
+    "key": "effect.minecraft.water_breathing",
+    "english_translation": "Water Breathing"
+  },
+  {
+    "key": "effect.minecraft.invisibility",
+    "english_translation": "Invisibility"
+  },
+  {
+    "key": "effect.minecraft.blindness",
+    "english_translation": "Blindness"
+  },
+  {
+    "key": "effect.minecraft.night_vision",
+    "english_translation": "Night Vision"
+  },
+  {
+    "key": "effect.minecraft.hunger",
+    "english_translation": "Hunger"
+  },
+  {
+    "key": "effect.minecraft.weakness",
+    "english_translation": "Weakness"
+  },
+  {
+    "key": "effect.minecraft.poison",
+    "english_translation": "Poison"
+  },
+  {
+    "key": "effect.minecraft.wither",
+    "english_translation": "Wither"
+  },
+  {
+    "key": "effect.minecraft.health_boost",
+    "english_translation": "Health Boost"
+  },
+  {
+    "key": "effect.minecraft.absorption",
+    "english_translation": "Absorption"
+  },
+  {
+    "key": "effect.minecraft.saturation",
+    "english_translation": "Saturation"
+  },
+  {
+    "key": "effect.minecraft.glowing",
+    "english_translation": "Glowing"
+  },
+  {
+    "key": "effect.minecraft.luck",
+    "english_translation": "Luck"
+  },
+  {
+    "key": "effect.minecraft.unluck",
+    "english_translation": "Bad Luck"
+  },
+  {
+    "key": "effect.minecraft.levitation",
+    "english_translation": "Levitation"
+  },
+  {
+    "key": "effect.minecraft.slow_falling",
+    "english_translation": "Slow Falling"
+  },
+  {
+    "key": "effect.minecraft.conduit_power",
+    "english_translation": "Conduit Power"
+  },
+  {
+    "key": "effect.minecraft.dolphins_grace",
+    "english_translation": "Dolphin's Grace"
+  },
+  {
+    "key": "effect.minecraft.bad_omen",
+    "english_translation": "Bad Omen"
+  },
+  {
+    "key": "effect.minecraft.hero_of_the_village",
+    "english_translation": "Hero of the Village"
+  },
+  {
+    "key": "effect.minecraft.darkness",
+    "english_translation": "Darkness"
+  },
+  {
+    "key": "event.minecraft.raid",
+    "english_translation": "Raid"
+  },
+  {
+    "key": "event.minecraft.raid.raiders_remaining",
+    "english_translation": "Raiders Remaining: %s"
+  },
+  {
+    "key": "event.minecraft.raid.victory",
+    "english_translation": "Victory"
+  },
+  {
+    "key": "event.minecraft.raid.defeat",
+    "english_translation": "Defeat"
+  },
+  {
+    "key": "item.minecraft.tipped_arrow.effect.empty",
+    "english_translation": "Uncraftable Tipped Arrow"
+  },
+  {
+    "key": "item.minecraft.tipped_arrow.effect.water",
+    "english_translation": "Arrow of Splashing"
+  },
+  {
+    "key": "item.minecraft.tipped_arrow.effect.mundane",
+    "english_translation": "Tipped Arrow"
+  },
+  {
+    "key": "item.minecraft.tipped_arrow.effect.thick",
+    "english_translation": "Tipped Arrow"
+  },
+  {
+    "key": "item.minecraft.tipped_arrow.effect.awkward",
+    "english_translation": "Tipped Arrow"
+  },
+  {
+    "key": "item.minecraft.tipped_arrow.effect.night_vision",
+    "english_translation": "Arrow of Night Vision"
+  },
+  {
+    "key": "item.minecraft.tipped_arrow.effect.invisibility",
+    "english_translation": "Arrow of Invisibility"
+  },
+  {
+    "key": "item.minecraft.tipped_arrow.effect.leaping",
+    "english_translation": "Arrow of Leaping"
+  },
+  {
+    "key": "item.minecraft.tipped_arrow.effect.fire_resistance",
+    "english_translation": "Arrow of Fire Resistance"
+  },
+  {
+    "key": "item.minecraft.tipped_arrow.effect.swiftness",
+    "english_translation": "Arrow of Swiftness"
+  },
+  {
+    "key": "item.minecraft.tipped_arrow.effect.slowness",
+    "english_translation": "Arrow of Slowness"
+  },
+  {
+    "key": "item.minecraft.tipped_arrow.effect.water_breathing",
+    "english_translation": "Arrow of Water Breathing"
+  },
+  {
+    "key": "item.minecraft.tipped_arrow.effect.healing",
+    "english_translation": "Arrow of Healing"
+  },
+  {
+    "key": "item.minecraft.tipped_arrow.effect.harming",
+    "english_translation": "Arrow of Harming"
+  },
+  {
+    "key": "item.minecraft.tipped_arrow.effect.poison",
+    "english_translation": "Arrow of Poison"
+  },
+  {
+    "key": "item.minecraft.tipped_arrow.effect.regeneration",
+    "english_translation": "Arrow of Regeneration"
+  },
+  {
+    "key": "item.minecraft.tipped_arrow.effect.strength",
+    "english_translation": "Arrow of Strength"
+  },
+  {
+    "key": "item.minecraft.tipped_arrow.effect.weakness",
+    "english_translation": "Arrow of Weakness"
+  },
+  {
+    "key": "item.minecraft.tipped_arrow.effect.levitation",
+    "english_translation": "Arrow of Levitation"
+  },
+  {
+    "key": "item.minecraft.tipped_arrow.effect.luck",
+    "english_translation": "Arrow of Luck"
+  },
+  {
+    "key": "item.minecraft.tipped_arrow.effect.turtle_master",
+    "english_translation": "Arrow of the Turtle Master"
+  },
+  {
+    "key": "item.minecraft.tipped_arrow.effect.slow_falling",
+    "english_translation": "Arrow of Slow Falling"
+  },
+  {
+    "key": "potion.whenDrank",
+    "english_translation": "When Applied:"
+  },
+  {
+    "key": "potion.withAmplifier",
+    "english_translation": "%s %s"
+  },
+  {
+    "key": "potion.withDuration",
+    "english_translation": "%s (%s)"
+  },
+  {
+    "key": "item.minecraft.potion.effect.empty",
+    "english_translation": "Uncraftable Potion"
+  },
+  {
+    "key": "item.minecraft.potion.effect.water",
+    "english_translation": "Water Bottle"
+  },
+  {
+    "key": "item.minecraft.potion.effect.mundane",
+    "english_translation": "Mundane Potion"
+  },
+  {
+    "key": "item.minecraft.potion.effect.thick",
+    "english_translation": "Thick Potion"
+  },
+  {
+    "key": "item.minecraft.potion.effect.awkward",
+    "english_translation": "Awkward Potion"
+  },
+  {
+    "key": "item.minecraft.potion.effect.night_vision",
+    "english_translation": "Potion of Night Vision"
+  },
+  {
+    "key": "item.minecraft.potion.effect.invisibility",
+    "english_translation": "Potion of Invisibility"
+  },
+  {
+    "key": "item.minecraft.potion.effect.leaping",
+    "english_translation": "Potion of Leaping"
+  },
+  {
+    "key": "item.minecraft.potion.effect.fire_resistance",
+    "english_translation": "Potion of Fire Resistance"
+  },
+  {
+    "key": "item.minecraft.potion.effect.swiftness",
+    "english_translation": "Potion of Swiftness"
+  },
+  {
+    "key": "item.minecraft.potion.effect.slowness",
+    "english_translation": "Potion of Slowness"
+  },
+  {
+    "key": "item.minecraft.potion.effect.water_breathing",
+    "english_translation": "Potion of Water Breathing"
+  },
+  {
+    "key": "item.minecraft.potion.effect.healing",
+    "english_translation": "Potion of Healing"
+  },
+  {
+    "key": "item.minecraft.potion.effect.harming",
+    "english_translation": "Potion of Harming"
+  },
+  {
+    "key": "item.minecraft.potion.effect.poison",
+    "english_translation": "Potion of Poison"
+  },
+  {
+    "key": "item.minecraft.potion.effect.regeneration",
+    "english_translation": "Potion of Regeneration"
+  },
+  {
+    "key": "item.minecraft.potion.effect.strength",
+    "english_translation": "Potion of Strength"
+  },
+  {
+    "key": "item.minecraft.potion.effect.weakness",
+    "english_translation": "Potion of Weakness"
+  },
+  {
+    "key": "item.minecraft.potion.effect.levitation",
+    "english_translation": "Potion of Levitation"
+  },
+  {
+    "key": "item.minecraft.potion.effect.luck",
+    "english_translation": "Potion of Luck"
+  },
+  {
+    "key": "item.minecraft.potion.effect.turtle_master",
+    "english_translation": "Potion of the Turtle Master"
+  },
+  {
+    "key": "item.minecraft.potion.effect.slow_falling",
+    "english_translation": "Potion of Slow Falling"
+  },
+  {
+    "key": "item.minecraft.splash_potion.effect.empty",
+    "english_translation": "Splash Uncraftable Potion"
+  },
+  {
+    "key": "item.minecraft.splash_potion.effect.water",
+    "english_translation": "Splash Water Bottle"
+  },
+  {
+    "key": "item.minecraft.splash_potion.effect.mundane",
+    "english_translation": "Mundane Splash Potion"
+  },
+  {
+    "key": "item.minecraft.splash_potion.effect.thick",
+    "english_translation": "Thick Splash Potion"
+  },
+  {
+    "key": "item.minecraft.splash_potion.effect.awkward",
+    "english_translation": "Awkward Splash Potion"
+  },
+  {
+    "key": "item.minecraft.splash_potion.effect.night_vision",
+    "english_translation": "Splash Potion of Night Vision"
+  },
+  {
+    "key": "item.minecraft.splash_potion.effect.invisibility",
+    "english_translation": "Splash Potion of Invisibility"
+  },
+  {
+    "key": "item.minecraft.splash_potion.effect.leaping",
+    "english_translation": "Splash Potion of Leaping"
+  },
+  {
+    "key": "item.minecraft.splash_potion.effect.fire_resistance",
+    "english_translation": "Splash Potion of Fire Resistance"
+  },
+  {
+    "key": "item.minecraft.splash_potion.effect.swiftness",
+    "english_translation": "Splash Potion of Swiftness"
+  },
+  {
+    "key": "item.minecraft.splash_potion.effect.slowness",
+    "english_translation": "Splash Potion of Slowness"
+  },
+  {
+    "key": "item.minecraft.splash_potion.effect.water_breathing",
+    "english_translation": "Splash Potion of Water Breathing"
+  },
+  {
+    "key": "item.minecraft.splash_potion.effect.healing",
+    "english_translation": "Splash Potion of Healing"
+  },
+  {
+    "key": "item.minecraft.splash_potion.effect.harming",
+    "english_translation": "Splash Potion of Harming"
+  },
+  {
+    "key": "item.minecraft.splash_potion.effect.poison",
+    "english_translation": "Splash Potion of Poison"
+  },
+  {
+    "key": "item.minecraft.splash_potion.effect.regeneration",
+    "english_translation": "Splash Potion of Regeneration"
+  },
+  {
+    "key": "item.minecraft.splash_potion.effect.strength",
+    "english_translation": "Splash Potion of Strength"
+  },
+  {
+    "key": "item.minecraft.splash_potion.effect.weakness",
+    "english_translation": "Splash Potion of Weakness"
+  },
+  {
+    "key": "item.minecraft.splash_potion.effect.levitation",
+    "english_translation": "Splash Potion of Levitation"
+  },
+  {
+    "key": "item.minecraft.splash_potion.effect.luck",
+    "english_translation": "Splash Potion of Luck"
+  },
+  {
+    "key": "item.minecraft.splash_potion.effect.turtle_master",
+    "english_translation": "Splash Potion of the Turtle Master"
+  },
+  {
+    "key": "item.minecraft.splash_potion.effect.slow_falling",
+    "english_translation": "Splash Potion of Slow Falling"
+  },
+  {
+    "key": "item.minecraft.lingering_potion.effect.empty",
+    "english_translation": "Lingering Uncraftable Potion"
+  },
+  {
+    "key": "item.minecraft.lingering_potion.effect.water",
+    "english_translation": "Lingering Water Bottle"
+  },
+  {
+    "key": "item.minecraft.lingering_potion.effect.mundane",
+    "english_translation": "Mundane Lingering Potion"
+  },
+  {
+    "key": "item.minecraft.lingering_potion.effect.thick",
+    "english_translation": "Thick Lingering Potion"
+  },
+  {
+    "key": "item.minecraft.lingering_potion.effect.awkward",
+    "english_translation": "Awkward Lingering Potion"
+  },
+  {
+    "key": "item.minecraft.lingering_potion.effect.night_vision",
+    "english_translation": "Lingering Potion of Night Vision"
+  },
+  {
+    "key": "item.minecraft.lingering_potion.effect.invisibility",
+    "english_translation": "Lingering Potion of Invisibility"
+  },
+  {
+    "key": "item.minecraft.lingering_potion.effect.leaping",
+    "english_translation": "Lingering Potion of Leaping"
+  },
+  {
+    "key": "item.minecraft.lingering_potion.effect.fire_resistance",
+    "english_translation": "Lingering Potion of Fire Resistance"
+  },
+  {
+    "key": "item.minecraft.lingering_potion.effect.swiftness",
+    "english_translation": "Lingering Potion of Swiftness"
+  },
+  {
+    "key": "item.minecraft.lingering_potion.effect.slowness",
+    "english_translation": "Lingering Potion of Slowness"
+  },
+  {
+    "key": "item.minecraft.lingering_potion.effect.water_breathing",
+    "english_translation": "Lingering Potion of Water Breathing"
+  },
+  {
+    "key": "item.minecraft.lingering_potion.effect.healing",
+    "english_translation": "Lingering Potion of Healing"
+  },
+  {
+    "key": "item.minecraft.lingering_potion.effect.harming",
+    "english_translation": "Lingering Potion of Harming"
+  },
+  {
+    "key": "item.minecraft.lingering_potion.effect.poison",
+    "english_translation": "Lingering Potion of Poison"
+  },
+  {
+    "key": "item.minecraft.lingering_potion.effect.regeneration",
+    "english_translation": "Lingering Potion of Regeneration"
+  },
+  {
+    "key": "item.minecraft.lingering_potion.effect.strength",
+    "english_translation": "Lingering Potion of Strength"
+  },
+  {
+    "key": "item.minecraft.lingering_potion.effect.weakness",
+    "english_translation": "Lingering Potion of Weakness"
+  },
+  {
+    "key": "item.minecraft.lingering_potion.effect.levitation",
+    "english_translation": "Lingering Potion of Levitation"
+  },
+  {
+    "key": "item.minecraft.lingering_potion.effect.luck",
+    "english_translation": "Lingering Potion of Luck"
+  },
+  {
+    "key": "item.minecraft.lingering_potion.effect.turtle_master",
+    "english_translation": "Lingering Potion of the Turtle Master"
+  },
+  {
+    "key": "item.minecraft.lingering_potion.effect.slow_falling",
+    "english_translation": "Lingering Potion of Slow Falling"
+  },
+  {
+    "key": "potion.potency.0",
+    "english_translation": ""
+  },
+  {
+    "key": "potion.potency.1",
+    "english_translation": "II"
+  },
+  {
+    "key": "potion.potency.2",
+    "english_translation": "III"
+  },
+  {
+    "key": "potion.potency.3",
+    "english_translation": "IV"
+  },
+  {
+    "key": "potion.potency.4",
+    "english_translation": "V"
+  },
+  {
+    "key": "potion.potency.5",
+    "english_translation": "VI"
+  },
+  {
+    "key": "enchantment.minecraft.sharpness",
+    "english_translation": "Sharpness"
+  },
+  {
+    "key": "enchantment.minecraft.smite",
+    "english_translation": "Smite"
+  },
+  {
+    "key": "enchantment.minecraft.bane_of_arthropods",
+    "english_translation": "Bane of Arthropods"
+  },
+  {
+    "key": "enchantment.minecraft.knockback",
+    "english_translation": "Knockback"
+  },
+  {
+    "key": "enchantment.minecraft.fire_aspect",
+    "english_translation": "Fire Aspect"
+  },
+  {
+    "key": "enchantment.minecraft.sweeping",
+    "english_translation": "Sweeping Edge"
+  },
+  {
+    "key": "enchantment.minecraft.protection",
+    "english_translation": "Protection"
+  },
+  {
+    "key": "enchantment.minecraft.fire_protection",
+    "english_translation": "Fire Protection"
+  },
+  {
+    "key": "enchantment.minecraft.feather_falling",
+    "english_translation": "Feather Falling"
+  },
+  {
+    "key": "enchantment.minecraft.blast_protection",
+    "english_translation": "Blast Protection"
+  },
+  {
+    "key": "enchantment.minecraft.projectile_protection",
+    "english_translation": "Projectile Protection"
+  },
+  {
+    "key": "enchantment.minecraft.respiration",
+    "english_translation": "Respiration"
+  },
+  {
+    "key": "enchantment.minecraft.aqua_affinity",
+    "english_translation": "Aqua Affinity"
+  },
+  {
+    "key": "enchantment.minecraft.depth_strider",
+    "english_translation": "Depth Strider"
+  },
+  {
+    "key": "enchantment.minecraft.frost_walker",
+    "english_translation": "Frost Walker"
+  },
+  {
+    "key": "enchantment.minecraft.soul_speed",
+    "english_translation": "Soul Speed"
+  },
+  {
+    "key": "enchantment.minecraft.swift_sneak",
+    "english_translation": "Swift Sneak"
+  },
+  {
+    "key": "enchantment.minecraft.efficiency",
+    "english_translation": "Efficiency"
+  },
+  {
+    "key": "enchantment.minecraft.silk_touch",
+    "english_translation": "Silk Touch"
+  },
+  {
+    "key": "enchantment.minecraft.unbreaking",
+    "english_translation": "Unbreaking"
+  },
+  {
+    "key": "enchantment.minecraft.looting",
+    "english_translation": "Looting"
+  },
+  {
+    "key": "enchantment.minecraft.fortune",
+    "english_translation": "Fortune"
+  },
+  {
+    "key": "enchantment.minecraft.luck_of_the_sea",
+    "english_translation": "Luck of the Sea"
+  },
+  {
+    "key": "enchantment.minecraft.lure",
+    "english_translation": "Lure"
+  },
+  {
+    "key": "enchantment.minecraft.power",
+    "english_translation": "Power"
+  },
+  {
+    "key": "enchantment.minecraft.flame",
+    "english_translation": "Flame"
+  },
+  {
+    "key": "enchantment.minecraft.punch",
+    "english_translation": "Punch"
+  },
+  {
+    "key": "enchantment.minecraft.infinity",
+    "english_translation": "Infinity"
+  },
+  {
+    "key": "enchantment.minecraft.thorns",
+    "english_translation": "Thorns"
+  },
+  {
+    "key": "enchantment.minecraft.mending",
+    "english_translation": "Mending"
+  },
+  {
+    "key": "enchantment.minecraft.binding_curse",
+    "english_translation": "Curse of Binding"
+  },
+  {
+    "key": "enchantment.minecraft.vanishing_curse",
+    "english_translation": "Curse of Vanishing"
+  },
+  {
+    "key": "enchantment.minecraft.loyalty",
+    "english_translation": "Loyalty"
+  },
+  {
+    "key": "enchantment.minecraft.impaling",
+    "english_translation": "Impaling"
+  },
+  {
+    "key": "enchantment.minecraft.riptide",
+    "english_translation": "Riptide"
+  },
+  {
+    "key": "enchantment.minecraft.channeling",
+    "english_translation": "Channeling"
+  },
+  {
+    "key": "enchantment.minecraft.multishot",
+    "english_translation": "Multishot"
+  },
+  {
+    "key": "enchantment.minecraft.quick_charge",
+    "english_translation": "Quick Charge"
+  },
+  {
+    "key": "enchantment.minecraft.piercing",
+    "english_translation": "Piercing"
+  },
+  {
+    "key": "enchantment.level.1",
+    "english_translation": "I"
+  },
+  {
+    "key": "enchantment.level.2",
+    "english_translation": "II"
+  },
+  {
+    "key": "enchantment.level.3",
+    "english_translation": "III"
+  },
+  {
+    "key": "enchantment.level.4",
+    "english_translation": "IV"
+  },
+  {
+    "key": "enchantment.level.5",
+    "english_translation": "V"
+  },
+  {
+    "key": "enchantment.level.6",
+    "english_translation": "VI"
+  },
+  {
+    "key": "enchantment.level.7",
+    "english_translation": "VII"
+  },
+  {
+    "key": "enchantment.level.8",
+    "english_translation": "VIII"
+  },
+  {
+    "key": "enchantment.level.9",
+    "english_translation": "IX"
+  },
+  {
+    "key": "enchantment.level.10",
+    "english_translation": "X"
+  },
+  {
+    "key": "gui.minutes",
+    "english_translation": "%s minute(s)"
+  },
+  {
+    "key": "gui.hours",
+    "english_translation": "%s hour(s)"
+  },
+  {
+    "key": "gui.days",
+    "english_translation": "%s day(s)"
+  },
+  {
+    "key": "gui.advancements",
+    "english_translation": "Advancements"
+  },
+  {
+    "key": "gui.stats",
+    "english_translation": "Statistics"
+  },
+  {
+    "key": "gui.entity_tooltip.type",
+    "english_translation": "Type: %s"
+  },
+  {
+    "key": "advancements.empty",
+    "english_translation": "There doesn't seem to be anything here..."
+  },
+  {
+    "key": "advancements.sad_label",
+    "english_translation": ":("
+  },
+  {
+    "key": "advancements.toast.task",
+    "english_translation": "Advancement Made!"
+  },
+  {
+    "key": "advancements.toast.challenge",
+    "english_translation": "Challenge Complete!"
+  },
+  {
+    "key": "advancements.toast.goal",
+    "english_translation": "Goal Reached!"
+  },
+  {
+    "key": "stats.tooltip.type.statistic",
+    "english_translation": "Statistic"
+  },
+  {
+    "key": "stat.generalButton",
+    "english_translation": "General"
+  },
+  {
+    "key": "stat.itemsButton",
+    "english_translation": "Items"
+  },
+  {
+    "key": "stat.mobsButton",
+    "english_translation": "Mobs"
+  },
+  {
+    "key": "stat_type.minecraft.mined",
+    "english_translation": "Times Mined"
+  },
+  {
+    "key": "stat_type.minecraft.crafted",
+    "english_translation": "Times Crafted"
+  },
+  {
+    "key": "stat_type.minecraft.used",
+    "english_translation": "Times Used"
+  },
+  {
+    "key": "stat_type.minecraft.broken",
+    "english_translation": "Times Broken"
+  },
+  {
+    "key": "stat_type.minecraft.picked_up",
+    "english_translation": "Picked Up"
+  },
+  {
+    "key": "stat_type.minecraft.dropped",
+    "english_translation": "Dropped"
+  },
+  {
+    "key": "stat_type.minecraft.killed",
+    "english_translation": "You killed %s %s"
+  },
+  {
+    "key": "stat_type.minecraft.killed.none",
+    "english_translation": "You have never killed %s"
+  },
+  {
+    "key": "stat_type.minecraft.killed_by",
+    "english_translation": "%s killed you %s time(s)"
+  },
+  {
+    "key": "stat_type.minecraft.killed_by.none",
+    "english_translation": "You have never been killed by %s"
+  },
+  {
+    "key": "stat.minecraft.animals_bred",
+    "english_translation": "Animals Bred"
+  },
+  {
+    "key": "stat.minecraft.aviate_one_cm",
+    "english_translation": "Distance by Elytra"
+  },
+  {
+    "key": "stat.minecraft.clean_armor",
+    "english_translation": "Armor Pieces Cleaned"
+  },
+  {
+    "key": "stat.minecraft.clean_banner",
+    "english_translation": "Banners Cleaned"
+  },
+  {
+    "key": "stat.minecraft.clean_shulker_box",
+    "english_translation": "Shulker Boxes Cleaned"
+  },
+  {
+    "key": "stat.minecraft.climb_one_cm",
+    "english_translation": "Distance Climbed"
+  },
+  {
+    "key": "stat.minecraft.bell_ring",
+    "english_translation": "Bells Rung"
+  },
+  {
+    "key": "stat.minecraft.target_hit",
+    "english_translation": "Targets Hit"
+  },
+  {
+    "key": "stat.minecraft.boat_one_cm",
+    "english_translation": "Distance by Boat"
+  },
+  {
+    "key": "stat.minecraft.crouch_one_cm",
+    "english_translation": "Distance Crouched"
+  },
+  {
+    "key": "stat.minecraft.damage_dealt",
+    "english_translation": "Damage Dealt"
+  },
+  {
+    "key": "stat.minecraft.damage_dealt_absorbed",
+    "english_translation": "Damage Dealt (Absorbed)"
+  },
+  {
+    "key": "stat.minecraft.damage_dealt_resisted",
+    "english_translation": "Damage Dealt (Resisted)"
+  },
+  {
+    "key": "stat.minecraft.damage_taken",
+    "english_translation": "Damage Taken"
+  },
+  {
+    "key": "stat.minecraft.damage_blocked_by_shield",
+    "english_translation": "Damage Blocked by Shield"
+  },
+  {
+    "key": "stat.minecraft.damage_absorbed",
+    "english_translation": "Damage Absorbed"
+  },
+  {
+    "key": "stat.minecraft.damage_resisted",
+    "english_translation": "Damage Resisted"
+  },
+  {
+    "key": "stat.minecraft.deaths",
+    "english_translation": "Number of Deaths"
+  },
+  {
+    "key": "stat.minecraft.walk_under_water_one_cm",
+    "english_translation": "Distance Walked under Water"
+  },
+  {
+    "key": "stat.minecraft.drop",
+    "english_translation": "Items Dropped"
+  },
+  {
+    "key": "stat.minecraft.eat_cake_slice",
+    "english_translation": "Cake Slices Eaten"
+  },
+  {
+    "key": "stat.minecraft.enchant_item",
+    "english_translation": "Items Enchanted"
+  },
+  {
+    "key": "stat.minecraft.fall_one_cm",
+    "english_translation": "Distance Fallen"
+  },
+  {
+    "key": "stat.minecraft.fill_cauldron",
+    "english_translation": "Cauldrons Filled"
+  },
+  {
+    "key": "stat.minecraft.fish_caught",
+    "english_translation": "Fish Caught"
+  },
+  {
+    "key": "stat.minecraft.fly_one_cm",
+    "english_translation": "Distance Flown"
+  },
+  {
+    "key": "stat.minecraft.horse_one_cm",
+    "english_translation": "Distance by Horse"
+  },
+  {
+    "key": "stat.minecraft.inspect_dispenser",
+    "english_translation": "Dispensers Searched"
+  },
+  {
+    "key": "stat.minecraft.inspect_dropper",
+    "english_translation": "Droppers Searched"
+  },
+  {
+    "key": "stat.minecraft.inspect_hopper",
+    "english_translation": "Hoppers Searched"
+  },
+  {
+    "key": "stat.minecraft.interact_with_anvil",
+    "english_translation": "Interactions with Anvil"
+  },
+  {
+    "key": "stat.minecraft.interact_with_beacon",
+    "english_translation": "Interactions with Beacon"
+  },
+  {
+    "key": "stat.minecraft.interact_with_brewingstand",
+    "english_translation": "Interactions with Brewing Stand"
+  },
+  {
+    "key": "stat.minecraft.interact_with_campfire",
+    "english_translation": "Interactions with Campfire"
+  },
+  {
+    "key": "stat.minecraft.interact_with_cartography_table",
+    "english_translation": "Interactions with Cartography Table"
+  },
+  {
+    "key": "stat.minecraft.interact_with_crafting_table",
+    "english_translation": "Interactions with Crafting Table"
+  },
+  {
+    "key": "stat.minecraft.interact_with_furnace",
+    "english_translation": "Interactions with Furnace"
+  },
+  {
+    "key": "stat.minecraft.interact_with_grindstone",
+    "english_translation": "Interactions with Grindstone"
+  },
+  {
+    "key": "stat.minecraft.interact_with_lectern",
+    "english_translation": "Interactions with Lectern"
+  },
+  {
+    "key": "stat.minecraft.interact_with_loom",
+    "english_translation": "Interactions with Loom"
+  },
+  {
+    "key": "stat.minecraft.interact_with_blast_furnace",
+    "english_translation": "Interactions with Blast Furnace"
+  },
+  {
+    "key": "stat.minecraft.interact_with_smithing_table",
+    "english_translation": "Interactions with Smithing Table"
+  },
+  {
+    "key": "stat.minecraft.interact_with_smoker",
+    "english_translation": "Interactions with Smoker"
+  },
+  {
+    "key": "stat.minecraft.interact_with_stonecutter",
+    "english_translation": "Interactions with Stonecutter"
+  },
+  {
+    "key": "stat.minecraft.jump",
+    "english_translation": "Jumps"
+  },
+  {
+    "key": "stat.minecraft.junk_fished",
+    "english_translation": "Junk Fished"
+  },
+  {
+    "key": "stat.minecraft.leave_game",
+    "english_translation": "Games Quit"
+  },
+  {
+    "key": "stat.minecraft.minecart_one_cm",
+    "english_translation": "Distance by Minecart"
+  },
+  {
+    "key": "stat.minecraft.mob_kills",
+    "english_translation": "Mob Kills"
+  },
+  {
+    "key": "stat.minecraft.open_barrel",
+    "english_translation": "Barrels Opened"
+  },
+  {
+    "key": "stat.minecraft.open_chest",
+    "english_translation": "Chests Opened"
+  },
+  {
+    "key": "stat.minecraft.open_enderchest",
+    "english_translation": "Ender Chests Opened"
+  },
+  {
+    "key": "stat.minecraft.open_shulker_box",
+    "english_translation": "Shulker Boxes Opened"
+  },
+  {
+    "key": "stat.minecraft.pig_one_cm",
+    "english_translation": "Distance by Pig"
+  },
+  {
+    "key": "stat.minecraft.strider_one_cm",
+    "english_translation": "Distance by Strider"
+  },
+  {
+    "key": "stat.minecraft.player_kills",
+    "english_translation": "Player Kills"
+  },
+  {
+    "key": "stat.minecraft.play_noteblock",
+    "english_translation": "Note Blocks Played"
+  },
+  {
+    "key": "stat.minecraft.play_time",
+    "english_translation": "Time Played"
+  },
+  {
+    "key": "stat.minecraft.play_record",
+    "english_translation": "Music Discs Played"
+  },
+  {
+    "key": "stat.minecraft.pot_flower",
+    "english_translation": "Plants Potted"
+  },
+  {
+    "key": "stat.minecraft.raid_trigger",
+    "english_translation": "Raids Triggered"
+  },
+  {
+    "key": "stat.minecraft.raid_win",
+    "english_translation": "Raids Won"
+  },
+  {
+    "key": "stat.minecraft.ring_bell",
+    "english_translation": "Bells Rung"
+  },
+  {
+    "key": "stat.minecraft.sleep_in_bed",
+    "english_translation": "Times Slept in a Bed"
+  },
+  {
+    "key": "stat.minecraft.sneak_time",
+    "english_translation": "Sneak Time"
+  },
+  {
+    "key": "stat.minecraft.sprint_one_cm",
+    "english_translation": "Distance Sprinted"
+  },
+  {
+    "key": "stat.minecraft.walk_on_water_one_cm",
+    "english_translation": "Distance Walked on Water"
+  },
+  {
+    "key": "stat.minecraft.swim_one_cm",
+    "english_translation": "Distance Swum"
+  },
+  {
+    "key": "stat.minecraft.talked_to_villager",
+    "english_translation": "Talked to Villagers"
+  },
+  {
+    "key": "stat.minecraft.time_since_rest",
+    "english_translation": "Time Since Last Rest"
+  },
+  {
+    "key": "stat.minecraft.time_since_death",
+    "english_translation": "Time Since Last Death"
+  },
+  {
+    "key": "stat.minecraft.total_world_time",
+    "english_translation": "Time with World Open"
+  },
+  {
+    "key": "stat.minecraft.traded_with_villager",
+    "english_translation": "Traded with Villagers"
+  },
+  {
+    "key": "stat.minecraft.treasure_fished",
+    "english_translation": "Treasure Fished"
+  },
+  {
+    "key": "stat.minecraft.trigger_trapped_chest",
+    "english_translation": "Trapped Chests Triggered"
+  },
+  {
+    "key": "stat.minecraft.tune_noteblock",
+    "english_translation": "Note Blocks Tuned"
+  },
+  {
+    "key": "stat.minecraft.use_cauldron",
+    "english_translation": "Water Taken from Cauldron"
+  },
+  {
+    "key": "stat.minecraft.walk_one_cm",
+    "english_translation": "Distance Walked"
+  },
+  {
+    "key": "recipe.toast.title",
+    "english_translation": "New Recipes Unlocked!"
+  },
+  {
+    "key": "recipe.toast.description",
+    "english_translation": "Check your recipe book"
+  },
+  {
+    "key": "itemGroup.buildingBlocks",
+    "english_translation": "Building Blocks"
+  },
+  {
+    "key": "itemGroup.decorations",
+    "english_translation": "Decoration Blocks"
+  },
+  {
+    "key": "itemGroup.redstone",
+    "english_translation": "Redstone"
+  },
+  {
+    "key": "itemGroup.transportation",
+    "english_translation": "Transportation"
+  },
+  {
+    "key": "itemGroup.misc",
+    "english_translation": "Miscellaneous"
+  },
+  {
+    "key": "itemGroup.search",
+    "english_translation": "Search Items"
+  },
+  {
+    "key": "itemGroup.food",
+    "english_translation": "Foodstuffs"
+  },
+  {
+    "key": "itemGroup.tools",
+    "english_translation": "Tools"
+  },
+  {
+    "key": "itemGroup.combat",
+    "english_translation": "Combat"
+  },
+  {
+    "key": "itemGroup.brewing",
+    "english_translation": "Brewing"
+  },
+  {
+    "key": "itemGroup.materials",
+    "english_translation": "Materials"
+  },
+  {
+    "key": "itemGroup.inventory",
+    "english_translation": "Survival Inventory"
+  },
+  {
+    "key": "itemGroup.hotbar",
+    "english_translation": "Saved Hotbars"
+  },
+  {
+    "key": "inventory.binSlot",
+    "english_translation": "Destroy Item"
+  },
+  {
+    "key": "inventory.hotbarSaved",
+    "english_translation": "Item hotbar saved (restore with %1$s+%2$s)"
+  },
+  {
+    "key": "inventory.hotbarInfo",
+    "english_translation": "Save hotbar with %1$s+%2$s"
+  },
+  {
+    "key": "advMode.setCommand",
+    "english_translation": "Set Console Command for Block"
+  },
+  {
+    "key": "advMode.setCommand.success",
+    "english_translation": "Command set: %s"
+  },
+  {
+    "key": "advMode.command",
+    "english_translation": "Console Command"
+  },
+  {
+    "key": "advMode.nearestPlayer",
+    "english_translation": "Use \"@p\" to target nearest player"
+  },
+  {
+    "key": "advMode.randomPlayer",
+    "english_translation": "Use \"@r\" to target random player"
+  },
+  {
+    "key": "advMode.allPlayers",
+    "english_translation": "Use \"@a\" to target all players"
+  },
+  {
+    "key": "advMode.allEntities",
+    "english_translation": "Use \"@e\" to target all entities"
+  },
+  {
+    "key": "advMode.self",
+    "english_translation": "Use \"@s\" to target the executing entity"
+  },
+  {
+    "key": "advMode.previousOutput",
+    "english_translation": "Previous Output"
+  },
+  {
+    "key": "advMode.mode",
+    "english_translation": "Mode"
+  },
+  {
+    "key": "advMode.mode.sequence",
+    "english_translation": "Chain"
+  },
+  {
+    "key": "advMode.mode.auto",
+    "english_translation": "Repeat"
+  },
+  {
+    "key": "advMode.mode.redstone",
+    "english_translation": "Impulse"
+  },
+  {
+    "key": "advMode.type",
+    "english_translation": "Type"
+  },
+  {
+    "key": "advMode.mode.conditional",
+    "english_translation": "Conditional"
+  },
+  {
+    "key": "advMode.mode.unconditional",
+    "english_translation": "Unconditional"
+  },
+  {
+    "key": "advMode.triggering",
+    "english_translation": "Triggering"
+  },
+  {
+    "key": "advMode.mode.redstoneTriggered",
+    "english_translation": "Needs Redstone"
+  },
+  {
+    "key": "advMode.mode.autoexec.bat",
+    "english_translation": "Always Active"
+  },
+  {
+    "key": "advMode.notEnabled",
+    "english_translation": "Command blocks are not enabled on this server"
+  },
+  {
+    "key": "advMode.notAllowed",
+    "english_translation": "Must be an opped player in creative mode"
+  },
+  {
+    "key": "advMode.trackOutput",
+    "english_translation": "Track output"
+  },
+  {
+    "key": "mount.onboard",
+    "english_translation": "Press %1$s to Dismount"
+  },
+  {
+    "key": "build.tooHigh",
+    "english_translation": "Height limit for building is %s"
+  },
+  {
+    "key": "item.modifiers.mainhand",
+    "english_translation": "When in Main Hand:"
+  },
+  {
+    "key": "item.modifiers.offhand",
+    "english_translation": "When in Off Hand:"
+  },
+  {
+    "key": "item.modifiers.feet",
+    "english_translation": "When on Feet:"
+  },
+  {
+    "key": "item.modifiers.legs",
+    "english_translation": "When on Legs:"
+  },
+  {
+    "key": "item.modifiers.chest",
+    "english_translation": "When on Body:"
+  },
+  {
+    "key": "item.modifiers.head",
+    "english_translation": "When on Head:"
+  },
+  {
+    "key": "attribute.unknown",
+    "english_translation": "Unknown attribute"
+  },
+  {
+    "key": "attribute.modifier.plus.0",
+    "english_translation": "+%s %s"
+  },
+  {
+    "key": "attribute.modifier.plus.1",
+    "english_translation": "+%s%% %s"
+  },
+  {
+    "key": "attribute.modifier.plus.2",
+    "english_translation": "+%s%% %s"
+  },
+  {
+    "key": "attribute.modifier.take.0",
+    "english_translation": "-%s %s"
+  },
+  {
+    "key": "attribute.modifier.take.1",
+    "english_translation": "-%s%% %s"
+  },
+  {
+    "key": "attribute.modifier.take.2",
+    "english_translation": "-%s%% %s"
+  },
+  {
+    "key": "attribute.modifier.equals.0",
+    "english_translation": "%s %s"
+  },
+  {
+    "key": "attribute.modifier.equals.1",
+    "english_translation": "%s%% %s"
+  },
+  {
+    "key": "attribute.modifier.equals.2",
+    "english_translation": "%s%% %s"
+  },
+  {
+    "key": "attribute.name.horse.jump_strength",
+    "english_translation": "Horse Jump Strength"
+  },
+  {
+    "key": "attribute.name.zombie.spawn_reinforcements",
+    "english_translation": "Zombie Reinforcements"
+  },
+  {
+    "key": "attribute.name.generic.max_health",
+    "english_translation": "Max Health"
+  },
+  {
+    "key": "attribute.name.generic.follow_range",
+    "english_translation": "Mob Follow Range"
+  },
+  {
+    "key": "attribute.name.generic.knockback_resistance",
+    "english_translation": "Knockback Resistance"
+  },
+  {
+    "key": "attribute.name.generic.movement_speed",
+    "english_translation": "Speed"
+  },
+  {
+    "key": "attribute.name.generic.flying_speed",
+    "english_translation": "Flying Speed"
+  },
+  {
+    "key": "attribute.name.generic.attack_damage",
+    "english_translation": "Attack Damage"
+  },
+  {
+    "key": "attribute.name.generic.attack_knockback",
+    "english_translation": "Attack Knockback"
+  },
+  {
+    "key": "attribute.name.generic.attack_speed",
+    "english_translation": "Attack Speed"
+  },
+  {
+    "key": "attribute.name.generic.luck",
+    "english_translation": "Luck"
+  },
+  {
+    "key": "attribute.name.generic.armor",
+    "english_translation": "Armor"
+  },
+  {
+    "key": "attribute.name.generic.armor_toughness",
+    "english_translation": "Armor Toughness"
+  },
+  {
+    "key": "screenshot.success",
+    "english_translation": "Saved screenshot as %s"
+  },
+  {
+    "key": "screenshot.failure",
+    "english_translation": "Couldn't save screenshot: %s"
+  },
+  {
+    "key": "block.minecraft.black_banner",
+    "english_translation": "Black Banner"
+  },
+  {
+    "key": "block.minecraft.red_banner",
+    "english_translation": "Red Banner"
+  },
+  {
+    "key": "block.minecraft.green_banner",
+    "english_translation": "Green Banner"
+  },
+  {
+    "key": "block.minecraft.brown_banner",
+    "english_translation": "Brown Banner"
+  },
+  {
+    "key": "block.minecraft.blue_banner",
+    "english_translation": "Blue Banner"
+  },
+  {
+    "key": "block.minecraft.purple_banner",
+    "english_translation": "Purple Banner"
+  },
+  {
+    "key": "block.minecraft.cyan_banner",
+    "english_translation": "Cyan Banner"
+  },
+  {
+    "key": "block.minecraft.light_gray_banner",
+    "english_translation": "Light Gray Banner"
+  },
+  {
+    "key": "block.minecraft.gray_banner",
+    "english_translation": "Gray Banner"
+  },
+  {
+    "key": "block.minecraft.pink_banner",
+    "english_translation": "Pink Banner"
+  },
+  {
+    "key": "block.minecraft.lime_banner",
+    "english_translation": "Lime Banner"
+  },
+  {
+    "key": "block.minecraft.yellow_banner",
+    "english_translation": "Yellow Banner"
+  },
+  {
+    "key": "block.minecraft.light_blue_banner",
+    "english_translation": "Light Blue Banner"
+  },
+  {
+    "key": "block.minecraft.magenta_banner",
+    "english_translation": "Magenta Banner"
+  },
+  {
+    "key": "block.minecraft.orange_banner",
+    "english_translation": "Orange Banner"
+  },
+  {
+    "key": "block.minecraft.white_banner",
+    "english_translation": "White Banner"
+  },
+  {
+    "key": "item.minecraft.shield",
+    "english_translation": "Shield"
+  },
+  {
+    "key": "item.minecraft.shield.black",
+    "english_translation": "Black Shield"
+  },
+  {
+    "key": "item.minecraft.shield.red",
+    "english_translation": "Red Shield"
+  },
+  {
+    "key": "item.minecraft.shield.green",
+    "english_translation": "Green Shield"
+  },
+  {
+    "key": "item.minecraft.shield.brown",
+    "english_translation": "Brown Shield"
+  },
+  {
+    "key": "item.minecraft.shield.blue",
+    "english_translation": "Blue Shield"
+  },
+  {
+    "key": "item.minecraft.shield.purple",
+    "english_translation": "Purple Shield"
+  },
+  {
+    "key": "item.minecraft.shield.cyan",
+    "english_translation": "Cyan Shield"
+  },
+  {
+    "key": "item.minecraft.shield.light_gray",
+    "english_translation": "Light Gray Shield"
+  },
+  {
+    "key": "item.minecraft.shield.gray",
+    "english_translation": "Gray Shield"
+  },
+  {
+    "key": "item.minecraft.shield.pink",
+    "english_translation": "Pink Shield"
+  },
+  {
+    "key": "item.minecraft.shield.lime",
+    "english_translation": "Lime Shield"
+  },
+  {
+    "key": "item.minecraft.shield.yellow",
+    "english_translation": "Yellow Shield"
+  },
+  {
+    "key": "item.minecraft.shield.light_blue",
+    "english_translation": "Light Blue Shield"
+  },
+  {
+    "key": "item.minecraft.shield.magenta",
+    "english_translation": "Magenta Shield"
+  },
+  {
+    "key": "item.minecraft.shield.orange",
+    "english_translation": "Orange Shield"
+  },
+  {
+    "key": "item.minecraft.shield.white",
+    "english_translation": "White Shield"
+  },
+  {
+    "key": "block.minecraft.banner.base.black",
+    "english_translation": "Fully Black Field"
+  },
+  {
+    "key": "block.minecraft.banner.base.red",
+    "english_translation": "Fully Red Field"
+  },
+  {
+    "key": "block.minecraft.banner.base.green",
+    "english_translation": "Fully Green Field"
+  },
+  {
+    "key": "block.minecraft.banner.base.brown",
+    "english_translation": "Fully Brown Field"
+  },
+  {
+    "key": "block.minecraft.banner.base.blue",
+    "english_translation": "Fully Blue Field"
+  },
+  {
+    "key": "block.minecraft.banner.base.purple",
+    "english_translation": "Fully Purple Field"
+  },
+  {
+    "key": "block.minecraft.banner.base.cyan",
+    "english_translation": "Fully Cyan Field"
+  },
+  {
+    "key": "block.minecraft.banner.base.light_gray",
+    "english_translation": "Fully Light Gray Field"
+  },
+  {
+    "key": "block.minecraft.banner.base.gray",
+    "english_translation": "Fully Gray Field"
+  },
+  {
+    "key": "block.minecraft.banner.base.pink",
+    "english_translation": "Fully Pink Field"
+  },
+  {
+    "key": "block.minecraft.banner.base.lime",
+    "english_translation": "Fully Lime Field"
+  },
+  {
+    "key": "block.minecraft.banner.base.yellow",
+    "english_translation": "Fully Yellow Field"
+  },
+  {
+    "key": "block.minecraft.banner.base.light_blue",
+    "english_translation": "Fully Light Blue Field"
+  },
+  {
+    "key": "block.minecraft.banner.base.magenta",
+    "english_translation": "Fully Magenta Field"
+  },
+  {
+    "key": "block.minecraft.banner.base.orange",
+    "english_translation": "Fully Orange Field"
+  },
+  {
+    "key": "block.minecraft.banner.base.white",
+    "english_translation": "Fully White Field"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_left.black",
+    "english_translation": "Black Base Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_left.red",
+    "english_translation": "Red Base Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_left.green",
+    "english_translation": "Green Base Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_left.brown",
+    "english_translation": "Brown Base Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_left.blue",
+    "english_translation": "Blue Base Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_left.purple",
+    "english_translation": "Purple Base Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_left.cyan",
+    "english_translation": "Cyan Base Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_left.light_gray",
+    "english_translation": "Light Gray Base Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_left.gray",
+    "english_translation": "Gray Base Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_left.pink",
+    "english_translation": "Pink Base Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_left.lime",
+    "english_translation": "Lime Base Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_left.yellow",
+    "english_translation": "Yellow Base Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_left.light_blue",
+    "english_translation": "Light Blue Base Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_left.magenta",
+    "english_translation": "Magenta Base Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_left.orange",
+    "english_translation": "Orange Base Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_left.white",
+    "english_translation": "White Base Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_right.black",
+    "english_translation": "Black Base Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_right.red",
+    "english_translation": "Red Base Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_right.green",
+    "english_translation": "Green Base Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_right.brown",
+    "english_translation": "Brown Base Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_right.blue",
+    "english_translation": "Blue Base Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_right.purple",
+    "english_translation": "Purple Base Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_right.cyan",
+    "english_translation": "Cyan Base Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_right.light_gray",
+    "english_translation": "Light Gray Base Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_right.gray",
+    "english_translation": "Gray Base Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_right.pink",
+    "english_translation": "Pink Base Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_right.lime",
+    "english_translation": "Lime Base Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_right.yellow",
+    "english_translation": "Yellow Base Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_right.light_blue",
+    "english_translation": "Light Blue Base Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_right.magenta",
+    "english_translation": "Magenta Base Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_right.orange",
+    "english_translation": "Orange Base Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_bottom_right.white",
+    "english_translation": "White Base Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_left.black",
+    "english_translation": "Black Chief Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_left.red",
+    "english_translation": "Red Chief Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_left.green",
+    "english_translation": "Green Chief Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_left.brown",
+    "english_translation": "Brown Chief Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_left.blue",
+    "english_translation": "Blue Chief Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_left.purple",
+    "english_translation": "Purple Chief Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_left.cyan",
+    "english_translation": "Cyan Chief Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_left.light_gray",
+    "english_translation": "Light Gray Chief Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_left.gray",
+    "english_translation": "Gray Chief Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_left.pink",
+    "english_translation": "Pink Chief Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_left.lime",
+    "english_translation": "Lime Chief Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_left.yellow",
+    "english_translation": "Yellow Chief Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_left.light_blue",
+    "english_translation": "Light Blue Chief Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_left.magenta",
+    "english_translation": "Magenta Chief Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_left.orange",
+    "english_translation": "Orange Chief Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_left.white",
+    "english_translation": "White Chief Dexter Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_right.black",
+    "english_translation": "Black Chief Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_right.red",
+    "english_translation": "Red Chief Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_right.green",
+    "english_translation": "Green Chief Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_right.brown",
+    "english_translation": "Brown Chief Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_right.blue",
+    "english_translation": "Blue Chief Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_right.purple",
+    "english_translation": "Purple Chief Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_right.cyan",
+    "english_translation": "Cyan Chief Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_right.light_gray",
+    "english_translation": "Light Gray Chief Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_right.gray",
+    "english_translation": "Gray Chief Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_right.pink",
+    "english_translation": "Pink Chief Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_right.lime",
+    "english_translation": "Lime Chief Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_right.yellow",
+    "english_translation": "Yellow Chief Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_right.light_blue",
+    "english_translation": "Light Blue Chief Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_right.magenta",
+    "english_translation": "Magenta Chief Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_right.orange",
+    "english_translation": "Orange Chief Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.square_top_right.white",
+    "english_translation": "White Chief Sinister Canton"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_bottom.black",
+    "english_translation": "Black Base"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_bottom.red",
+    "english_translation": "Red Base"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_bottom.green",
+    "english_translation": "Green Base"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_bottom.brown",
+    "english_translation": "Brown Base"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_bottom.blue",
+    "english_translation": "Blue Base"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_bottom.purple",
+    "english_translation": "Purple Base"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_bottom.cyan",
+    "english_translation": "Cyan Base"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_bottom.light_gray",
+    "english_translation": "Light Gray Base"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_bottom.gray",
+    "english_translation": "Gray Base"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_bottom.pink",
+    "english_translation": "Pink Base"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_bottom.lime",
+    "english_translation": "Lime Base"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_bottom.yellow",
+    "english_translation": "Yellow Base"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_bottom.light_blue",
+    "english_translation": "Light Blue Base"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_bottom.magenta",
+    "english_translation": "Magenta Base"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_bottom.orange",
+    "english_translation": "Orange Base"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_bottom.white",
+    "english_translation": "White Base"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_top.black",
+    "english_translation": "Black Chief"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_top.red",
+    "english_translation": "Red Chief"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_top.green",
+    "english_translation": "Green Chief"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_top.brown",
+    "english_translation": "Brown Chief"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_top.blue",
+    "english_translation": "Blue Chief"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_top.purple",
+    "english_translation": "Purple Chief"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_top.cyan",
+    "english_translation": "Cyan Chief"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_top.light_gray",
+    "english_translation": "Light Gray Chief"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_top.gray",
+    "english_translation": "Gray Chief"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_top.pink",
+    "english_translation": "Pink Chief"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_top.lime",
+    "english_translation": "Lime Chief"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_top.yellow",
+    "english_translation": "Yellow Chief"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_top.light_blue",
+    "english_translation": "Light Blue Chief"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_top.magenta",
+    "english_translation": "Magenta Chief"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_top.orange",
+    "english_translation": "Orange Chief"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_top.white",
+    "english_translation": "White Chief"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_left.black",
+    "english_translation": "Black Pale Dexter"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_left.red",
+    "english_translation": "Red Pale Dexter"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_left.green",
+    "english_translation": "Green Pale Dexter"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_left.brown",
+    "english_translation": "Brown Pale Dexter"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_left.blue",
+    "english_translation": "Blue Pale Dexter"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_left.purple",
+    "english_translation": "Purple Pale Dexter"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_left.cyan",
+    "english_translation": "Cyan Pale Dexter"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_left.light_gray",
+    "english_translation": "Light Gray Pale Dexter"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_left.gray",
+    "english_translation": "Gray Pale Dexter"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_left.pink",
+    "english_translation": "Pink Pale Dexter"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_left.lime",
+    "english_translation": "Lime Pale Dexter"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_left.yellow",
+    "english_translation": "Yellow Pale Dexter"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_left.light_blue",
+    "english_translation": "Light Blue Pale Dexter"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_left.magenta",
+    "english_translation": "Magenta Pale Dexter"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_left.orange",
+    "english_translation": "Orange Pale Dexter"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_left.white",
+    "english_translation": "White Pale Dexter"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_right.black",
+    "english_translation": "Black Pale Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_right.red",
+    "english_translation": "Red Pale Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_right.green",
+    "english_translation": "Green Pale Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_right.brown",
+    "english_translation": "Brown Pale Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_right.blue",
+    "english_translation": "Blue Pale Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_right.purple",
+    "english_translation": "Purple Pale Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_right.cyan",
+    "english_translation": "Cyan Pale Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_right.light_gray",
+    "english_translation": "Light Gray Pale Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_right.gray",
+    "english_translation": "Gray Pale Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_right.pink",
+    "english_translation": "Pink Pale Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_right.lime",
+    "english_translation": "Lime Pale Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_right.yellow",
+    "english_translation": "Yellow Pale Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_right.light_blue",
+    "english_translation": "Light Blue Pale Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_right.magenta",
+    "english_translation": "Magenta Pale Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_right.orange",
+    "english_translation": "Orange Pale Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_right.white",
+    "english_translation": "White Pale Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_center.black",
+    "english_translation": "Black Pale"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_center.red",
+    "english_translation": "Red Pale"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_center.green",
+    "english_translation": "Green Pale"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_center.brown",
+    "english_translation": "Brown Pale"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_center.blue",
+    "english_translation": "Blue Pale"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_center.purple",
+    "english_translation": "Purple Pale"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_center.cyan",
+    "english_translation": "Cyan Pale"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_center.light_gray",
+    "english_translation": "Light Gray Pale"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_center.gray",
+    "english_translation": "Gray Pale"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_center.pink",
+    "english_translation": "Pink Pale"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_center.lime",
+    "english_translation": "Lime Pale"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_center.yellow",
+    "english_translation": "Yellow Pale"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_center.light_blue",
+    "english_translation": "Light Blue Pale"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_center.magenta",
+    "english_translation": "Magenta Pale"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_center.orange",
+    "english_translation": "Orange Pale"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_center.white",
+    "english_translation": "White Pale"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_middle.black",
+    "english_translation": "Black Fess"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_middle.red",
+    "english_translation": "Red Fess"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_middle.green",
+    "english_translation": "Green Fess"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_middle.brown",
+    "english_translation": "Brown Fess"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_middle.blue",
+    "english_translation": "Blue Fess"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_middle.purple",
+    "english_translation": "Purple Fess"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_middle.cyan",
+    "english_translation": "Cyan Fess"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_middle.light_gray",
+    "english_translation": "Light Gray Fess"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_middle.gray",
+    "english_translation": "Gray Fess"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_middle.pink",
+    "english_translation": "Pink Fess"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_middle.lime",
+    "english_translation": "Lime Fess"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_middle.yellow",
+    "english_translation": "Yellow Fess"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_middle.light_blue",
+    "english_translation": "Light Blue Fess"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_middle.magenta",
+    "english_translation": "Magenta Fess"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_middle.orange",
+    "english_translation": "Orange Fess"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_middle.white",
+    "english_translation": "White Fess"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downright.black",
+    "english_translation": "Black Bend"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downright.red",
+    "english_translation": "Red Bend"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downright.green",
+    "english_translation": "Green Bend"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downright.brown",
+    "english_translation": "Brown Bend"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downright.blue",
+    "english_translation": "Blue Bend"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downright.purple",
+    "english_translation": "Purple Bend"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downright.cyan",
+    "english_translation": "Cyan Bend"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downright.light_gray",
+    "english_translation": "Light Gray Bend"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downright.gray",
+    "english_translation": "Gray Bend"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downright.pink",
+    "english_translation": "Pink Bend"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downright.lime",
+    "english_translation": "Lime Bend"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downright.yellow",
+    "english_translation": "Yellow Bend"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downright.light_blue",
+    "english_translation": "Light Blue Bend"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downright.magenta",
+    "english_translation": "Magenta Bend"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downright.orange",
+    "english_translation": "Orange Bend"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downright.white",
+    "english_translation": "White Bend"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downleft.black",
+    "english_translation": "Black Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downleft.red",
+    "english_translation": "Red Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downleft.green",
+    "english_translation": "Green Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downleft.brown",
+    "english_translation": "Brown Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downleft.blue",
+    "english_translation": "Blue Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downleft.purple",
+    "english_translation": "Purple Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downleft.cyan",
+    "english_translation": "Cyan Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downleft.light_gray",
+    "english_translation": "Light Gray Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downleft.gray",
+    "english_translation": "Gray Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downleft.pink",
+    "english_translation": "Pink Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downleft.lime",
+    "english_translation": "Lime Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downleft.yellow",
+    "english_translation": "Yellow Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downleft.light_blue",
+    "english_translation": "Light Blue Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downleft.magenta",
+    "english_translation": "Magenta Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downleft.orange",
+    "english_translation": "Orange Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.stripe_downleft.white",
+    "english_translation": "White Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.small_stripes.black",
+    "english_translation": "Black Paly"
+  },
+  {
+    "key": "block.minecraft.banner.small_stripes.red",
+    "english_translation": "Red Paly"
+  },
+  {
+    "key": "block.minecraft.banner.small_stripes.green",
+    "english_translation": "Green Paly"
+  },
+  {
+    "key": "block.minecraft.banner.small_stripes.brown",
+    "english_translation": "Brown Paly"
+  },
+  {
+    "key": "block.minecraft.banner.small_stripes.blue",
+    "english_translation": "Blue Paly"
+  },
+  {
+    "key": "block.minecraft.banner.small_stripes.purple",
+    "english_translation": "Purple Paly"
+  },
+  {
+    "key": "block.minecraft.banner.small_stripes.cyan",
+    "english_translation": "Cyan Paly"
+  },
+  {
+    "key": "block.minecraft.banner.small_stripes.light_gray",
+    "english_translation": "Light Gray Paly"
+  },
+  {
+    "key": "block.minecraft.banner.small_stripes.gray",
+    "english_translation": "Gray Paly"
+  },
+  {
+    "key": "block.minecraft.banner.small_stripes.pink",
+    "english_translation": "Pink Paly"
+  },
+  {
+    "key": "block.minecraft.banner.small_stripes.lime",
+    "english_translation": "Lime Paly"
+  },
+  {
+    "key": "block.minecraft.banner.small_stripes.yellow",
+    "english_translation": "Yellow Paly"
+  },
+  {
+    "key": "block.minecraft.banner.small_stripes.light_blue",
+    "english_translation": "Light Blue Paly"
+  },
+  {
+    "key": "block.minecraft.banner.small_stripes.magenta",
+    "english_translation": "Magenta Paly"
+  },
+  {
+    "key": "block.minecraft.banner.small_stripes.orange",
+    "english_translation": "Orange Paly"
+  },
+  {
+    "key": "block.minecraft.banner.small_stripes.white",
+    "english_translation": "White Paly"
+  },
+  {
+    "key": "block.minecraft.banner.cross.black",
+    "english_translation": "Black Saltire"
+  },
+  {
+    "key": "block.minecraft.banner.cross.red",
+    "english_translation": "Red Saltire"
+  },
+  {
+    "key": "block.minecraft.banner.cross.green",
+    "english_translation": "Green Saltire"
+  },
+  {
+    "key": "block.minecraft.banner.cross.brown",
+    "english_translation": "Brown Saltire"
+  },
+  {
+    "key": "block.minecraft.banner.cross.blue",
+    "english_translation": "Blue Saltire"
+  },
+  {
+    "key": "block.minecraft.banner.cross.purple",
+    "english_translation": "Purple Saltire"
+  },
+  {
+    "key": "block.minecraft.banner.cross.cyan",
+    "english_translation": "Cyan Saltire"
+  },
+  {
+    "key": "block.minecraft.banner.cross.light_gray",
+    "english_translation": "Light Gray Saltire"
+  },
+  {
+    "key": "block.minecraft.banner.cross.gray",
+    "english_translation": "Gray Saltire"
+  },
+  {
+    "key": "block.minecraft.banner.cross.pink",
+    "english_translation": "Pink Saltire"
+  },
+  {
+    "key": "block.minecraft.banner.cross.lime",
+    "english_translation": "Lime Saltire"
+  },
+  {
+    "key": "block.minecraft.banner.cross.yellow",
+    "english_translation": "Yellow Saltire"
+  },
+  {
+    "key": "block.minecraft.banner.cross.light_blue",
+    "english_translation": "Light Blue Saltire"
+  },
+  {
+    "key": "block.minecraft.banner.cross.magenta",
+    "english_translation": "Magenta Saltire"
+  },
+  {
+    "key": "block.minecraft.banner.cross.orange",
+    "english_translation": "Orange Saltire"
+  },
+  {
+    "key": "block.minecraft.banner.cross.white",
+    "english_translation": "White Saltire"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_bottom.black",
+    "english_translation": "Black Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_bottom.red",
+    "english_translation": "Red Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_bottom.green",
+    "english_translation": "Green Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_bottom.brown",
+    "english_translation": "Brown Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_bottom.blue",
+    "english_translation": "Blue Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_bottom.purple",
+    "english_translation": "Purple Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_bottom.cyan",
+    "english_translation": "Cyan Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_bottom.light_gray",
+    "english_translation": "Light Gray Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_bottom.gray",
+    "english_translation": "Gray Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_bottom.pink",
+    "english_translation": "Pink Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_bottom.lime",
+    "english_translation": "Lime Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_bottom.yellow",
+    "english_translation": "Yellow Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_bottom.light_blue",
+    "english_translation": "Light Blue Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_bottom.magenta",
+    "english_translation": "Magenta Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_bottom.orange",
+    "english_translation": "Orange Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_bottom.white",
+    "english_translation": "White Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_top.black",
+    "english_translation": "Black Inverted Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_top.red",
+    "english_translation": "Red Inverted Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_top.green",
+    "english_translation": "Green Inverted Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_top.brown",
+    "english_translation": "Brown Inverted Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_top.blue",
+    "english_translation": "Blue Inverted Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_top.purple",
+    "english_translation": "Purple Inverted Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_top.cyan",
+    "english_translation": "Cyan Inverted Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_top.light_gray",
+    "english_translation": "Light Gray Inverted Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_top.gray",
+    "english_translation": "Gray Inverted Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_top.pink",
+    "english_translation": "Pink Inverted Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_top.lime",
+    "english_translation": "Lime Inverted Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_top.yellow",
+    "english_translation": "Yellow Inverted Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_top.light_blue",
+    "english_translation": "Light Blue Inverted Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_top.magenta",
+    "english_translation": "Magenta Inverted Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_top.orange",
+    "english_translation": "Orange Inverted Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangle_top.white",
+    "english_translation": "White Inverted Chevron"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_bottom.black",
+    "english_translation": "Black Base Indented"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_bottom.red",
+    "english_translation": "Red Base Indented"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_bottom.green",
+    "english_translation": "Green Base Indented"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_bottom.brown",
+    "english_translation": "Brown Base Indented"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_bottom.blue",
+    "english_translation": "Blue Base Indented"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_bottom.purple",
+    "english_translation": "Purple Base Indented"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_bottom.cyan",
+    "english_translation": "Cyan Base Indented"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_bottom.light_gray",
+    "english_translation": "Light Gray Base Indented"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_bottom.gray",
+    "english_translation": "Gray Base Indented"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_bottom.pink",
+    "english_translation": "Pink Base Indented"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_bottom.lime",
+    "english_translation": "Lime Base Indented"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_bottom.yellow",
+    "english_translation": "Yellow Base Indented"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_bottom.light_blue",
+    "english_translation": "Light Blue Base Indented"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_bottom.magenta",
+    "english_translation": "Magenta Base Indented"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_bottom.orange",
+    "english_translation": "Orange Base Indented"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_bottom.white",
+    "english_translation": "White Base Indented"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_top.black",
+    "english_translation": "Black Chief Indented"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_top.red",
+    "english_translation": "Red Chief Indented"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_top.green",
+    "english_translation": "Green Chief Indented"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_top.brown",
+    "english_translation": "Brown Chief Indented"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_top.blue",
+    "english_translation": "Blue Chief Indented"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_top.purple",
+    "english_translation": "Purple Chief Indented"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_top.cyan",
+    "english_translation": "Cyan Chief Indented"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_top.light_gray",
+    "english_translation": "Light Gray Chief Indented"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_top.gray",
+    "english_translation": "Gray Chief Indented"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_top.pink",
+    "english_translation": "Pink Chief Indented"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_top.lime",
+    "english_translation": "Lime Chief Indented"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_top.yellow",
+    "english_translation": "Yellow Chief Indented"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_top.light_blue",
+    "english_translation": "Light Blue Chief Indented"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_top.magenta",
+    "english_translation": "Magenta Chief Indented"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_top.orange",
+    "english_translation": "Orange Chief Indented"
+  },
+  {
+    "key": "block.minecraft.banner.triangles_top.white",
+    "english_translation": "White Chief Indented"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_left.black",
+    "english_translation": "Black Per Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_left.red",
+    "english_translation": "Red Per Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_left.green",
+    "english_translation": "Green Per Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_left.brown",
+    "english_translation": "Brown Per Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_left.blue",
+    "english_translation": "Blue Per Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_left.purple",
+    "english_translation": "Purple Per Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_left.cyan",
+    "english_translation": "Cyan Per Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_left.light_gray",
+    "english_translation": "Light Gray Per Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_left.gray",
+    "english_translation": "Gray Per Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_left.pink",
+    "english_translation": "Pink Per Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_left.lime",
+    "english_translation": "Lime Per Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_left.yellow",
+    "english_translation": "Yellow Per Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_left.light_blue",
+    "english_translation": "Light Blue Per Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_left.magenta",
+    "english_translation": "Magenta Per Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_left.orange",
+    "english_translation": "Orange Per Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_left.white",
+    "english_translation": "White Per Bend Sinister"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_right.black",
+    "english_translation": "Black Per Bend"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_right.red",
+    "english_translation": "Red Per Bend"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_right.green",
+    "english_translation": "Green Per Bend"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_right.brown",
+    "english_translation": "Brown Per Bend"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_right.blue",
+    "english_translation": "Blue Per Bend"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_right.purple",
+    "english_translation": "Purple Per Bend"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_right.cyan",
+    "english_translation": "Cyan Per Bend"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_right.light_gray",
+    "english_translation": "Light Gray Per Bend"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_right.gray",
+    "english_translation": "Gray Per Bend"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_right.pink",
+    "english_translation": "Pink Per Bend"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_right.lime",
+    "english_translation": "Lime Per Bend"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_right.yellow",
+    "english_translation": "Yellow Per Bend"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_right.light_blue",
+    "english_translation": "Light Blue Per Bend"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_right.magenta",
+    "english_translation": "Magenta Per Bend"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_right.orange",
+    "english_translation": "Orange Per Bend"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_right.white",
+    "english_translation": "White Per Bend"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_left.black",
+    "english_translation": "Black Per Bend Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_left.red",
+    "english_translation": "Red Per Bend Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_left.green",
+    "english_translation": "Green Per Bend Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_left.brown",
+    "english_translation": "Brown Per Bend Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_left.blue",
+    "english_translation": "Blue Per Bend Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_left.purple",
+    "english_translation": "Purple Per Bend Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_left.cyan",
+    "english_translation": "Cyan Per Bend Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_left.light_gray",
+    "english_translation": "Light Gray Per Bend Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_left.gray",
+    "english_translation": "Gray Per Bend Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_left.pink",
+    "english_translation": "Pink Per Bend Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_left.lime",
+    "english_translation": "Lime Per Bend Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_left.yellow",
+    "english_translation": "Yellow Per Bend Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_left.light_blue",
+    "english_translation": "Light Blue Per Bend Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_left.magenta",
+    "english_translation": "Magenta Per Bend Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_left.orange",
+    "english_translation": "Orange Per Bend Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_left.white",
+    "english_translation": "White Per Bend Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_right.black",
+    "english_translation": "Black Per Bend Sinister Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_right.red",
+    "english_translation": "Red Per Bend Sinister Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_right.green",
+    "english_translation": "Green Per Bend Sinister Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_right.brown",
+    "english_translation": "Brown Per Bend Sinister Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_right.blue",
+    "english_translation": "Blue Per Bend Sinister Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_right.purple",
+    "english_translation": "Purple Per Bend Sinister Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_right.cyan",
+    "english_translation": "Cyan Per Bend Sinister Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_right.light_gray",
+    "english_translation": "Light Gray Per Bend Sinister Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_right.gray",
+    "english_translation": "Gray Per Bend Sinister Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_right.pink",
+    "english_translation": "Pink Per Bend Sinister Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_right.lime",
+    "english_translation": "Lime Per Bend Sinister Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_right.yellow",
+    "english_translation": "Yellow Per Bend Sinister Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_right.light_blue",
+    "english_translation": "Light Blue Per Bend Sinister Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_right.magenta",
+    "english_translation": "Magenta Per Bend Sinister Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_right.orange",
+    "english_translation": "Orange Per Bend Sinister Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.diagonal_up_right.white",
+    "english_translation": "White Per Bend Sinister Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.circle.black",
+    "english_translation": "Black Roundel"
+  },
+  {
+    "key": "block.minecraft.banner.circle.red",
+    "english_translation": "Red Roundel"
+  },
+  {
+    "key": "block.minecraft.banner.circle.green",
+    "english_translation": "Green Roundel"
+  },
+  {
+    "key": "block.minecraft.banner.circle.brown",
+    "english_translation": "Brown Roundel"
+  },
+  {
+    "key": "block.minecraft.banner.circle.blue",
+    "english_translation": "Blue Roundel"
+  },
+  {
+    "key": "block.minecraft.banner.circle.purple",
+    "english_translation": "Purple Roundel"
+  },
+  {
+    "key": "block.minecraft.banner.circle.cyan",
+    "english_translation": "Cyan Roundel"
+  },
+  {
+    "key": "block.minecraft.banner.circle.light_gray",
+    "english_translation": "Light Gray Roundel"
+  },
+  {
+    "key": "block.minecraft.banner.circle.gray",
+    "english_translation": "Gray Roundel"
+  },
+  {
+    "key": "block.minecraft.banner.circle.pink",
+    "english_translation": "Pink Roundel"
+  },
+  {
+    "key": "block.minecraft.banner.circle.lime",
+    "english_translation": "Lime Roundel"
+  },
+  {
+    "key": "block.minecraft.banner.circle.yellow",
+    "english_translation": "Yellow Roundel"
+  },
+  {
+    "key": "block.minecraft.banner.circle.light_blue",
+    "english_translation": "Light Blue Roundel"
+  },
+  {
+    "key": "block.minecraft.banner.circle.magenta",
+    "english_translation": "Magenta Roundel"
+  },
+  {
+    "key": "block.minecraft.banner.circle.orange",
+    "english_translation": "Orange Roundel"
+  },
+  {
+    "key": "block.minecraft.banner.circle.white",
+    "english_translation": "White Roundel"
+  },
+  {
+    "key": "block.minecraft.banner.rhombus.black",
+    "english_translation": "Black Lozenge"
+  },
+  {
+    "key": "block.minecraft.banner.rhombus.red",
+    "english_translation": "Red Lozenge"
+  },
+  {
+    "key": "block.minecraft.banner.rhombus.green",
+    "english_translation": "Green Lozenge"
+  },
+  {
+    "key": "block.minecraft.banner.rhombus.brown",
+    "english_translation": "Brown Lozenge"
+  },
+  {
+    "key": "block.minecraft.banner.rhombus.blue",
+    "english_translation": "Blue Lozenge"
+  },
+  {
+    "key": "block.minecraft.banner.rhombus.purple",
+    "english_translation": "Purple Lozenge"
+  },
+  {
+    "key": "block.minecraft.banner.rhombus.cyan",
+    "english_translation": "Cyan Lozenge"
+  },
+  {
+    "key": "block.minecraft.banner.rhombus.light_gray",
+    "english_translation": "Light Gray Lozenge"
+  },
+  {
+    "key": "block.minecraft.banner.rhombus.gray",
+    "english_translation": "Gray Lozenge"
+  },
+  {
+    "key": "block.minecraft.banner.rhombus.pink",
+    "english_translation": "Pink Lozenge"
+  },
+  {
+    "key": "block.minecraft.banner.rhombus.lime",
+    "english_translation": "Lime Lozenge"
+  },
+  {
+    "key": "block.minecraft.banner.rhombus.yellow",
+    "english_translation": "Yellow Lozenge"
+  },
+  {
+    "key": "block.minecraft.banner.rhombus.light_blue",
+    "english_translation": "Light Blue Lozenge"
+  },
+  {
+    "key": "block.minecraft.banner.rhombus.magenta",
+    "english_translation": "Magenta Lozenge"
+  },
+  {
+    "key": "block.minecraft.banner.rhombus.orange",
+    "english_translation": "Orange Lozenge"
+  },
+  {
+    "key": "block.minecraft.banner.rhombus.white",
+    "english_translation": "White Lozenge"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical.black",
+    "english_translation": "Black Per Pale"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical.red",
+    "english_translation": "Red Per Pale"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical.green",
+    "english_translation": "Green Per Pale"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical.brown",
+    "english_translation": "Brown Per Pale"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical.blue",
+    "english_translation": "Blue Per Pale"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical.purple",
+    "english_translation": "Purple Per Pale"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical.cyan",
+    "english_translation": "Cyan Per Pale"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical.light_gray",
+    "english_translation": "Light Gray Per Pale"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical.gray",
+    "english_translation": "Gray Per Pale"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical.pink",
+    "english_translation": "Pink Per Pale"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical.lime",
+    "english_translation": "Lime Per Pale"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical.yellow",
+    "english_translation": "Yellow Per Pale"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical.light_blue",
+    "english_translation": "Light Blue Per Pale"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical.magenta",
+    "english_translation": "Magenta Per Pale"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical.orange",
+    "english_translation": "Orange Per Pale"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical.white",
+    "english_translation": "White Per Pale"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal.black",
+    "english_translation": "Black Per Fess"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal.red",
+    "english_translation": "Red Per Fess"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal.green",
+    "english_translation": "Green Per Fess"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal.brown",
+    "english_translation": "Brown Per Fess"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal.blue",
+    "english_translation": "Blue Per Fess"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal.purple",
+    "english_translation": "Purple Per Fess"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal.cyan",
+    "english_translation": "Cyan Per Fess"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal.light_gray",
+    "english_translation": "Light Gray Per Fess"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal.gray",
+    "english_translation": "Gray Per Fess"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal.pink",
+    "english_translation": "Pink Per Fess"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal.lime",
+    "english_translation": "Lime Per Fess"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal.yellow",
+    "english_translation": "Yellow Per Fess"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal.light_blue",
+    "english_translation": "Light Blue Per Fess"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal.magenta",
+    "english_translation": "Magenta Per Fess"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal.orange",
+    "english_translation": "Orange Per Fess"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal.white",
+    "english_translation": "White Per Fess"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical_right.black",
+    "english_translation": "Black Per Pale Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical_right.red",
+    "english_translation": "Red Per Pale Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical_right.green",
+    "english_translation": "Green Per Pale Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical_right.brown",
+    "english_translation": "Brown Per Pale Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical_right.blue",
+    "english_translation": "Blue Per Pale Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical_right.purple",
+    "english_translation": "Purple Per Pale Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical_right.cyan",
+    "english_translation": "Cyan Per Pale Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical_right.light_gray",
+    "english_translation": "Light Gray Per Pale Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical_right.gray",
+    "english_translation": "Gray Per Pale Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical_right.pink",
+    "english_translation": "Pink Per Pale Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical_right.lime",
+    "english_translation": "Lime Per Pale Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical_right.yellow",
+    "english_translation": "Yellow Per Pale Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical_right.light_blue",
+    "english_translation": "Light Blue Per Pale Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical_right.magenta",
+    "english_translation": "Magenta Per Pale Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical_right.orange",
+    "english_translation": "Orange Per Pale Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.half_vertical_right.white",
+    "english_translation": "White Per Pale Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal_bottom.black",
+    "english_translation": "Black Per Fess Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal_bottom.red",
+    "english_translation": "Red Per Fess Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal_bottom.green",
+    "english_translation": "Green Per Fess Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal_bottom.brown",
+    "english_translation": "Brown Per Fess Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal_bottom.blue",
+    "english_translation": "Blue Per Fess Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal_bottom.purple",
+    "english_translation": "Purple Per Fess Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal_bottom.cyan",
+    "english_translation": "Cyan Per Fess Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal_bottom.light_gray",
+    "english_translation": "Light Gray Per Fess Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal_bottom.gray",
+    "english_translation": "Gray Per Fess Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal_bottom.pink",
+    "english_translation": "Pink Per Fess Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal_bottom.lime",
+    "english_translation": "Lime Per Fess Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal_bottom.yellow",
+    "english_translation": "Yellow Per Fess Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal_bottom.light_blue",
+    "english_translation": "Light Blue Per Fess Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal_bottom.magenta",
+    "english_translation": "Magenta Per Fess Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal_bottom.orange",
+    "english_translation": "Orange Per Fess Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.half_horizontal_bottom.white",
+    "english_translation": "White Per Fess Inverted"
+  },
+  {
+    "key": "block.minecraft.banner.creeper.black",
+    "english_translation": "Black Creeper Charge"
+  },
+  {
+    "key": "block.minecraft.banner.creeper.red",
+    "english_translation": "Red Creeper Charge"
+  },
+  {
+    "key": "block.minecraft.banner.creeper.green",
+    "english_translation": "Green Creeper Charge"
+  },
+  {
+    "key": "block.minecraft.banner.creeper.brown",
+    "english_translation": "Brown Creeper Charge"
+  },
+  {
+    "key": "block.minecraft.banner.creeper.blue",
+    "english_translation": "Blue Creeper Charge"
+  },
+  {
+    "key": "block.minecraft.banner.creeper.purple",
+    "english_translation": "Purple Creeper Charge"
+  },
+  {
+    "key": "block.minecraft.banner.creeper.cyan",
+    "english_translation": "Cyan Creeper Charge"
+  },
+  {
+    "key": "block.minecraft.banner.creeper.light_gray",
+    "english_translation": "Light Gray Creeper Charge"
+  },
+  {
+    "key": "block.minecraft.banner.creeper.gray",
+    "english_translation": "Gray Creeper Charge"
+  },
+  {
+    "key": "block.minecraft.banner.creeper.pink",
+    "english_translation": "Pink Creeper Charge"
+  },
+  {
+    "key": "block.minecraft.banner.creeper.lime",
+    "english_translation": "Lime Creeper Charge"
+  },
+  {
+    "key": "block.minecraft.banner.creeper.yellow",
+    "english_translation": "Yellow Creeper Charge"
+  },
+  {
+    "key": "block.minecraft.banner.creeper.light_blue",
+    "english_translation": "Light Blue Creeper Charge"
+  },
+  {
+    "key": "block.minecraft.banner.creeper.magenta",
+    "english_translation": "Magenta Creeper Charge"
+  },
+  {
+    "key": "block.minecraft.banner.creeper.orange",
+    "english_translation": "Orange Creeper Charge"
+  },
+  {
+    "key": "block.minecraft.banner.creeper.white",
+    "english_translation": "White Creeper Charge"
+  },
+  {
+    "key": "block.minecraft.banner.bricks.black",
+    "english_translation": "Black Field Masoned"
+  },
+  {
+    "key": "block.minecraft.banner.bricks.red",
+    "english_translation": "Red Field Masoned"
+  },
+  {
+    "key": "block.minecraft.banner.bricks.green",
+    "english_translation": "Green Field Masoned"
+  },
+  {
+    "key": "block.minecraft.banner.bricks.brown",
+    "english_translation": "Brown Field Masoned"
+  },
+  {
+    "key": "block.minecraft.banner.bricks.blue",
+    "english_translation": "Blue Field Masoned"
+  },
+  {
+    "key": "block.minecraft.banner.bricks.purple",
+    "english_translation": "Purple Field Masoned"
+  },
+  {
+    "key": "block.minecraft.banner.bricks.cyan",
+    "english_translation": "Cyan Field Masoned"
+  },
+  {
+    "key": "block.minecraft.banner.bricks.light_gray",
+    "english_translation": "Light Gray Field Masoned"
+  },
+  {
+    "key": "block.minecraft.banner.bricks.gray",
+    "english_translation": "Gray Field Masoned"
+  },
+  {
+    "key": "block.minecraft.banner.bricks.pink",
+    "english_translation": "Pink Field Masoned"
+  },
+  {
+    "key": "block.minecraft.banner.bricks.lime",
+    "english_translation": "Lime Field Masoned"
+  },
+  {
+    "key": "block.minecraft.banner.bricks.yellow",
+    "english_translation": "Yellow Field Masoned"
+  },
+  {
+    "key": "block.minecraft.banner.bricks.light_blue",
+    "english_translation": "Light Blue Field Masoned"
+  },
+  {
+    "key": "block.minecraft.banner.bricks.magenta",
+    "english_translation": "Magenta Field Masoned"
+  },
+  {
+    "key": "block.minecraft.banner.bricks.orange",
+    "english_translation": "Orange Field Masoned"
+  },
+  {
+    "key": "block.minecraft.banner.bricks.white",
+    "english_translation": "White Field Masoned"
+  },
+  {
+    "key": "block.minecraft.banner.gradient.black",
+    "english_translation": "Black Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.gradient.red",
+    "english_translation": "Red Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.gradient.green",
+    "english_translation": "Green Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.gradient.brown",
+    "english_translation": "Brown Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.gradient.blue",
+    "english_translation": "Blue Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.gradient.purple",
+    "english_translation": "Purple Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.gradient.cyan",
+    "english_translation": "Cyan Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.gradient.light_gray",
+    "english_translation": "Light Gray Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.gradient.gray",
+    "english_translation": "Gray Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.gradient.pink",
+    "english_translation": "Pink Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.gradient.lime",
+    "english_translation": "Lime Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.gradient.yellow",
+    "english_translation": "Yellow Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.gradient.light_blue",
+    "english_translation": "Light Blue Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.gradient.magenta",
+    "english_translation": "Magenta Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.gradient.orange",
+    "english_translation": "Orange Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.gradient.white",
+    "english_translation": "White Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.gradient_up.black",
+    "english_translation": "Black Base Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.gradient_up.red",
+    "english_translation": "Red Base Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.gradient_up.green",
+    "english_translation": "Green Base Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.gradient_up.brown",
+    "english_translation": "Brown Base Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.gradient_up.blue",
+    "english_translation": "Blue Base Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.gradient_up.purple",
+    "english_translation": "Purple Base Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.gradient_up.cyan",
+    "english_translation": "Cyan Base Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.gradient_up.light_gray",
+    "english_translation": "Light Gray Base Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.gradient_up.gray",
+    "english_translation": "Gray Base Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.gradient_up.pink",
+    "english_translation": "Pink Base Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.gradient_up.lime",
+    "english_translation": "Lime Base Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.gradient_up.yellow",
+    "english_translation": "Yellow Base Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.gradient_up.light_blue",
+    "english_translation": "Light Blue Base Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.gradient_up.magenta",
+    "english_translation": "Magenta Base Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.gradient_up.orange",
+    "english_translation": "Orange Base Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.gradient_up.white",
+    "english_translation": "White Base Gradient"
+  },
+  {
+    "key": "block.minecraft.banner.skull.black",
+    "english_translation": "Black Skull Charge"
+  },
+  {
+    "key": "block.minecraft.banner.skull.red",
+    "english_translation": "Red Skull Charge"
+  },
+  {
+    "key": "block.minecraft.banner.skull.green",
+    "english_translation": "Green Skull Charge"
+  },
+  {
+    "key": "block.minecraft.banner.skull.brown",
+    "english_translation": "Brown Skull Charge"
+  },
+  {
+    "key": "block.minecraft.banner.skull.blue",
+    "english_translation": "Blue Skull Charge"
+  },
+  {
+    "key": "block.minecraft.banner.skull.purple",
+    "english_translation": "Purple Skull Charge"
+  },
+  {
+    "key": "block.minecraft.banner.skull.cyan",
+    "english_translation": "Cyan Skull Charge"
+  },
+  {
+    "key": "block.minecraft.banner.skull.light_gray",
+    "english_translation": "Light Gray Skull Charge"
+  },
+  {
+    "key": "block.minecraft.banner.skull.gray",
+    "english_translation": "Gray Skull Charge"
+  },
+  {
+    "key": "block.minecraft.banner.skull.pink",
+    "english_translation": "Pink Skull Charge"
+  },
+  {
+    "key": "block.minecraft.banner.skull.lime",
+    "english_translation": "Lime Skull Charge"
+  },
+  {
+    "key": "block.minecraft.banner.skull.yellow",
+    "english_translation": "Yellow Skull Charge"
+  },
+  {
+    "key": "block.minecraft.banner.skull.light_blue",
+    "english_translation": "Light Blue Skull Charge"
+  },
+  {
+    "key": "block.minecraft.banner.skull.magenta",
+    "english_translation": "Magenta Skull Charge"
+  },
+  {
+    "key": "block.minecraft.banner.skull.orange",
+    "english_translation": "Orange Skull Charge"
+  },
+  {
+    "key": "block.minecraft.banner.skull.white",
+    "english_translation": "White Skull Charge"
+  },
+  {
+    "key": "block.minecraft.banner.flower.black",
+    "english_translation": "Black Flower Charge"
+  },
+  {
+    "key": "block.minecraft.banner.flower.red",
+    "english_translation": "Red Flower Charge"
+  },
+  {
+    "key": "block.minecraft.banner.flower.green",
+    "english_translation": "Green Flower Charge"
+  },
+  {
+    "key": "block.minecraft.banner.flower.brown",
+    "english_translation": "Brown Flower Charge"
+  },
+  {
+    "key": "block.minecraft.banner.flower.blue",
+    "english_translation": "Blue Flower Charge"
+  },
+  {
+    "key": "block.minecraft.banner.flower.purple",
+    "english_translation": "Purple Flower Charge"
+  },
+  {
+    "key": "block.minecraft.banner.flower.cyan",
+    "english_translation": "Cyan Flower Charge"
+  },
+  {
+    "key": "block.minecraft.banner.flower.light_gray",
+    "english_translation": "Light Gray Flower Charge"
+  },
+  {
+    "key": "block.minecraft.banner.flower.gray",
+    "english_translation": "Gray Flower Charge"
+  },
+  {
+    "key": "block.minecraft.banner.flower.pink",
+    "english_translation": "Pink Flower Charge"
+  },
+  {
+    "key": "block.minecraft.banner.flower.lime",
+    "english_translation": "Lime Flower Charge"
+  },
+  {
+    "key": "block.minecraft.banner.flower.yellow",
+    "english_translation": "Yellow Flower Charge"
+  },
+  {
+    "key": "block.minecraft.banner.flower.light_blue",
+    "english_translation": "Light Blue Flower Charge"
+  },
+  {
+    "key": "block.minecraft.banner.flower.magenta",
+    "english_translation": "Magenta Flower Charge"
+  },
+  {
+    "key": "block.minecraft.banner.flower.orange",
+    "english_translation": "Orange Flower Charge"
+  },
+  {
+    "key": "block.minecraft.banner.flower.white",
+    "english_translation": "White Flower Charge"
+  },
+  {
+    "key": "block.minecraft.banner.border.black",
+    "english_translation": "Black Bordure"
+  },
+  {
+    "key": "block.minecraft.banner.border.red",
+    "english_translation": "Red Bordure"
+  },
+  {
+    "key": "block.minecraft.banner.border.green",
+    "english_translation": "Green Bordure"
+  },
+  {
+    "key": "block.minecraft.banner.border.brown",
+    "english_translation": "Brown Bordure"
+  },
+  {
+    "key": "block.minecraft.banner.border.blue",
+    "english_translation": "Blue Bordure"
+  },
+  {
+    "key": "block.minecraft.banner.border.purple",
+    "english_translation": "Purple Bordure"
+  },
+  {
+    "key": "block.minecraft.banner.border.cyan",
+    "english_translation": "Cyan Bordure"
+  },
+  {
+    "key": "block.minecraft.banner.border.light_gray",
+    "english_translation": "Light Gray Bordure"
+  },
+  {
+    "key": "block.minecraft.banner.border.gray",
+    "english_translation": "Gray Bordure"
+  },
+  {
+    "key": "block.minecraft.banner.border.pink",
+    "english_translation": "Pink Bordure"
+  },
+  {
+    "key": "block.minecraft.banner.border.lime",
+    "english_translation": "Lime Bordure"
+  },
+  {
+    "key": "block.minecraft.banner.border.yellow",
+    "english_translation": "Yellow Bordure"
+  },
+  {
+    "key": "block.minecraft.banner.border.light_blue",
+    "english_translation": "Light Blue Bordure"
+  },
+  {
+    "key": "block.minecraft.banner.border.magenta",
+    "english_translation": "Magenta Bordure"
+  },
+  {
+    "key": "block.minecraft.banner.border.orange",
+    "english_translation": "Orange Bordure"
+  },
+  {
+    "key": "block.minecraft.banner.border.white",
+    "english_translation": "White Bordure"
+  },
+  {
+    "key": "block.minecraft.banner.curly_border.black",
+    "english_translation": "Black Bordure Indented"
+  },
+  {
+    "key": "block.minecraft.banner.curly_border.red",
+    "english_translation": "Red Bordure Indented"
+  },
+  {
+    "key": "block.minecraft.banner.curly_border.green",
+    "english_translation": "Green Bordure Indented"
+  },
+  {
+    "key": "block.minecraft.banner.curly_border.brown",
+    "english_translation": "Brown Bordure Indented"
+  },
+  {
+    "key": "block.minecraft.banner.curly_border.blue",
+    "english_translation": "Blue Bordure Indented"
+  },
+  {
+    "key": "block.minecraft.banner.curly_border.purple",
+    "english_translation": "Purple Bordure Indented"
+  },
+  {
+    "key": "block.minecraft.banner.curly_border.cyan",
+    "english_translation": "Cyan Bordure Indented"
+  },
+  {
+    "key": "block.minecraft.banner.curly_border.light_gray",
+    "english_translation": "Light Gray Bordure Indented"
+  },
+  {
+    "key": "block.minecraft.banner.curly_border.gray",
+    "english_translation": "Gray Bordure Indented"
+  },
+  {
+    "key": "block.minecraft.banner.curly_border.pink",
+    "english_translation": "Pink Bordure Indented"
+  },
+  {
+    "key": "block.minecraft.banner.curly_border.lime",
+    "english_translation": "Lime Bordure Indented"
+  },
+  {
+    "key": "block.minecraft.banner.curly_border.yellow",
+    "english_translation": "Yellow Bordure Indented"
+  },
+  {
+    "key": "block.minecraft.banner.curly_border.light_blue",
+    "english_translation": "Light Blue Bordure Indented"
+  },
+  {
+    "key": "block.minecraft.banner.curly_border.magenta",
+    "english_translation": "Magenta Bordure Indented"
+  },
+  {
+    "key": "block.minecraft.banner.curly_border.orange",
+    "english_translation": "Orange Bordure Indented"
+  },
+  {
+    "key": "block.minecraft.banner.curly_border.white",
+    "english_translation": "White Bordure Indented"
+  },
+  {
+    "key": "block.minecraft.banner.mojang.black",
+    "english_translation": "Black Thing"
+  },
+  {
+    "key": "block.minecraft.banner.mojang.red",
+    "english_translation": "Red Thing"
+  },
+  {
+    "key": "block.minecraft.banner.mojang.green",
+    "english_translation": "Green Thing"
+  },
+  {
+    "key": "block.minecraft.banner.mojang.brown",
+    "english_translation": "Brown Thing"
+  },
+  {
+    "key": "block.minecraft.banner.mojang.blue",
+    "english_translation": "Blue Thing"
+  },
+  {
+    "key": "block.minecraft.banner.mojang.purple",
+    "english_translation": "Purple Thing"
+  },
+  {
+    "key": "block.minecraft.banner.mojang.cyan",
+    "english_translation": "Cyan Thing"
+  },
+  {
+    "key": "block.minecraft.banner.mojang.light_gray",
+    "english_translation": "Light Gray Thing"
+  },
+  {
+    "key": "block.minecraft.banner.mojang.gray",
+    "english_translation": "Gray Thing"
+  },
+  {
+    "key": "block.minecraft.banner.mojang.pink",
+    "english_translation": "Pink Thing"
+  },
+  {
+    "key": "block.minecraft.banner.mojang.lime",
+    "english_translation": "Lime Thing"
+  },
+  {
+    "key": "block.minecraft.banner.mojang.yellow",
+    "english_translation": "Yellow Thing"
+  },
+  {
+    "key": "block.minecraft.banner.mojang.light_blue",
+    "english_translation": "Light Blue Thing"
+  },
+  {
+    "key": "block.minecraft.banner.mojang.magenta",
+    "english_translation": "Magenta Thing"
+  },
+  {
+    "key": "block.minecraft.banner.mojang.orange",
+    "english_translation": "Orange Thing"
+  },
+  {
+    "key": "block.minecraft.banner.mojang.white",
+    "english_translation": "White Thing"
+  },
+  {
+    "key": "block.minecraft.banner.straight_cross.black",
+    "english_translation": "Black Cross"
+  },
+  {
+    "key": "block.minecraft.banner.straight_cross.red",
+    "english_translation": "Red Cross"
+  },
+  {
+    "key": "block.minecraft.banner.straight_cross.green",
+    "english_translation": "Green Cross"
+  },
+  {
+    "key": "block.minecraft.banner.straight_cross.brown",
+    "english_translation": "Brown Cross"
+  },
+  {
+    "key": "block.minecraft.banner.straight_cross.blue",
+    "english_translation": "Blue Cross"
+  },
+  {
+    "key": "block.minecraft.banner.straight_cross.purple",
+    "english_translation": "Purple Cross"
+  },
+  {
+    "key": "block.minecraft.banner.straight_cross.cyan",
+    "english_translation": "Cyan Cross"
+  },
+  {
+    "key": "block.minecraft.banner.straight_cross.light_gray",
+    "english_translation": "Light Gray Cross"
+  },
+  {
+    "key": "block.minecraft.banner.straight_cross.gray",
+    "english_translation": "Gray Cross"
+  },
+  {
+    "key": "block.minecraft.banner.straight_cross.pink",
+    "english_translation": "Pink Cross"
+  },
+  {
+    "key": "block.minecraft.banner.straight_cross.lime",
+    "english_translation": "Lime Cross"
+  },
+  {
+    "key": "block.minecraft.banner.straight_cross.yellow",
+    "english_translation": "Yellow Cross"
+  },
+  {
+    "key": "block.minecraft.banner.straight_cross.light_blue",
+    "english_translation": "Light Blue Cross"
+  },
+  {
+    "key": "block.minecraft.banner.straight_cross.magenta",
+    "english_translation": "Magenta Cross"
+  },
+  {
+    "key": "block.minecraft.banner.straight_cross.orange",
+    "english_translation": "Orange Cross"
+  },
+  {
+    "key": "block.minecraft.banner.straight_cross.white",
+    "english_translation": "White Cross"
+  },
+  {
+    "key": "block.minecraft.banner.globe.black",
+    "english_translation": "Black Globe"
+  },
+  {
+    "key": "block.minecraft.banner.globe.red",
+    "english_translation": "Red Globe"
+  },
+  {
+    "key": "block.minecraft.banner.globe.green",
+    "english_translation": "Green Globe"
+  },
+  {
+    "key": "block.minecraft.banner.globe.brown",
+    "english_translation": "Brown Globe"
+  },
+  {
+    "key": "block.minecraft.banner.globe.blue",
+    "english_translation": "Blue Globe"
+  },
+  {
+    "key": "block.minecraft.banner.globe.purple",
+    "english_translation": "Purple Globe"
+  },
+  {
+    "key": "block.minecraft.banner.globe.cyan",
+    "english_translation": "Cyan Globe"
+  },
+  {
+    "key": "block.minecraft.banner.globe.light_gray",
+    "english_translation": "Light Gray Globe"
+  },
+  {
+    "key": "block.minecraft.banner.globe.gray",
+    "english_translation": "Gray Globe"
+  },
+  {
+    "key": "block.minecraft.banner.globe.pink",
+    "english_translation": "Pink Globe"
+  },
+  {
+    "key": "block.minecraft.banner.globe.lime",
+    "english_translation": "Lime Globe"
+  },
+  {
+    "key": "block.minecraft.banner.globe.yellow",
+    "english_translation": "Yellow Globe"
+  },
+  {
+    "key": "block.minecraft.banner.globe.light_blue",
+    "english_translation": "Light Blue Globe"
+  },
+  {
+    "key": "block.minecraft.banner.globe.magenta",
+    "english_translation": "Magenta Globe"
+  },
+  {
+    "key": "block.minecraft.banner.globe.orange",
+    "english_translation": "Orange Globe"
+  },
+  {
+    "key": "block.minecraft.banner.globe.white",
+    "english_translation": "White Globe"
+  },
+  {
+    "key": "block.minecraft.banner.piglin.black",
+    "english_translation": "Black Snout"
+  },
+  {
+    "key": "block.minecraft.banner.piglin.red",
+    "english_translation": "Red Snout"
+  },
+  {
+    "key": "block.minecraft.banner.piglin.green",
+    "english_translation": "Green Snout"
+  },
+  {
+    "key": "block.minecraft.banner.piglin.brown",
+    "english_translation": "Brown Snout"
+  },
+  {
+    "key": "block.minecraft.banner.piglin.blue",
+    "english_translation": "Blue Snout"
+  },
+  {
+    "key": "block.minecraft.banner.piglin.purple",
+    "english_translation": "Purple Snout"
+  },
+  {
+    "key": "block.minecraft.banner.piglin.cyan",
+    "english_translation": "Cyan Snout"
+  },
+  {
+    "key": "block.minecraft.banner.piglin.light_gray",
+    "english_translation": "Light Gray Snout"
+  },
+  {
+    "key": "block.minecraft.banner.piglin.gray",
+    "english_translation": "Gray Snout"
+  },
+  {
+    "key": "block.minecraft.banner.piglin.pink",
+    "english_translation": "Pink Snout"
+  },
+  {
+    "key": "block.minecraft.banner.piglin.lime",
+    "english_translation": "Lime Snout"
+  },
+  {
+    "key": "block.minecraft.banner.piglin.yellow",
+    "english_translation": "Yellow Snout"
+  },
+  {
+    "key": "block.minecraft.banner.piglin.light_blue",
+    "english_translation": "Light Blue Snout"
+  },
+  {
+    "key": "block.minecraft.banner.piglin.magenta",
+    "english_translation": "Magenta Snout"
+  },
+  {
+    "key": "block.minecraft.banner.piglin.orange",
+    "english_translation": "Orange Snout"
+  },
+  {
+    "key": "block.minecraft.banner.piglin.white",
+    "english_translation": "White Snout"
+  },
+  {
+    "key": "subtitles.ambient.cave",
+    "english_translation": "Eerie noise"
+  },
+  {
+    "key": "subtitles.block.amethyst_block.chime",
+    "english_translation": "Amethyst chimes"
+  },
+  {
+    "key": "subtitles.block.anvil.destroy",
+    "english_translation": "Anvil destroyed"
+  },
+  {
+    "key": "subtitles.block.anvil.land",
+    "english_translation": "Anvil landed"
+  },
+  {
+    "key": "subtitles.block.anvil.use",
+    "english_translation": "Anvil used"
+  },
+  {
+    "key": "subtitles.block.barrel.close",
+    "english_translation": "Barrel closes"
+  },
+  {
+    "key": "subtitles.block.barrel.open",
+    "english_translation": "Barrel opens"
+  },
+  {
+    "key": "subtitles.block.beacon.activate",
+    "english_translation": "Beacon activates"
+  },
+  {
+    "key": "subtitles.block.beacon.ambient",
+    "english_translation": "Beacon hums"
+  },
+  {
+    "key": "subtitles.block.beacon.deactivate",
+    "english_translation": "Beacon deactivates"
+  },
+  {
+    "key": "subtitles.block.beacon.power_select",
+    "english_translation": "Beacon power selected"
+  },
+  {
+    "key": "subtitles.block.beehive.drip",
+    "english_translation": "Honey drips"
+  },
+  {
+    "key": "subtitles.block.beehive.enter",
+    "english_translation": "Bee enters hive"
+  },
+  {
+    "key": "subtitles.block.beehive.exit",
+    "english_translation": "Bee leaves hive"
+  },
+  {
+    "key": "subtitles.block.beehive.shear",
+    "english_translation": "Shears scrape"
+  },
+  {
+    "key": "subtitles.block.beehive.work",
+    "english_translation": "Bees work"
+  },
+  {
+    "key": "subtitles.block.bell.resonate",
+    "english_translation": "Bell resonates"
+  },
+  {
+    "key": "subtitles.block.bell.use",
+    "english_translation": "Bell rings"
+  },
+  {
+    "key": "subtitles.block.big_dripleaf.tilt_down",
+    "english_translation": "Dripleaf tilts down"
+  },
+  {
+    "key": "subtitles.block.big_dripleaf.tilt_up",
+    "english_translation": "Dripleaf tilts up"
+  },
+  {
+    "key": "subtitles.block.blastfurnace.fire_crackle",
+    "english_translation": "Blast Furnace crackles"
+  },
+  {
+    "key": "subtitles.block.brewing_stand.brew",
+    "english_translation": "Brewing Stand bubbles"
+  },
+  {
+    "key": "subtitles.block.bubble_column.bubble_pop",
+    "english_translation": "Bubbles pop"
+  },
+  {
+    "key": "subtitles.block.bubble_column.upwards_ambient",
+    "english_translation": "Bubbles flow"
+  },
+  {
+    "key": "subtitles.block.bubble_column.upwards_inside",
+    "english_translation": "Bubbles woosh"
+  },
+  {
+    "key": "subtitles.block.bubble_column.whirlpool_ambient",
+    "english_translation": "Bubbles whirl"
+  },
+  {
+    "key": "subtitles.block.bubble_column.whirlpool_inside",
+    "english_translation": "Bubbles zoom"
+  },
+  {
+    "key": "subtitles.block.button.click",
+    "english_translation": "Button clicks"
+  },
+  {
+    "key": "subtitles.block.campfire.crackle",
+    "english_translation": "Campfire crackles"
+  },
+  {
+    "key": "subtitles.block.candle.crackle",
+    "english_translation": "Candle crackles"
+  },
+  {
+    "key": "subtitles.block.cake.add_candle",
+    "english_translation": "Cake squishes"
+  },
+  {
+    "key": "subtitles.block.chest.close",
+    "english_translation": "Chest closes"
+  },
+  {
+    "key": "subtitles.block.chest.locked",
+    "english_translation": "Chest locked"
+  },
+  {
+    "key": "subtitles.block.chest.open",
+    "english_translation": "Chest opens"
+  },
+  {
+    "key": "subtitles.block.chorus_flower.death",
+    "english_translation": "Chorus Flower withers"
+  },
+  {
+    "key": "subtitles.block.chorus_flower.grow",
+    "english_translation": "Chorus Flower grows"
+  },
+  {
+    "key": "subtitles.block.comparator.click",
+    "english_translation": "Comparator clicks"
+  },
+  {
+    "key": "subtitles.block.composter.empty",
+    "english_translation": "Composter emptied"
+  },
+  {
+    "key": "subtitles.block.composter.fill",
+    "english_translation": "Composter filled"
+  },
+  {
+    "key": "subtitles.block.composter.ready",
+    "english_translation": "Composter composts"
+  },
+  {
+    "key": "subtitles.block.conduit.activate",
+    "english_translation": "Conduit activates"
+  },
+  {
+    "key": "subtitles.block.conduit.ambient",
+    "english_translation": "Conduit pulses"
+  },
+  {
+    "key": "subtitles.block.conduit.attack.target",
+    "english_translation": "Conduit attacks"
+  },
+  {
+    "key": "subtitles.block.conduit.deactivate",
+    "english_translation": "Conduit deactivates"
+  },
+  {
+    "key": "subtitles.block.dispenser.dispense",
+    "english_translation": "Dispensed item"
+  },
+  {
+    "key": "subtitles.block.dispenser.fail",
+    "english_translation": "Dispenser failed"
+  },
+  {
+    "key": "subtitles.block.door.toggle",
+    "english_translation": "Door creaks"
+  },
+  {
+    "key": "subtitles.block.enchantment_table.use",
+    "english_translation": "Enchanting Table used"
+  },
+  {
+    "key": "subtitles.block.end_portal.spawn",
+    "english_translation": "End Portal opens"
+  },
+  {
+    "key": "subtitles.block.end_portal_frame.fill",
+    "english_translation": "Eye of Ender attaches"
+  },
+  {
+    "key": "subtitles.block.fence_gate.toggle",
+    "english_translation": "Fence Gate creaks"
+  },
+  {
+    "key": "subtitles.block.fire.ambient",
+    "english_translation": "Fire crackles"
+  },
+  {
+    "key": "subtitles.block.fire.extinguish",
+    "english_translation": "Fire extinguished"
+  },
+  {
+    "key": "subtitles.block.frogspawn.hatch",
+    "english_translation": "Tadpole hatches"
+  },
+  {
+    "key": "subtitles.block.furnace.fire_crackle",
+    "english_translation": "Furnace crackles"
+  },
+  {
+    "key": "subtitles.block.generic.break",
+    "english_translation": "Block broken"
+  },
+  {
+    "key": "subtitles.block.generic.footsteps",
+    "english_translation": "Footsteps"
+  },
+  {
+    "key": "subtitles.block.generic.hit",
+    "english_translation": "Block breaking"
+  },
+  {
+    "key": "subtitles.block.generic.place",
+    "english_translation": "Block placed"
+  },
+  {
+    "key": "subtitles.block.grindstone.use",
+    "english_translation": "Grindstone used"
+  },
+  {
+    "key": "subtitles.block.growing_plant.crop",
+    "english_translation": "Plant cropped"
+  },
+  {
+    "key": "subtitles.block.honey_block.slide",
+    "english_translation": "Sliding down a honey block"
+  },
+  {
+    "key": "subtitles.item.honeycomb.wax_on",
+    "english_translation": "Wax on"
+  },
+  {
+    "key": "subtitles.block.iron_trapdoor.close",
+    "english_translation": "Trapdoor closes"
+  },
+  {
+    "key": "subtitles.block.iron_trapdoor.open",
+    "english_translation": "Trapdoor opens"
+  },
+  {
+    "key": "subtitles.block.lava.ambient",
+    "english_translation": "Lava pops"
+  },
+  {
+    "key": "subtitles.block.lava.extinguish",
+    "english_translation": "Lava hisses"
+  },
+  {
+    "key": "subtitles.block.lever.click",
+    "english_translation": "Lever clicks"
+  },
+  {
+    "key": "subtitles.block.note_block.note",
+    "english_translation": "Note Block plays"
+  },
+  {
+    "key": "subtitles.block.piston.move",
+    "english_translation": "Piston moves"
+  },
+  {
+    "key": "subtitles.block.pointed_dripstone.land",
+    "english_translation": "Stalactite crashes down"
+  },
+  {
+    "key": "subtitles.block.pointed_dripstone.drip_lava",
+    "english_translation": "Lava drips"
+  },
+  {
+    "key": "subtitles.block.pointed_dripstone.drip_water",
+    "english_translation": "Water drips"
+  },
+  {
+    "key": "subtitles.block.pointed_dripstone.drip_lava_into_cauldron",
+    "english_translation": "Lava drips into Cauldron"
+  },
+  {
+    "key": "subtitles.block.pointed_dripstone.drip_water_into_cauldron",
+    "english_translation": "Water drips into Cauldron"
+  },
+  {
+    "key": "subtitles.block.portal.ambient",
+    "english_translation": "Portal whooshes"
+  },
+  {
+    "key": "subtitles.block.portal.travel",
+    "english_translation": "Portal noise fades"
+  },
+  {
+    "key": "subtitles.block.portal.trigger",
+    "english_translation": "Portal noise intensifies"
+  },
+  {
+    "key": "subtitles.block.pressure_plate.click",
+    "english_translation": "Pressure Plate clicks"
+  },
+  {
+    "key": "subtitles.block.pumpkin.carve",
+    "english_translation": "Shears carve"
+  },
+  {
+    "key": "subtitles.block.redstone_torch.burnout",
+    "english_translation": "Torch fizzes"
+  },
+  {
+    "key": "subtitles.block.respawn_anchor.ambient",
+    "english_translation": "Portal whooshes"
+  },
+  {
+    "key": "subtitles.block.respawn_anchor.charge",
+    "english_translation": "Respawn Anchor is charged"
+  },
+  {
+    "key": "subtitles.block.respawn_anchor.deplete",
+    "english_translation": "Respawn Anchor depletes"
+  },
+  {
+    "key": "subtitles.block.respawn_anchor.set_spawn",
+    "english_translation": "Respawn Anchor sets spawn"
+  },
+  {
+    "key": "subtitles.block.sculk.charge",
+    "english_translation": "Sculk bubbles"
+  },
+  {
+    "key": "subtitles.block.sculk.spread",
+    "english_translation": "Sculk spreads"
+  },
+  {
+    "key": "subtitles.block.sculk_catalyst.bloom",
+    "english_translation": "Sculk Catalyst blooms"
+  },
+  {
+    "key": "subtitles.block.sculk_sensor.clicking",
+    "english_translation": "Sculk Sensor starts clicking"
+  },
+  {
+    "key": "subtitles.block.sculk_sensor.clicking_stop",
+    "english_translation": "Sculk Sensor stops clicking"
+  },
+  {
+    "key": "subtitles.block.sculk_shrieker.shriek",
+    "english_translation": "Sculk Shrieker shrieks"
+  },
+  {
+    "key": "subtitles.block.shulker_box.close",
+    "english_translation": "Shulker closes"
+  },
+  {
+    "key": "subtitles.block.shulker_box.open",
+    "english_translation": "Shulker opens"
+  },
+  {
+    "key": "subtitles.block.smithing_table.use",
+    "english_translation": "Smithing Table used"
+  },
+  {
+    "key": "subtitles.block.smoker.smoke",
+    "english_translation": "Smoker smokes"
+  },
+  {
+    "key": "subtitles.block.sweet_berry_bush.pick_berries",
+    "english_translation": "Berries pop"
+  },
+  {
+    "key": "subtitles.block.trapdoor.toggle",
+    "english_translation": "Trapdoor creaks"
+  },
+  {
+    "key": "subtitles.block.tripwire.attach",
+    "english_translation": "Tripwire attaches"
+  },
+  {
+    "key": "subtitles.block.tripwire.click",
+    "english_translation": "Tripwire clicks"
+  },
+  {
+    "key": "subtitles.block.tripwire.detach",
+    "english_translation": "Tripwire detaches"
+  },
+  {
+    "key": "subtitles.block.water.ambient",
+    "english_translation": "Water flows"
+  },
+  {
+    "key": "subtitles.enchant.thorns.hit",
+    "english_translation": "Thorns prick"
+  },
+  {
+    "key": "subtitles.entity.allay.death",
+    "english_translation": "Allay dies"
+  },
+  {
+    "key": "subtitles.entity.allay.hurt",
+    "english_translation": "Allay hurts"
+  },
+  {
+    "key": "subtitles.entity.allay.ambient_with_item",
+    "english_translation": "Allay seeks"
+  },
+  {
+    "key": "subtitles.entity.allay.ambient_without_item",
+    "english_translation": "Allay yearns"
+  },
+  {
+    "key": "subtitles.entity.allay.item_given",
+    "english_translation": "Allay chortles"
+  },
+  {
+    "key": "subtitles.entity.allay.item_taken",
+    "english_translation": "Allay allays"
+  },
+  {
+    "key": "subtitles.entity.allay.item_thrown",
+    "english_translation": "Allay tosses"
+  },
+  {
+    "key": "subtitles.entity.armor_stand.fall",
+    "english_translation": "Something fell"
+  },
+  {
+    "key": "subtitles.entity.arrow.hit",
+    "english_translation": "Arrow hits"
+  },
+  {
+    "key": "subtitles.entity.arrow.hit_player",
+    "english_translation": "Player hit"
+  },
+  {
+    "key": "subtitles.entity.arrow.shoot",
+    "english_translation": "Arrow fired"
+  },
+  {
+    "key": "subtitles.entity.axolotl.attack",
+    "english_translation": "Axolotl attacks"
+  },
+  {
+    "key": "subtitles.entity.axolotl.death",
+    "english_translation": "Axolotl dies"
+  },
+  {
+    "key": "subtitles.entity.axolotl.hurt",
+    "english_translation": "Axolotl hurts"
+  },
+  {
+    "key": "subtitles.entity.axolotl.idle_air",
+    "english_translation": "Axolotl chirps"
+  },
+  {
+    "key": "subtitles.entity.axolotl.idle_water",
+    "english_translation": "Axolotl chirps"
+  },
+  {
+    "key": "subtitles.entity.axolotl.splash",
+    "english_translation": "Axolotl splashes"
+  },
+  {
+    "key": "subtitles.entity.axolotl.swim",
+    "english_translation": "Axolotl swims"
+  },
+  {
+    "key": "subtitles.entity.bat.ambient",
+    "english_translation": "Bat screeches"
+  },
+  {
+    "key": "subtitles.entity.bat.death",
+    "english_translation": "Bat dies"
+  },
+  {
+    "key": "subtitles.entity.bat.hurt",
+    "english_translation": "Bat hurts"
+  },
+  {
+    "key": "subtitles.entity.bat.takeoff",
+    "english_translation": "Bat takes off"
+  },
+  {
+    "key": "subtitles.entity.bee.ambient",
+    "english_translation": "Bee buzzes"
+  },
+  {
+    "key": "subtitles.entity.bee.death",
+    "english_translation": "Bee dies"
+  },
+  {
+    "key": "subtitles.entity.bee.hurt",
+    "english_translation": "Bee hurts"
+  },
+  {
+    "key": "subtitles.entity.bee.loop",
+    "english_translation": "Bee buzzes"
+  },
+  {
+    "key": "subtitles.entity.bee.loop_aggressive",
+    "english_translation": "Bee buzzes angrily"
+  },
+  {
+    "key": "subtitles.entity.bee.pollinate",
+    "english_translation": "Bee buzzes happily"
+  },
+  {
+    "key": "subtitles.entity.bee.sting",
+    "english_translation": "Bee stings"
+  },
+  {
+    "key": "subtitles.entity.blaze.ambient",
+    "english_translation": "Blaze breathes"
+  },
+  {
+    "key": "subtitles.entity.blaze.burn",
+    "english_translation": "Blaze crackles"
+  },
+  {
+    "key": "subtitles.entity.blaze.death",
+    "english_translation": "Blaze dies"
+  },
+  {
+    "key": "subtitles.entity.blaze.hurt",
+    "english_translation": "Blaze hurts"
+  },
+  {
+    "key": "subtitles.entity.blaze.shoot",
+    "english_translation": "Blaze shoots"
+  },
+  {
+    "key": "subtitles.entity.boat.paddle_land",
+    "english_translation": "Rowing"
+  },
+  {
+    "key": "subtitles.entity.boat.paddle_water",
+    "english_translation": "Rowing"
+  },
+  {
+    "key": "subtitles.entity.cat.ambient",
+    "english_translation": "Cat meows"
+  },
+  {
+    "key": "subtitles.entity.cat.beg_for_food",
+    "english_translation": "Cat begs"
+  },
+  {
+    "key": "subtitles.entity.cat.death",
+    "english_translation": "Cat dies"
+  },
+  {
+    "key": "subtitles.entity.cat.eat",
+    "english_translation": "Cat eats"
+  },
+  {
+    "key": "subtitles.entity.cat.hiss",
+    "english_translation": "Cat hisses"
+  },
+  {
+    "key": "subtitles.entity.cat.hurt",
+    "english_translation": "Cat hurts"
+  },
+  {
+    "key": "subtitles.entity.cat.purr",
+    "english_translation": "Cat purrs"
+  },
+  {
+    "key": "subtitles.entity.chicken.ambient",
+    "english_translation": "Chicken clucks"
+  },
+  {
+    "key": "subtitles.entity.chicken.death",
+    "english_translation": "Chicken dies"
+  },
+  {
+    "key": "subtitles.entity.chicken.egg",
+    "english_translation": "Chicken plops"
+  },
+  {
+    "key": "subtitles.entity.chicken.hurt",
+    "english_translation": "Chicken hurts"
+  },
+  {
+    "key": "subtitles.entity.cod.death",
+    "english_translation": "Cod dies"
+  },
+  {
+    "key": "subtitles.entity.cod.flop",
+    "english_translation": "Cod flops"
+  },
+  {
+    "key": "subtitles.entity.cod.hurt",
+    "english_translation": "Cod hurts"
+  },
+  {
+    "key": "subtitles.entity.cow.ambient",
+    "english_translation": "Cow moos"
+  },
+  {
+    "key": "subtitles.entity.cow.death",
+    "english_translation": "Cow dies"
+  },
+  {
+    "key": "subtitles.entity.cow.hurt",
+    "english_translation": "Cow hurts"
+  },
+  {
+    "key": "subtitles.entity.cow.milk",
+    "english_translation": "Cow gets milked"
+  },
+  {
+    "key": "subtitles.entity.creeper.death",
+    "english_translation": "Creeper dies"
+  },
+  {
+    "key": "subtitles.entity.creeper.hurt",
+    "english_translation": "Creeper hurts"
+  },
+  {
+    "key": "subtitles.entity.creeper.primed",
+    "english_translation": "Creeper hisses"
+  },
+  {
+    "key": "subtitles.entity.dolphin.ambient",
+    "english_translation": "Dolphin chirps"
+  },
+  {
+    "key": "subtitles.entity.dolphin.ambient_water",
+    "english_translation": "Dolphin whistles"
+  },
+  {
+    "key": "subtitles.entity.dolphin.attack",
+    "english_translation": "Dolphin attacks"
+  },
+  {
+    "key": "subtitles.entity.dolphin.death",
+    "english_translation": "Dolphin dies"
+  },
+  {
+    "key": "subtitles.entity.dolphin.eat",
+    "english_translation": "Dolphin eats"
+  },
+  {
+    "key": "subtitles.entity.dolphin.hurt",
+    "english_translation": "Dolphin hurts"
+  },
+  {
+    "key": "subtitles.entity.dolphin.jump",
+    "english_translation": "Dolphin jumps"
+  },
+  {
+    "key": "subtitles.entity.dolphin.play",
+    "english_translation": "Dolphin plays"
+  },
+  {
+    "key": "subtitles.entity.dolphin.splash",
+    "english_translation": "Dolphin splashes"
+  },
+  {
+    "key": "subtitles.entity.dolphin.swim",
+    "english_translation": "Dolphin swims"
+  },
+  {
+    "key": "subtitles.entity.donkey.ambient",
+    "english_translation": "Donkey hee-haws"
+  },
+  {
+    "key": "subtitles.entity.donkey.angry",
+    "english_translation": "Donkey neighs"
+  },
+  {
+    "key": "subtitles.entity.donkey.chest",
+    "english_translation": "Donkey Chest equips"
+  },
+  {
+    "key": "subtitles.entity.donkey.death",
+    "english_translation": "Donkey dies"
+  },
+  {
+    "key": "subtitles.entity.donkey.eat",
+    "english_translation": "Donkey eats"
+  },
+  {
+    "key": "subtitles.entity.donkey.hurt",
+    "english_translation": "Donkey hurts"
+  },
+  {
+    "key": "subtitles.entity.drowned.ambient",
+    "english_translation": "Drowned gurgles"
+  },
+  {
+    "key": "subtitles.entity.drowned.ambient_water",
+    "english_translation": "Drowned gurgles"
+  },
+  {
+    "key": "subtitles.entity.drowned.death",
+    "english_translation": "Drowned dies"
+  },
+  {
+    "key": "subtitles.entity.drowned.hurt",
+    "english_translation": "Drowned hurts"
+  },
+  {
+    "key": "subtitles.entity.drowned.shoot",
+    "english_translation": "Drowned throws Trident"
+  },
+  {
+    "key": "subtitles.entity.drowned.step",
+    "english_translation": "Drowned steps"
+  },
+  {
+    "key": "subtitles.entity.drowned.swim",
+    "english_translation": "Drowned swims"
+  },
+  {
+    "key": "subtitles.entity.egg.throw",
+    "english_translation": "Egg flies"
+  },
+  {
+    "key": "subtitles.entity.elder_guardian.ambient",
+    "english_translation": "Elder Guardian moans"
+  },
+  {
+    "key": "subtitles.entity.elder_guardian.ambient_land",
+    "english_translation": "Elder Guardian flaps"
+  },
+  {
+    "key": "subtitles.entity.elder_guardian.curse",
+    "english_translation": "Elder Guardian curses"
+  },
+  {
+    "key": "subtitles.entity.elder_guardian.death",
+    "english_translation": "Elder Guardian dies"
+  },
+  {
+    "key": "subtitles.entity.elder_guardian.flop",
+    "english_translation": "Elder Guardian flops"
+  },
+  {
+    "key": "subtitles.entity.elder_guardian.hurt",
+    "english_translation": "Elder Guardian hurts"
+  },
+  {
+    "key": "subtitles.entity.ender_dragon.ambient",
+    "english_translation": "Dragon roars"
+  },
+  {
+    "key": "subtitles.entity.ender_dragon.death",
+    "english_translation": "Dragon dies"
+  },
+  {
+    "key": "subtitles.entity.ender_dragon.flap",
+    "english_translation": "Dragon flaps"
+  },
+  {
+    "key": "subtitles.entity.ender_dragon.growl",
+    "english_translation": "Dragon growls"
+  },
+  {
+    "key": "subtitles.entity.ender_dragon.hurt",
+    "english_translation": "Dragon hurts"
+  },
+  {
+    "key": "subtitles.entity.ender_dragon.shoot",
+    "english_translation": "Dragon shoots"
+  },
+  {
+    "key": "subtitles.entity.ender_eye.death",
+    "english_translation": "Eye of Ender falls"
+  },
+  {
+    "key": "subtitles.entity.ender_eye.launch",
+    "english_translation": "Eye of Ender shoots"
+  },
+  {
+    "key": "subtitles.entity.ender_pearl.throw",
+    "english_translation": "Ender Pearl flies"
+  },
+  {
+    "key": "subtitles.entity.enderman.ambient",
+    "english_translation": "Enderman vwoops"
+  },
+  {
+    "key": "subtitles.entity.enderman.death",
+    "english_translation": "Enderman dies"
+  },
+  {
+    "key": "subtitles.entity.enderman.hurt",
+    "english_translation": "Enderman hurts"
+  },
+  {
+    "key": "subtitles.entity.enderman.stare",
+    "english_translation": "Enderman cries out"
+  },
+  {
+    "key": "subtitles.entity.enderman.teleport",
+    "english_translation": "Enderman teleports"
+  },
+  {
+    "key": "subtitles.entity.endermite.ambient",
+    "english_translation": "Endermite scuttles"
+  },
+  {
+    "key": "subtitles.entity.endermite.death",
+    "english_translation": "Endermite dies"
+  },
+  {
+    "key": "subtitles.entity.endermite.hurt",
+    "english_translation": "Endermite hurts"
+  },
+  {
+    "key": "subtitles.entity.evoker.ambient",
+    "english_translation": "Evoker murmurs"
+  },
+  {
+    "key": "subtitles.entity.evoker.cast_spell",
+    "english_translation": "Evoker casts spell"
+  },
+  {
+    "key": "subtitles.entity.evoker.celebrate",
+    "english_translation": "Evoker cheers"
+  },
+  {
+    "key": "subtitles.entity.evoker.death",
+    "english_translation": "Evoker dies"
+  },
+  {
+    "key": "subtitles.entity.evoker.hurt",
+    "english_translation": "Evoker hurts"
+  },
+  {
+    "key": "subtitles.entity.evoker.prepare_attack",
+    "english_translation": "Evoker prepares attack"
+  },
+  {
+    "key": "subtitles.entity.evoker.prepare_summon",
+    "english_translation": "Evoker prepares summoning"
+  },
+  {
+    "key": "subtitles.entity.evoker.prepare_wololo",
+    "english_translation": "Evoker prepares charming"
+  },
+  {
+    "key": "subtitles.entity.evoker_fangs.attack",
+    "english_translation": "Fangs snap"
+  },
+  {
+    "key": "subtitles.entity.experience_orb.pickup",
+    "english_translation": "Experience gained"
+  },
+  {
+    "key": "subtitles.entity.firework_rocket.blast",
+    "english_translation": "Firework blasts"
+  },
+  {
+    "key": "subtitles.entity.firework_rocket.launch",
+    "english_translation": "Firework launches"
+  },
+  {
+    "key": "subtitles.entity.firework_rocket.twinkle",
+    "english_translation": "Firework twinkles"
+  },
+  {
+    "key": "subtitles.entity.fishing_bobber.retrieve",
+    "english_translation": "Bobber retrieved"
+  },
+  {
+    "key": "subtitles.entity.fishing_bobber.splash",
+    "english_translation": "Fishing Bobber splashes"
+  },
+  {
+    "key": "subtitles.entity.fishing_bobber.throw",
+    "english_translation": "Bobber thrown"
+  },
+  {
+    "key": "subtitles.entity.fox.aggro",
+    "english_translation": "Fox angers"
+  },
+  {
+    "key": "subtitles.entity.fox.ambient",
+    "english_translation": "Fox squeaks"
+  },
+  {
+    "key": "subtitles.entity.fox.bite",
+    "english_translation": "Fox bites"
+  },
+  {
+    "key": "subtitles.entity.fox.death",
+    "english_translation": "Fox dies"
+  },
+  {
+    "key": "subtitles.entity.fox.eat",
+    "english_translation": "Fox eats"
+  },
+  {
+    "key": "subtitles.entity.fox.hurt",
+    "english_translation": "Fox hurts"
+  },
+  {
+    "key": "subtitles.entity.fox.screech",
+    "english_translation": "Fox screeches"
+  },
+  {
+    "key": "subtitles.entity.fox.sleep",
+    "english_translation": "Fox snores"
+  },
+  {
+    "key": "subtitles.entity.fox.sniff",
+    "english_translation": "Fox sniffs"
+  },
+  {
+    "key": "subtitles.entity.fox.spit",
+    "english_translation": "Fox spits"
+  },
+  {
+    "key": "subtitles.entity.fox.teleport",
+    "english_translation": "Fox teleports"
+  },
+  {
+    "key": "subtitles.entity.frog.ambient",
+    "english_translation": "Frog croaks"
+  },
+  {
+    "key": "subtitles.entity.frog.death",
+    "english_translation": "Frog dies"
+  },
+  {
+    "key": "subtitles.entity.frog.eat",
+    "english_translation": "Frog eats"
+  },
+  {
+    "key": "subtitles.entity.frog.hurt",
+    "english_translation": "Frog hurts"
+  },
+  {
+    "key": "subtitles.entity.frog.lay_spawn",
+    "english_translation": "Frog lays spawn"
+  },
+  {
+    "key": "subtitles.entity.frog.long_jump",
+    "english_translation": "Frog jumps"
+  },
+  {
+    "key": "subtitles.entity.generic.big_fall",
+    "english_translation": "Something fell"
+  },
+  {
+    "key": "subtitles.entity.generic.burn",
+    "english_translation": "Burning"
+  },
+  {
+    "key": "subtitles.entity.generic.death",
+    "english_translation": "Dying"
+  },
+  {
+    "key": "subtitles.entity.generic.drink",
+    "english_translation": "Sipping"
+  },
+  {
+    "key": "subtitles.entity.generic.eat",
+    "english_translation": "Eating"
+  },
+  {
+    "key": "subtitles.entity.generic.explode",
+    "english_translation": "Explosion"
+  },
+  {
+    "key": "subtitles.entity.generic.extinguish_fire",
+    "english_translation": "Fire extinguishes"
+  },
+  {
+    "key": "subtitles.entity.generic.hurt",
+    "english_translation": "Something hurts"
+  },
+  {
+    "key": "subtitles.entity.generic.small_fall",
+    "english_translation": "Something trips"
+  },
+  {
+    "key": "subtitles.entity.generic.splash",
+    "english_translation": "Splashing"
+  },
+  {
+    "key": "subtitles.entity.generic.swim",
+    "english_translation": "Swimming"
+  },
+  {
+    "key": "subtitles.entity.ghast.ambient",
+    "english_translation": "Ghast cries"
+  },
+  {
+    "key": "subtitles.entity.ghast.death",
+    "english_translation": "Ghast dies"
+  },
+  {
+    "key": "subtitles.entity.ghast.hurt",
+    "english_translation": "Ghast hurts"
+  },
+  {
+    "key": "subtitles.entity.ghast.shoot",
+    "english_translation": "Ghast shoots"
+  },
+  {
+    "key": "subtitles.entity.glow_item_frame.add_item",
+    "english_translation": "Glow Item Frame fills"
+  },
+  {
+    "key": "subtitles.entity.glow_item_frame.break",
+    "english_translation": "Glow Item Frame breaks"
+  },
+  {
+    "key": "subtitles.entity.glow_item_frame.place",
+    "english_translation": "Glow Item Frame placed"
+  },
+  {
+    "key": "subtitles.entity.glow_item_frame.remove_item",
+    "english_translation": "Glow Item Frame empties"
+  },
+  {
+    "key": "subtitles.entity.glow_item_frame.rotate_item",
+    "english_translation": "Glow Item Frame clicks"
+  },
+  {
+    "key": "subtitles.entity.glow_squid.ambient",
+    "english_translation": "Glow Squid swims"
+  },
+  {
+    "key": "subtitles.entity.glow_squid.death",
+    "english_translation": "Glow Squid dies"
+  },
+  {
+    "key": "subtitles.entity.glow_squid.hurt",
+    "english_translation": "Glow Squid hurts"
+  },
+  {
+    "key": "subtitles.entity.glow_squid.squirt",
+    "english_translation": "Glow Squid shoots ink"
+  },
+  {
+    "key": "subtitles.entity.goat.ambient",
+    "english_translation": "Goat bleats"
+  },
+  {
+    "key": "subtitles.entity.goat.screaming.ambient",
+    "english_translation": "Goat bellows"
+  },
+  {
+    "key": "subtitles.entity.goat.death",
+    "english_translation": "Goat dies"
+  },
+  {
+    "key": "subtitles.entity.goat.eat",
+    "english_translation": "Goat eats"
+  },
+  {
+    "key": "subtitles.entity.goat.horn_break",
+    "english_translation": "Goat Horn breaks off"
+  },
+  {
+    "key": "subtitles.entity.goat.hurt",
+    "english_translation": "Goat hurts"
+  },
+  {
+    "key": "subtitles.entity.goat.long_jump",
+    "english_translation": "Goat leaps"
+  },
+  {
+    "key": "subtitles.entity.goat.milk",
+    "english_translation": "Goat gets milked"
+  },
+  {
+    "key": "subtitles.entity.goat.prepare_ram",
+    "english_translation": "Goat stomps"
+  },
+  {
+    "key": "subtitles.entity.goat.ram_impact",
+    "english_translation": "Goat rams"
+  },
+  {
+    "key": "subtitles.entity.goat.step",
+    "english_translation": "Goat steps"
+  },
+  {
+    "key": "subtitles.entity.guardian.ambient",
+    "english_translation": "Guardian moans"
+  },
+  {
+    "key": "subtitles.entity.guardian.ambient_land",
+    "english_translation": "Guardian flaps"
+  },
+  {
+    "key": "subtitles.entity.guardian.attack",
+    "english_translation": "Guardian shoots"
+  },
+  {
+    "key": "subtitles.entity.guardian.death",
+    "english_translation": "Guardian dies"
+  },
+  {
+    "key": "subtitles.entity.guardian.flop",
+    "english_translation": "Guardian flops"
+  },
+  {
+    "key": "subtitles.entity.guardian.hurt",
+    "english_translation": "Guardian hurts"
+  },
+  {
+    "key": "subtitles.entity.hoglin.ambient",
+    "english_translation": "Hoglin growls"
+  },
+  {
+    "key": "subtitles.entity.hoglin.angry",
+    "english_translation": "Hoglin growls angrily"
+  },
+  {
+    "key": "subtitles.entity.hoglin.attack",
+    "english_translation": "Hoglin attacks"
+  },
+  {
+    "key": "subtitles.entity.hoglin.converted_to_zombified",
+    "english_translation": "Hoglin converts to Zoglin"
+  },
+  {
+    "key": "subtitles.entity.hoglin.death",
+    "english_translation": "Hoglin dies"
+  },
+  {
+    "key": "subtitles.entity.hoglin.hurt",
+    "english_translation": "Hoglin hurts"
+  },
+  {
+    "key": "subtitles.entity.hoglin.retreat",
+    "english_translation": "Hoglin retreats"
+  },
+  {
+    "key": "subtitles.entity.hoglin.step",
+    "english_translation": "Hoglin steps"
+  },
+  {
+    "key": "subtitles.entity.horse.ambient",
+    "english_translation": "Horse neighs"
+  },
+  {
+    "key": "subtitles.entity.horse.angry",
+    "english_translation": "Horse neighs"
+  },
+  {
+    "key": "subtitles.entity.horse.armor",
+    "english_translation": "Horse armor equips"
+  },
+  {
+    "key": "subtitles.entity.horse.breathe",
+    "english_translation": "Horse breathes"
+  },
+  {
+    "key": "subtitles.entity.horse.death",
+    "english_translation": "Horse dies"
+  },
+  {
+    "key": "subtitles.entity.horse.eat",
+    "english_translation": "Horse eats"
+  },
+  {
+    "key": "subtitles.entity.horse.gallop",
+    "english_translation": "Horse gallops"
+  },
+  {
+    "key": "subtitles.entity.horse.hurt",
+    "english_translation": "Horse hurts"
+  },
+  {
+    "key": "subtitles.entity.horse.jump",
+    "english_translation": "Horse jumps"
+  },
+  {
+    "key": "subtitles.entity.horse.saddle",
+    "english_translation": "Saddle equips"
+  },
+  {
+    "key": "subtitles.entity.husk.ambient",
+    "english_translation": "Husk groans"
+  },
+  {
+    "key": "subtitles.entity.husk.converted_to_zombie",
+    "english_translation": "Husk converts to Zombie"
+  },
+  {
+    "key": "subtitles.entity.husk.death",
+    "english_translation": "Husk dies"
+  },
+  {
+    "key": "subtitles.entity.husk.hurt",
+    "english_translation": "Husk hurts"
+  },
+  {
+    "key": "subtitles.entity.illusioner.ambient",
+    "english_translation": "Illusioner murmurs"
+  },
+  {
+    "key": "subtitles.entity.illusioner.cast_spell",
+    "english_translation": "Illusioner casts spell"
+  },
+  {
+    "key": "subtitles.entity.illusioner.death",
+    "english_translation": "Illusioner dies"
+  },
+  {
+    "key": "subtitles.entity.illusioner.hurt",
+    "english_translation": "Illusioner hurts"
+  },
+  {
+    "key": "subtitles.entity.illusioner.mirror_move",
+    "english_translation": "Illusioner displaces"
+  },
+  {
+    "key": "subtitles.entity.illusioner.prepare_blindness",
+    "english_translation": "Illusioner prepares blindness"
+  },
+  {
+    "key": "subtitles.entity.illusioner.prepare_mirror",
+    "english_translation": "Illusioner prepares mirror image"
+  },
+  {
+    "key": "subtitles.entity.iron_golem.attack",
+    "english_translation": "Iron Golem attacks"
+  },
+  {
+    "key": "subtitles.entity.iron_golem.damage",
+    "english_translation": "Iron Golem breaks"
+  },
+  {
+    "key": "subtitles.entity.iron_golem.death",
+    "english_translation": "Iron Golem dies"
+  },
+  {
+    "key": "subtitles.entity.iron_golem.hurt",
+    "english_translation": "Iron Golem hurts"
+  },
+  {
+    "key": "subtitles.entity.iron_golem.repair",
+    "english_translation": "Iron Golem repaired"
+  },
+  {
+    "key": "subtitles.entity.item.break",
+    "english_translation": "Item breaks"
+  },
+  {
+    "key": "subtitles.entity.item.pickup",
+    "english_translation": "Item plops"
+  },
+  {
+    "key": "subtitles.entity.item_frame.add_item",
+    "english_translation": "Item Frame fills"
+  },
+  {
+    "key": "subtitles.entity.item_frame.break",
+    "english_translation": "Item Frame breaks"
+  },
+  {
+    "key": "subtitles.entity.item_frame.place",
+    "english_translation": "Item Frame placed"
+  },
+  {
+    "key": "subtitles.entity.item_frame.remove_item",
+    "english_translation": "Item Frame empties"
+  },
+  {
+    "key": "subtitles.entity.item_frame.rotate_item",
+    "english_translation": "Item Frame clicks"
+  },
+  {
+    "key": "subtitles.entity.leash_knot.break",
+    "english_translation": "Leash knot breaks"
+  },
+  {
+    "key": "subtitles.entity.leash_knot.place",
+    "english_translation": "Leash knot tied"
+  },
+  {
+    "key": "subtitles.entity.lightning_bolt.impact",
+    "english_translation": "Lightning strikes"
+  },
+  {
+    "key": "subtitles.entity.lightning_bolt.thunder",
+    "english_translation": "Thunder roars"
+  },
+  {
+    "key": "subtitles.entity.llama.ambient",
+    "english_translation": "Llama bleats"
+  },
+  {
+    "key": "subtitles.entity.llama.angry",
+    "english_translation": "Llama bleats angrily"
+  },
+  {
+    "key": "subtitles.entity.llama.chest",
+    "english_translation": "Llama Chest equips"
+  },
+  {
+    "key": "subtitles.entity.llama.death",
+    "english_translation": "Llama dies"
+  },
+  {
+    "key": "subtitles.entity.llama.eat",
+    "english_translation": "Llama eats"
+  },
+  {
+    "key": "subtitles.entity.llama.hurt",
+    "english_translation": "Llama hurts"
+  },
+  {
+    "key": "subtitles.entity.llama.spit",
+    "english_translation": "Llama spits"
+  },
+  {
+    "key": "subtitles.entity.llama.step",
+    "english_translation": "Llama steps"
+  },
+  {
+    "key": "subtitles.entity.llama.swag",
+    "english_translation": "Llama is decorated"
+  },
+  {
+    "key": "subtitles.entity.magma_cube.death",
+    "english_translation": "Magma Cube dies"
+  },
+  {
+    "key": "subtitles.entity.magma_cube.hurt",
+    "english_translation": "Magma Cube hurts"
+  },
+  {
+    "key": "subtitles.entity.magma_cube.squish",
+    "english_translation": "Magma Cube squishes"
+  },
+  {
+    "key": "subtitles.entity.minecart.riding",
+    "english_translation": "Minecart rolls"
+  },
+  {
+    "key": "subtitles.entity.mooshroom.convert",
+    "english_translation": "Mooshroom transforms"
+  },
+  {
+    "key": "subtitles.entity.mooshroom.eat",
+    "english_translation": "Mooshroom eats"
+  },
+  {
+    "key": "subtitles.entity.mooshroom.milk",
+    "english_translation": "Mooshroom gets milked"
+  },
+  {
+    "key": "subtitles.entity.mooshroom.suspicious_milk",
+    "english_translation": "Mooshroom gets milked suspiciously"
+  },
+  {
+    "key": "subtitles.entity.mule.ambient",
+    "english_translation": "Mule hee-haws"
+  },
+  {
+    "key": "subtitles.entity.mule.angry",
+    "english_translation": "Mule neighs"
+  },
+  {
+    "key": "subtitles.entity.mule.chest",
+    "english_translation": "Mule Chest equips"
+  },
+  {
+    "key": "subtitles.entity.mule.death",
+    "english_translation": "Mule dies"
+  },
+  {
+    "key": "subtitles.entity.mule.eat",
+    "english_translation": "Mule eats"
+  },
+  {
+    "key": "subtitles.entity.mule.hurt",
+    "english_translation": "Mule hurts"
+  },
+  {
+    "key": "subtitles.entity.painting.break",
+    "english_translation": "Painting breaks"
+  },
+  {
+    "key": "subtitles.entity.painting.place",
+    "english_translation": "Painting placed"
+  },
+  {
+    "key": "subtitles.entity.panda.aggressive_ambient",
+    "english_translation": "Panda huffs"
+  },
+  {
+    "key": "subtitles.entity.panda.ambient",
+    "english_translation": "Panda pants"
+  },
+  {
+    "key": "subtitles.entity.panda.bite",
+    "english_translation": "Panda bites"
+  },
+  {
+    "key": "subtitles.entity.panda.cant_breed",
+    "english_translation": "Panda bleats"
+  },
+  {
+    "key": "subtitles.entity.panda.death",
+    "english_translation": "Panda dies"
+  },
+  {
+    "key": "subtitles.entity.panda.eat",
+    "english_translation": "Panda eats"
+  },
+  {
+    "key": "subtitles.entity.panda.hurt",
+    "english_translation": "Panda hurts"
+  },
+  {
+    "key": "subtitles.entity.panda.pre_sneeze",
+    "english_translation": "Panda's nose tickles"
+  },
+  {
+    "key": "subtitles.entity.panda.sneeze",
+    "english_translation": "Panda sneezes"
+  },
+  {
+    "key": "subtitles.entity.panda.step",
+    "english_translation": "Panda steps"
+  },
+  {
+    "key": "subtitles.entity.panda.worried_ambient",
+    "english_translation": "Panda whimpers"
+  },
+  {
+    "key": "subtitles.entity.parrot.ambient",
+    "english_translation": "Parrot talks"
+  },
+  {
+    "key": "subtitles.entity.parrot.death",
+    "english_translation": "Parrot dies"
+  },
+  {
+    "key": "subtitles.entity.parrot.eats",
+    "english_translation": "Parrot eats"
+  },
+  {
+    "key": "subtitles.entity.parrot.fly",
+    "english_translation": "Parrot flutters"
+  },
+  {
+    "key": "subtitles.entity.parrot.hurts",
+    "english_translation": "Parrot hurts"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.blaze",
+    "english_translation": "Parrot breathes"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.creeper",
+    "english_translation": "Parrot hisses"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.drowned",
+    "english_translation": "Parrot gurgles"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.elder_guardian",
+    "english_translation": "Parrot moans"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.ender_dragon",
+    "english_translation": "Parrot roars"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.endermite",
+    "english_translation": "Parrot scuttles"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.evoker",
+    "english_translation": "Parrot murmurs"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.ghast",
+    "english_translation": "Parrot cries"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.guardian",
+    "english_translation": "Parrot moans"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.hoglin",
+    "english_translation": "Parrot growls"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.husk",
+    "english_translation": "Parrot groans"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.illusioner",
+    "english_translation": "Parrot murmurs"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.magma_cube",
+    "english_translation": "Parrot squishes"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.phantom",
+    "english_translation": "Parrot screeches"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.piglin",
+    "english_translation": "Parrot snorts"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.piglin_brute",
+    "english_translation": "Parrot snorts"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.pillager",
+    "english_translation": "Parrot murmurs"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.ravager",
+    "english_translation": "Parrot grunts"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.shulker",
+    "english_translation": "Parrot lurks"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.silverfish",
+    "english_translation": "Parrot hisses"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.skeleton",
+    "english_translation": "Parrot rattles"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.slime",
+    "english_translation": "Parrot squishes"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.spider",
+    "english_translation": "Parrot hisses"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.stray",
+    "english_translation": "Parrot rattles"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.vex",
+    "english_translation": "Parrot vexes"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.vindicator",
+    "english_translation": "Parrot mutters"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.warden",
+    "english_translation": "Parrot whines"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.witch",
+    "english_translation": "Parrot giggles"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.wither",
+    "english_translation": "Parrot angers"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.wither_skeleton",
+    "english_translation": "Parrot rattles"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.zoglin",
+    "english_translation": "Parrot growls"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.zombie",
+    "english_translation": "Parrot groans"
+  },
+  {
+    "key": "subtitles.entity.parrot.imitate.zombie_villager",
+    "english_translation": "Parrot groans"
+  },
+  {
+    "key": "subtitles.entity.phantom.ambient",
+    "english_translation": "Phantom screeches"
+  },
+  {
+    "key": "subtitles.entity.phantom.bite",
+    "english_translation": "Phantom bites"
+  },
+  {
+    "key": "subtitles.entity.phantom.death",
+    "english_translation": "Phantom dies"
+  },
+  {
+    "key": "subtitles.entity.phantom.flap",
+    "english_translation": "Phantom flaps"
+  },
+  {
+    "key": "subtitles.entity.phantom.hurt",
+    "english_translation": "Phantom hurts"
+  },
+  {
+    "key": "subtitles.entity.phantom.swoop",
+    "english_translation": "Phantom swoops"
+  },
+  {
+    "key": "subtitles.entity.pig.ambient",
+    "english_translation": "Pig oinks"
+  },
+  {
+    "key": "subtitles.entity.pig.death",
+    "english_translation": "Pig dies"
+  },
+  {
+    "key": "subtitles.entity.pig.hurt",
+    "english_translation": "Pig hurts"
+  },
+  {
+    "key": "subtitles.entity.pig.saddle",
+    "english_translation": "Saddle equips"
+  },
+  {
+    "key": "subtitles.entity.piglin.admiring_item",
+    "english_translation": "Piglin admires item"
+  },
+  {
+    "key": "subtitles.entity.piglin.ambient",
+    "english_translation": "Piglin snorts"
+  },
+  {
+    "key": "subtitles.entity.piglin.angry",
+    "english_translation": "Piglin snorts angrily"
+  },
+  {
+    "key": "subtitles.entity.piglin.celebrate",
+    "english_translation": "Piglin celebrates"
+  },
+  {
+    "key": "subtitles.entity.piglin.converted_to_zombified",
+    "english_translation": "Piglin converts to Zombified Piglin"
+  },
+  {
+    "key": "subtitles.entity.piglin.death",
+    "english_translation": "Piglin dies"
+  },
+  {
+    "key": "subtitles.entity.piglin.hurt",
+    "english_translation": "Piglin hurts"
+  },
+  {
+    "key": "subtitles.entity.piglin.jealous",
+    "english_translation": "Piglin snorts enviously"
+  },
+  {
+    "key": "subtitles.entity.piglin.retreat",
+    "english_translation": "Piglin retreats"
+  },
+  {
+    "key": "subtitles.entity.piglin.step",
+    "english_translation": "Piglin steps"
+  },
+  {
+    "key": "subtitles.entity.piglin_brute.ambient",
+    "english_translation": "Piglin Brute snorts"
+  },
+  {
+    "key": "subtitles.entity.piglin_brute.angry",
+    "english_translation": "Piglin Brute snorts angrily"
+  },
+  {
+    "key": "subtitles.entity.piglin_brute.death",
+    "english_translation": "Piglin Brute dies"
+  },
+  {
+    "key": "subtitles.entity.piglin_brute.hurt",
+    "english_translation": "Piglin Brute hurts"
+  },
+  {
+    "key": "subtitles.entity.piglin_brute.step",
+    "english_translation": "Piglin Brute steps"
+  },
+  {
+    "key": "subtitles.entity.piglin_brute.converted_to_zombified",
+    "english_translation": "Piglin Brute converts to Zombified Piglin"
+  },
+  {
+    "key": "subtitles.entity.pillager.ambient",
+    "english_translation": "Pillager murmurs"
+  },
+  {
+    "key": "subtitles.entity.pillager.celebrate",
+    "english_translation": "Pillager cheers"
+  },
+  {
+    "key": "subtitles.entity.pillager.death",
+    "english_translation": "Pillager dies"
+  },
+  {
+    "key": "subtitles.entity.pillager.hurt",
+    "english_translation": "Pillager hurts"
+  },
+  {
+    "key": "subtitles.entity.player.attack.crit",
+    "english_translation": "Critical attack"
+  },
+  {
+    "key": "subtitles.entity.player.attack.knockback",
+    "english_translation": "Knockback attack"
+  },
+  {
+    "key": "subtitles.entity.player.attack.strong",
+    "english_translation": "Strong attack"
+  },
+  {
+    "key": "subtitles.entity.player.attack.sweep",
+    "english_translation": "Sweeping attack"
+  },
+  {
+    "key": "subtitles.entity.player.attack.weak",
+    "english_translation": "Weak attack"
+  },
+  {
+    "key": "subtitles.entity.player.burp",
+    "english_translation": "Burp"
+  },
+  {
+    "key": "subtitles.entity.player.death",
+    "english_translation": "Player dies"
+  },
+  {
+    "key": "subtitles.entity.player.hurt",
+    "english_translation": "Player hurts"
+  },
+  {
+    "key": "subtitles.entity.player.hurt_drown",
+    "english_translation": "Player drowning"
+  },
+  {
+    "key": "subtitles.entity.player.hurt_on_fire",
+    "english_translation": "Player burns"
+  },
+  {
+    "key": "subtitles.entity.player.levelup",
+    "english_translation": "Player dings"
+  },
+  {
+    "key": "subtitles.entity.player.freeze_hurt",
+    "english_translation": "Player freezes"
+  },
+  {
+    "key": "subtitles.entity.polar_bear.ambient",
+    "english_translation": "Polar Bear groans"
+  },
+  {
+    "key": "subtitles.entity.polar_bear.ambient_baby",
+    "english_translation": "Polar Bear hums"
+  },
+  {
+    "key": "subtitles.entity.polar_bear.death",
+    "english_translation": "Polar Bear dies"
+  },
+  {
+    "key": "subtitles.entity.polar_bear.hurt",
+    "english_translation": "Polar Bear hurts"
+  },
+  {
+    "key": "subtitles.entity.polar_bear.warning",
+    "english_translation": "Polar Bear roars"
+  },
+  {
+    "key": "subtitles.entity.potion.splash",
+    "english_translation": "Bottle smashes"
+  },
+  {
+    "key": "subtitles.entity.potion.throw",
+    "english_translation": "Bottle thrown"
+  },
+  {
+    "key": "subtitles.entity.puffer_fish.blow_out",
+    "english_translation": "Pufferfish deflates"
+  },
+  {
+    "key": "subtitles.entity.puffer_fish.blow_up",
+    "english_translation": "Pufferfish inflates"
+  },
+  {
+    "key": "subtitles.entity.puffer_fish.death",
+    "english_translation": "Pufferfish dies"
+  },
+  {
+    "key": "subtitles.entity.puffer_fish.flop",
+    "english_translation": "Pufferfish flops"
+  },
+  {
+    "key": "subtitles.entity.puffer_fish.hurt",
+    "english_translation": "Pufferfish hurts"
+  },
+  {
+    "key": "subtitles.entity.puffer_fish.sting",
+    "english_translation": "Pufferfish stings"
+  },
+  {
+    "key": "subtitles.entity.rabbit.ambient",
+    "english_translation": "Rabbit squeaks"
+  },
+  {
+    "key": "subtitles.entity.rabbit.attack",
+    "english_translation": "Rabbit attacks"
+  },
+  {
+    "key": "subtitles.entity.rabbit.death",
+    "english_translation": "Rabbit dies"
+  },
+  {
+    "key": "subtitles.entity.rabbit.hurt",
+    "english_translation": "Rabbit hurts"
+  },
+  {
+    "key": "subtitles.entity.rabbit.jump",
+    "english_translation": "Rabbit hops"
+  },
+  {
+    "key": "subtitles.entity.ravager.ambient",
+    "english_translation": "Ravager grunts"
+  },
+  {
+    "key": "subtitles.entity.ravager.attack",
+    "english_translation": "Ravager bites"
+  },
+  {
+    "key": "subtitles.entity.ravager.celebrate",
+    "english_translation": "Ravager cheers"
+  },
+  {
+    "key": "subtitles.entity.ravager.death",
+    "english_translation": "Ravager dies"
+  },
+  {
+    "key": "subtitles.entity.ravager.hurt",
+    "english_translation": "Ravager hurts"
+  },
+  {
+    "key": "subtitles.entity.ravager.roar",
+    "english_translation": "Ravager roars"
+  },
+  {
+    "key": "subtitles.entity.ravager.step",
+    "english_translation": "Ravager steps"
+  },
+  {
+    "key": "subtitles.entity.ravager.stunned",
+    "english_translation": "Ravager stunned"
+  },
+  {
+    "key": "subtitles.entity.salmon.death",
+    "english_translation": "Salmon dies"
+  },
+  {
+    "key": "subtitles.entity.salmon.flop",
+    "english_translation": "Salmon flops"
+  },
+  {
+    "key": "subtitles.entity.salmon.hurt",
+    "english_translation": "Salmon hurts"
+  },
+  {
+    "key": "subtitles.entity.sheep.ambient",
+    "english_translation": "Sheep baahs"
+  },
+  {
+    "key": "subtitles.entity.sheep.death",
+    "english_translation": "Sheep dies"
+  },
+  {
+    "key": "subtitles.entity.sheep.hurt",
+    "english_translation": "Sheep hurts"
+  },
+  {
+    "key": "subtitles.entity.shulker.ambient",
+    "english_translation": "Shulker lurks"
+  },
+  {
+    "key": "subtitles.entity.shulker.close",
+    "english_translation": "Shulker closes"
+  },
+  {
+    "key": "subtitles.entity.shulker.death",
+    "english_translation": "Shulker dies"
+  },
+  {
+    "key": "subtitles.entity.shulker.hurt",
+    "english_translation": "Shulker hurts"
+  },
+  {
+    "key": "subtitles.entity.shulker.open",
+    "english_translation": "Shulker opens"
+  },
+  {
+    "key": "subtitles.entity.shulker.shoot",
+    "english_translation": "Shulker shoots"
+  },
+  {
+    "key": "subtitles.entity.shulker.teleport",
+    "english_translation": "Shulker teleports"
+  },
+  {
+    "key": "subtitles.entity.shulker_bullet.hit",
+    "english_translation": "Shulker Bullet explodes"
+  },
+  {
+    "key": "subtitles.entity.shulker_bullet.hurt",
+    "english_translation": "Shulker Bullet breaks"
+  },
+  {
+    "key": "subtitles.entity.silverfish.ambient",
+    "english_translation": "Silverfish hisses"
+  },
+  {
+    "key": "subtitles.entity.silverfish.death",
+    "english_translation": "Silverfish dies"
+  },
+  {
+    "key": "subtitles.entity.silverfish.hurt",
+    "english_translation": "Silverfish hurts"
+  },
+  {
+    "key": "subtitles.entity.skeleton.ambient",
+    "english_translation": "Skeleton rattles"
+  },
+  {
+    "key": "subtitles.entity.skeleton.converted_to_stray",
+    "english_translation": "Skeleton converts to Stray"
+  },
+  {
+    "key": "subtitles.entity.skeleton.death",
+    "english_translation": "Skeleton dies"
+  },
+  {
+    "key": "subtitles.entity.skeleton.hurt",
+    "english_translation": "Skeleton hurts"
+  },
+  {
+    "key": "subtitles.entity.skeleton.shoot",
+    "english_translation": "Skeleton shoots"
+  },
+  {
+    "key": "subtitles.entity.skeleton_horse.ambient",
+    "english_translation": "Skeleton Horse cries"
+  },
+  {
+    "key": "subtitles.entity.skeleton_horse.death",
+    "english_translation": "Skeleton Horse dies"
+  },
+  {
+    "key": "subtitles.entity.skeleton_horse.hurt",
+    "english_translation": "Skeleton Horse hurts"
+  },
+  {
+    "key": "subtitles.entity.skeleton_horse.swim",
+    "english_translation": "Skeleton Horse swims"
+  },
+  {
+    "key": "subtitles.entity.slime.attack",
+    "english_translation": "Slime attacks"
+  },
+  {
+    "key": "subtitles.entity.slime.death",
+    "english_translation": "Slime dies"
+  },
+  {
+    "key": "subtitles.entity.slime.hurt",
+    "english_translation": "Slime hurts"
+  },
+  {
+    "key": "subtitles.entity.slime.squish",
+    "english_translation": "Slime squishes"
+  },
+  {
+    "key": "subtitles.entity.snow_golem.death",
+    "english_translation": "Snow Golem dies"
+  },
+  {
+    "key": "subtitles.entity.snow_golem.hurt",
+    "english_translation": "Snow Golem hurts"
+  },
+  {
+    "key": "subtitles.entity.snowball.throw",
+    "english_translation": "Snowball flies"
+  },
+  {
+    "key": "subtitles.entity.spider.ambient",
+    "english_translation": "Spider hisses"
+  },
+  {
+    "key": "subtitles.entity.spider.death",
+    "english_translation": "Spider dies"
+  },
+  {
+    "key": "subtitles.entity.spider.hurt",
+    "english_translation": "Spider hurts"
+  },
+  {
+    "key": "subtitles.entity.squid.ambient",
+    "english_translation": "Squid swims"
+  },
+  {
+    "key": "subtitles.entity.squid.death",
+    "english_translation": "Squid dies"
+  },
+  {
+    "key": "subtitles.entity.squid.hurt",
+    "english_translation": "Squid hurts"
+  },
+  {
+    "key": "subtitles.entity.squid.squirt",
+    "english_translation": "Squid shoots ink"
+  },
+  {
+    "key": "subtitles.entity.stray.ambient",
+    "english_translation": "Stray rattles"
+  },
+  {
+    "key": "subtitles.entity.stray.death",
+    "english_translation": "Stray dies"
+  },
+  {
+    "key": "subtitles.entity.stray.hurt",
+    "english_translation": "Stray hurts"
+  },
+  {
+    "key": "subtitles.entity.strider.death",
+    "english_translation": "Strider dies"
+  },
+  {
+    "key": "subtitles.entity.strider.eat",
+    "english_translation": "Strider eats"
+  },
+  {
+    "key": "subtitles.entity.strider.happy",
+    "english_translation": "Strider warbles"
+  },
+  {
+    "key": "subtitles.entity.strider.hurt",
+    "english_translation": "Strider hurts"
+  },
+  {
+    "key": "subtitles.entity.strider.idle",
+    "english_translation": "Strider chirps"
+  },
+  {
+    "key": "subtitles.entity.strider.retreat",
+    "english_translation": "Strider retreats"
+  },
+  {
+    "key": "subtitles.entity.tadpole.death",
+    "english_translation": "Tadpole dies"
+  },
+  {
+    "key": "subtitles.entity.tadpole.flop",
+    "english_translation": "Tadpole flops"
+  },
+  {
+    "key": "subtitles.entity.tadpole.hurt",
+    "english_translation": "Tadpole hurts"
+  },
+  {
+    "key": "subtitles.entity.tnt.primed",
+    "english_translation": "TNT fizzes"
+  },
+  {
+    "key": "subtitles.entity.tropical_fish.death",
+    "english_translation": "Tropical Fish dies"
+  },
+  {
+    "key": "subtitles.entity.tropical_fish.flop",
+    "english_translation": "Tropical Fish flops"
+  },
+  {
+    "key": "subtitles.entity.tropical_fish.hurt",
+    "english_translation": "Tropical Fish hurts"
+  },
+  {
+    "key": "subtitles.entity.turtle.ambient_land",
+    "english_translation": "Turtle chirps"
+  },
+  {
+    "key": "subtitles.entity.turtle.death",
+    "english_translation": "Turtle dies"
+  },
+  {
+    "key": "subtitles.entity.turtle.death_baby",
+    "english_translation": "Turtle baby dies"
+  },
+  {
+    "key": "subtitles.entity.turtle.egg_break",
+    "english_translation": "Turtle Egg breaks"
+  },
+  {
+    "key": "subtitles.entity.turtle.egg_crack",
+    "english_translation": "Turtle Egg cracks"
+  },
+  {
+    "key": "subtitles.entity.turtle.egg_hatch",
+    "english_translation": "Turtle Egg hatches"
+  },
+  {
+    "key": "subtitles.entity.turtle.hurt",
+    "english_translation": "Turtle hurts"
+  },
+  {
+    "key": "subtitles.entity.turtle.hurt_baby",
+    "english_translation": "Turtle baby hurts"
+  },
+  {
+    "key": "subtitles.entity.turtle.lay_egg",
+    "english_translation": "Turtle lays egg"
+  },
+  {
+    "key": "subtitles.entity.turtle.shamble",
+    "english_translation": "Turtle shambles"
+  },
+  {
+    "key": "subtitles.entity.turtle.shamble_baby",
+    "english_translation": "Turtle baby shambles"
+  },
+  {
+    "key": "subtitles.entity.turtle.swim",
+    "english_translation": "Turtle swims"
+  },
+  {
+    "key": "subtitles.entity.vex.ambient",
+    "english_translation": "Vex vexes"
+  },
+  {
+    "key": "subtitles.entity.vex.charge",
+    "english_translation": "Vex shrieks"
+  },
+  {
+    "key": "subtitles.entity.vex.death",
+    "english_translation": "Vex dies"
+  },
+  {
+    "key": "subtitles.entity.vex.hurt",
+    "english_translation": "Vex hurts"
+  },
+  {
+    "key": "subtitles.entity.villager.ambient",
+    "english_translation": "Villager mumbles"
+  },
+  {
+    "key": "subtitles.entity.villager.celebrate",
+    "english_translation": "Villager cheers"
+  },
+  {
+    "key": "subtitles.entity.villager.death",
+    "english_translation": "Villager dies"
+  },
+  {
+    "key": "subtitles.entity.villager.hurt",
+    "english_translation": "Villager hurts"
+  },
+  {
+    "key": "subtitles.entity.villager.no",
+    "english_translation": "Villager disagrees"
+  },
+  {
+    "key": "subtitles.entity.villager.trade",
+    "english_translation": "Villager trades"
+  },
+  {
+    "key": "subtitles.entity.villager.work_armorer",
+    "english_translation": "Armorer works"
+  },
+  {
+    "key": "subtitles.entity.villager.work_butcher",
+    "english_translation": "Butcher works"
+  },
+  {
+    "key": "subtitles.entity.villager.work_cartographer",
+    "english_translation": "Cartographer works"
+  },
+  {
+    "key": "subtitles.entity.villager.work_cleric",
+    "english_translation": "Cleric works"
+  },
+  {
+    "key": "subtitles.entity.villager.work_farmer",
+    "english_translation": "Farmer works"
+  },
+  {
+    "key": "subtitles.entity.villager.work_fisherman",
+    "english_translation": "Fisherman works"
+  },
+  {
+    "key": "subtitles.entity.villager.work_fletcher",
+    "english_translation": "Fletcher works"
+  },
+  {
+    "key": "subtitles.entity.villager.work_leatherworker",
+    "english_translation": "Leatherworker works"
+  },
+  {
+    "key": "subtitles.entity.villager.work_librarian",
+    "english_translation": "Librarian works"
+  },
+  {
+    "key": "subtitles.entity.villager.work_mason",
+    "english_translation": "Mason works"
+  },
+  {
+    "key": "subtitles.entity.villager.work_shepherd",
+    "english_translation": "Shepherd works"
+  },
+  {
+    "key": "subtitles.entity.villager.work_toolsmith",
+    "english_translation": "Toolsmith works"
+  },
+  {
+    "key": "subtitles.entity.villager.work_weaponsmith",
+    "english_translation": "Weaponsmith works"
+  },
+  {
+    "key": "subtitles.entity.villager.yes",
+    "english_translation": "Villager agrees"
+  },
+  {
+    "key": "subtitles.entity.vindicator.ambient",
+    "english_translation": "Vindicator mutters"
+  },
+  {
+    "key": "subtitles.entity.vindicator.celebrate",
+    "english_translation": "Vindicator cheers"
+  },
+  {
+    "key": "subtitles.entity.vindicator.death",
+    "english_translation": "Vindicator dies"
+  },
+  {
+    "key": "subtitles.entity.vindicator.hurt",
+    "english_translation": "Vindicator hurts"
+  },
+  {
+    "key": "subtitles.entity.wandering_trader.ambient",
+    "english_translation": "Wandering Trader mumbles"
+  },
+  {
+    "key": "subtitles.entity.wandering_trader.death",
+    "english_translation": "Wandering Trader dies"
+  },
+  {
+    "key": "subtitles.entity.wandering_trader.disappeared",
+    "english_translation": "Wandering Trader disappears"
+  },
+  {
+    "key": "subtitles.entity.wandering_trader.drink_milk",
+    "english_translation": "Wandering Trader drinks milk"
+  },
+  {
+    "key": "subtitles.entity.wandering_trader.drink_potion",
+    "english_translation": "Wandering Trader drinks potion"
+  },
+  {
+    "key": "subtitles.entity.wandering_trader.hurt",
+    "english_translation": "Wandering Trader hurts"
+  },
+  {
+    "key": "subtitles.entity.wandering_trader.no",
+    "english_translation": "Wandering Trader disagrees"
+  },
+  {
+    "key": "subtitles.entity.wandering_trader.reappeared",
+    "english_translation": "Wandering Trader appears"
+  },
+  {
+    "key": "subtitles.entity.wandering_trader.trade",
+    "english_translation": "Wandering Trader trades"
+  },
+  {
+    "key": "subtitles.entity.wandering_trader.yes",
+    "english_translation": "Wandering Trader agrees"
+  },
+  {
+    "key": "subtitles.entity.warden.roar",
+    "english_translation": "Warden roars"
+  },
+  {
+    "key": "subtitles.entity.warden.sniff",
+    "english_translation": "Warden sniffs"
+  },
+  {
+    "key": "subtitles.entity.warden.emerge",
+    "english_translation": "Warden emerges"
+  },
+  {
+    "key": "subtitles.entity.warden.dig",
+    "english_translation": "Warden digs"
+  },
+  {
+    "key": "subtitles.entity.warden.hurt",
+    "english_translation": "Warden hurts"
+  },
+  {
+    "key": "subtitles.entity.warden.death",
+    "english_translation": "Warden dies"
+  },
+  {
+    "key": "subtitles.entity.warden.step",
+    "english_translation": "Warden steps"
+  },
+  {
+    "key": "subtitles.entity.warden.listening",
+    "english_translation": "Warden takes notice"
+  },
+  {
+    "key": "subtitles.entity.warden.listening_angry",
+    "english_translation": "Warden takes notice angrily"
+  },
+  {
+    "key": "subtitles.entity.warden.heartbeat",
+    "english_translation": "Warden's heart beats"
+  },
+  {
+    "key": "subtitles.entity.warden.attack_impact",
+    "english_translation": "Warden lands hit"
+  },
+  {
+    "key": "subtitles.entity.warden.tendril_clicks",
+    "english_translation": "Warden's tendrils click"
+  },
+  {
+    "key": "subtitles.entity.warden.angry",
+    "english_translation": "Warden rages"
+  },
+  {
+    "key": "subtitles.entity.warden.agitated",
+    "english_translation": "Warden groans angrily"
+  },
+  {
+    "key": "subtitles.entity.warden.ambient",
+    "english_translation": "Warden whines"
+  },
+  {
+    "key": "subtitles.entity.warden.nearby_close",
+    "english_translation": "Warden approaches"
+  },
+  {
+    "key": "subtitles.entity.warden.nearby_closer",
+    "english_translation": "Warden advances"
+  },
+  {
+    "key": "subtitles.entity.warden.nearby_closest",
+    "english_translation": "Warden draws close"
+  },
+  {
+    "key": "subtitles.entity.warden.sonic_charge",
+    "english_translation": "Warden charges"
+  },
+  {
+    "key": "subtitles.entity.warden.sonic_boom",
+    "english_translation": "Warden booms"
+  },
+  {
+    "key": "subtitles.entity.witch.ambient",
+    "english_translation": "Witch giggles"
+  },
+  {
+    "key": "subtitles.entity.witch.celebrate",
+    "english_translation": "Witch cheers"
+  },
+  {
+    "key": "subtitles.entity.witch.death",
+    "english_translation": "Witch dies"
+  },
+  {
+    "key": "subtitles.entity.witch.drink",
+    "english_translation": "Witch drinks"
+  },
+  {
+    "key": "subtitles.entity.witch.hurt",
+    "english_translation": "Witch hurts"
+  },
+  {
+    "key": "subtitles.entity.witch.throw",
+    "english_translation": "Witch throws"
+  },
+  {
+    "key": "subtitles.entity.wither.ambient",
+    "english_translation": "Wither angers"
+  },
+  {
+    "key": "subtitles.entity.wither.death",
+    "english_translation": "Wither dies"
+  },
+  {
+    "key": "subtitles.entity.wither.hurt",
+    "english_translation": "Wither hurts"
+  },
+  {
+    "key": "subtitles.entity.wither.shoot",
+    "english_translation": "Wither attacks"
+  },
+  {
+    "key": "subtitles.entity.wither.spawn",
+    "english_translation": "Wither released"
+  },
+  {
+    "key": "subtitles.entity.wither_skeleton.ambient",
+    "english_translation": "Wither Skeleton rattles"
+  },
+  {
+    "key": "subtitles.entity.wither_skeleton.death",
+    "english_translation": "Wither Skeleton dies"
+  },
+  {
+    "key": "subtitles.entity.wither_skeleton.hurt",
+    "english_translation": "Wither Skeleton hurts"
+  },
+  {
+    "key": "subtitles.entity.wolf.ambient",
+    "english_translation": "Wolf pants"
+  },
+  {
+    "key": "subtitles.entity.wolf.death",
+    "english_translation": "Wolf dies"
+  },
+  {
+    "key": "subtitles.entity.wolf.growl",
+    "english_translation": "Wolf growls"
+  },
+  {
+    "key": "subtitles.entity.wolf.hurt",
+    "english_translation": "Wolf hurts"
+  },
+  {
+    "key": "subtitles.entity.wolf.shake",
+    "english_translation": "Wolf shakes"
+  },
+  {
+    "key": "subtitles.entity.zoglin.ambient",
+    "english_translation": "Zoglin growls"
+  },
+  {
+    "key": "subtitles.entity.zoglin.angry",
+    "english_translation": "Zoglin growls angrily"
+  },
+  {
+    "key": "subtitles.entity.zoglin.attack",
+    "english_translation": "Zoglin attacks"
+  },
+  {
+    "key": "subtitles.entity.zoglin.death",
+    "english_translation": "Zoglin dies"
+  },
+  {
+    "key": "subtitles.entity.zoglin.hurt",
+    "english_translation": "Zoglin hurts"
+  },
+  {
+    "key": "subtitles.entity.zoglin.step",
+    "english_translation": "Zoglin steps"
+  },
+  {
+    "key": "subtitles.entity.zombie.ambient",
+    "english_translation": "Zombie groans"
+  },
+  {
+    "key": "subtitles.entity.zombie.attack_wooden_door",
+    "english_translation": "Door shakes"
+  },
+  {
+    "key": "subtitles.entity.zombie.converted_to_drowned",
+    "english_translation": "Zombie converts to Drowned"
+  },
+  {
+    "key": "subtitles.entity.zombie.break_wooden_door",
+    "english_translation": "Door breaks"
+  },
+  {
+    "key": "subtitles.entity.zombie.death",
+    "english_translation": "Zombie dies"
+  },
+  {
+    "key": "subtitles.entity.zombie.destroy_egg",
+    "english_translation": "Turtle Egg stomped"
+  },
+  {
+    "key": "subtitles.entity.zombie.hurt",
+    "english_translation": "Zombie hurts"
+  },
+  {
+    "key": "subtitles.entity.zombie.infect",
+    "english_translation": "Zombie infects"
+  },
+  {
+    "key": "subtitles.entity.zombie_horse.ambient",
+    "english_translation": "Zombie Horse cries"
+  },
+  {
+    "key": "subtitles.entity.zombie_horse.death",
+    "english_translation": "Zombie Horse dies"
+  },
+  {
+    "key": "subtitles.entity.zombie_horse.hurt",
+    "english_translation": "Zombie Horse hurts"
+  },
+  {
+    "key": "subtitles.entity.zombie_villager.ambient",
+    "english_translation": "Zombie Villager groans"
+  },
+  {
+    "key": "subtitles.entity.zombie_villager.converted",
+    "english_translation": "Zombie Villager vociferates"
+  },
+  {
+    "key": "subtitles.entity.zombie_villager.cure",
+    "english_translation": "Zombie Villager snuffles"
+  },
+  {
+    "key": "subtitles.entity.zombie_villager.death",
+    "english_translation": "Zombie Villager dies"
+  },
+  {
+    "key": "subtitles.entity.zombie_villager.hurt",
+    "english_translation": "Zombie Villager hurts"
+  },
+  {
+    "key": "subtitles.entity.zombified_piglin.ambient",
+    "english_translation": "Zombified Piglin grunts"
+  },
+  {
+    "key": "subtitles.entity.zombified_piglin.angry",
+    "english_translation": "Zombified Piglin grunts angrily"
+  },
+  {
+    "key": "subtitles.entity.zombified_piglin.death",
+    "english_translation": "Zombified Piglin dies"
+  },
+  {
+    "key": "subtitles.entity.zombified_piglin.hurt",
+    "english_translation": "Zombified Piglin hurts"
+  },
+  {
+    "key": "subtitles.event.raid.horn",
+    "english_translation": "Ominous horn blares"
+  },
+  {
+    "key": "subtitles.item.armor.equip",
+    "english_translation": "Gear equips"
+  },
+  {
+    "key": "subtitles.item.armor.equip_chain",
+    "english_translation": "Chain armor jingles"
+  },
+  {
+    "key": "subtitles.item.armor.equip_diamond",
+    "english_translation": "Diamond armor clangs"
+  },
+  {
+    "key": "subtitles.item.armor.equip_elytra",
+    "english_translation": "Elytra rustle"
+  },
+  {
+    "key": "subtitles.item.armor.equip_gold",
+    "english_translation": "Gold armor clinks"
+  },
+  {
+    "key": "subtitles.item.armor.equip_iron",
+    "english_translation": "Iron armor clanks"
+  },
+  {
+    "key": "subtitles.item.armor.equip_leather",
+    "english_translation": "Leather armor rustles"
+  },
+  {
+    "key": "subtitles.item.armor.equip_netherite",
+    "english_translation": "Netherite armor clanks"
+  },
+  {
+    "key": "subtitles.item.armor.equip_turtle",
+    "english_translation": "Turtle Shell thunks"
+  },
+  {
+    "key": "subtitles.item.axe.strip",
+    "english_translation": "Axe strips"
+  },
+  {
+    "key": "subtitles.item.axe.scrape",
+    "english_translation": "Axe scrapes"
+  },
+  {
+    "key": "subtitles.item.axe.wax_off",
+    "english_translation": "Wax off"
+  },
+  {
+    "key": "subtitles.item.bone_meal.use",
+    "english_translation": "Bone Meal crinkles"
+  },
+  {
+    "key": "subtitles.item.book.page_turn",
+    "english_translation": "Page rustles"
+  },
+  {
+    "key": "subtitles.item.book.put",
+    "english_translation": "Book thumps"
+  },
+  {
+    "key": "subtitles.item.bottle.empty",
+    "english_translation": "Bottle empties"
+  },
+  {
+    "key": "subtitles.item.bottle.fill",
+    "english_translation": "Bottle fills"
+  },
+  {
+    "key": "subtitles.item.bucket.empty",
+    "english_translation": "Bucket empties"
+  },
+  {
+    "key": "subtitles.item.bucket.fill",
+    "english_translation": "Bucket fills"
+  },
+  {
+    "key": "subtitles.item.bucket.fill_axolotl",
+    "english_translation": "Axolotl scooped"
+  },
+  {
+    "key": "subtitles.item.bucket.fill_fish",
+    "english_translation": "Fish captured"
+  },
+  {
+    "key": "subtitles.item.bucket.fill_tadpole",
+    "english_translation": "Tadpole captured"
+  },
+  {
+    "key": "subtitles.item.bundle.drop_contents",
+    "english_translation": "Bundle empties"
+  },
+  {
+    "key": "subtitles.item.bundle.insert",
+    "english_translation": "Item packed"
+  },
+  {
+    "key": "subtitles.item.bundle.remove_one",
+    "english_translation": "Item unpacked"
+  },
+  {
+    "key": "subtitles.item.chorus_fruit.teleport",
+    "english_translation": "Player teleports"
+  },
+  {
+    "key": "subtitles.item.crop.plant",
+    "english_translation": "Crop planted"
+  },
+  {
+    "key": "subtitles.item.crossbow.charge",
+    "english_translation": "Crossbow charges up"
+  },
+  {
+    "key": "subtitles.item.crossbow.hit",
+    "english_translation": "Arrow hits"
+  },
+  {
+    "key": "subtitles.item.crossbow.load",
+    "english_translation": "Crossbow loads"
+  },
+  {
+    "key": "subtitles.item.crossbow.shoot",
+    "english_translation": "Crossbow fires"
+  },
+  {
+    "key": "subtitles.item.firecharge.use",
+    "english_translation": "Fireball whooshes"
+  },
+  {
+    "key": "subtitles.item.flintandsteel.use",
+    "english_translation": "Flint and Steel click"
+  },
+  {
+    "key": "subtitles.item.goat_horn.play",
+    "english_translation": "Goat Horn plays"
+  },
+  {
+    "key": "subtitles.item.hoe.till",
+    "english_translation": "Hoe tills"
+  },
+  {
+    "key": "subtitles.item.honey_bottle.drink",
+    "english_translation": "Gulping"
+  },
+  {
+    "key": "subtitles.item.lodestone_compass.lock",
+    "english_translation": "Lodestone Compass locks onto Lodestone"
+  },
+  {
+    "key": "subtitles.item.nether_wart.plant",
+    "english_translation": "Crop planted"
+  },
+  {
+    "key": "subtitles.item.shears.shear",
+    "english_translation": "Shears click"
+  },
+  {
+    "key": "subtitles.item.shield.block",
+    "english_translation": "Shield blocks"
+  },
+  {
+    "key": "subtitles.item.shovel.flatten",
+    "english_translation": "Shovel flattens"
+  },
+  {
+    "key": "subtitles.item.totem.use",
+    "english_translation": "Totem activates"
+  },
+  {
+    "key": "subtitles.item.trident.hit",
+    "english_translation": "Trident stabs"
+  },
+  {
+    "key": "subtitles.item.trident.hit_ground",
+    "english_translation": "Trident vibrates"
+  },
+  {
+    "key": "subtitles.item.trident.return",
+    "english_translation": "Trident returns"
+  },
+  {
+    "key": "subtitles.item.trident.riptide",
+    "english_translation": "Trident zooms"
+  },
+  {
+    "key": "subtitles.item.trident.throw",
+    "english_translation": "Trident clangs"
+  },
+  {
+    "key": "subtitles.item.trident.thunder",
+    "english_translation": "Trident thunder cracks"
+  },
+  {
+    "key": "subtitles.item.spyglass.use",
+    "english_translation": "Spyglass expands"
+  },
+  {
+    "key": "subtitles.item.spyglass.stop_using",
+    "english_translation": "Spyglass retracts"
+  },
+  {
+    "key": "subtitles.item.ink_sac.use",
+    "english_translation": "Ink Sac splotches"
+  },
+  {
+    "key": "subtitles.item.glow_ink_sac.use",
+    "english_translation": "Glow Ink Sac splotches"
+  },
+  {
+    "key": "subtitles.item.dye.use",
+    "english_translation": "Dye stains"
+  },
+  {
+    "key": "subtitles.particle.soul_escape",
+    "english_translation": "Soul escapes"
+  },
+  {
+    "key": "subtitles.ui.cartography_table.take_result",
+    "english_translation": "Map drawn"
+  },
+  {
+    "key": "subtitles.ui.loom.take_result",
+    "english_translation": "Loom used"
+  },
+  {
+    "key": "subtitles.ui.stonecutter.take_result",
+    "english_translation": "Stonecutter used"
+  },
+  {
+    "key": "subtitles.weather.rain",
+    "english_translation": "Rain falls"
+  },
+  {
+    "key": "debug.prefix",
+    "english_translation": "[Debug]:"
+  },
+  {
+    "key": "debug.reload_chunks.help",
+    "english_translation": "F3 + A = Reload chunks"
+  },
+  {
+    "key": "debug.show_hitboxes.help",
+    "english_translation": "F3 + B = Show hitboxes"
+  },
+  {
+    "key": "debug.clear_chat.help",
+    "english_translation": "F3 + D = Clear chat"
+  },
+  {
+    "key": "debug.chunk_boundaries.help",
+    "english_translation": "F3 + G = Show chunk boundaries"
+  },
+  {
+    "key": "debug.advanced_tooltips.help",
+    "english_translation": "F3 + H = Advanced tooltips"
+  },
+  {
+    "key": "debug.creative_spectator.help",
+    "english_translation": "F3 + N = Cycle previous gamemode <-> spectator"
+  },
+  {
+    "key": "debug.pause_focus.help",
+    "english_translation": "F3 + P = Pause on lost focus"
+  },
+  {
+    "key": "debug.help.help",
+    "english_translation": "F3 + Q = Show this list"
+  },
+  {
+    "key": "debug.reload_resourcepacks.help",
+    "english_translation": "F3 + T = Reload resource packs"
+  },
+  {
+    "key": "debug.pause.help",
+    "english_translation": "F3 + Esc = Pause without pause menu (if pausing is possible)"
+  },
+  {
+    "key": "debug.copy_location.help",
+    "english_translation": "F3 + C = Copy location as /tp command, hold F3 + C to crash the game"
+  },
+  {
+    "key": "debug.inspect.help",
+    "english_translation": "F3 + I = Copy entity or block data to clipboard"
+  },
+  {
+    "key": "debug.gamemodes.help",
+    "english_translation": "F3 + F4 = Open game mode switcher"
+  },
+  {
+    "key": "debug.profiling.help",
+    "english_translation": "F3 + L = Start/stop profiling"
+  },
+  {
+    "key": "debug.copy_location.message",
+    "english_translation": "Copied location to clipboard"
+  },
+  {
+    "key": "debug.inspect.server.block",
+    "english_translation": "Copied server-side block data to clipboard"
+  },
+  {
+    "key": "debug.inspect.server.entity",
+    "english_translation": "Copied server-side entity data to clipboard"
+  },
+  {
+    "key": "debug.inspect.client.block",
+    "english_translation": "Copied client-side block data to clipboard"
+  },
+  {
+    "key": "debug.inspect.client.entity",
+    "english_translation": "Copied client-side entity data to clipboard"
+  },
+  {
+    "key": "debug.reload_chunks.message",
+    "english_translation": "Reloading all chunks"
+  },
+  {
+    "key": "debug.show_hitboxes.on",
+    "english_translation": "Hitboxes: shown"
+  },
+  {
+    "key": "debug.show_hitboxes.off",
+    "english_translation": "Hitboxes: hidden"
+  },
+  {
+    "key": "debug.chunk_boundaries.on",
+    "english_translation": "Chunk borders: shown"
+  },
+  {
+    "key": "debug.chunk_boundaries.off",
+    "english_translation": "Chunk borders: hidden"
+  },
+  {
+    "key": "debug.advanced_tooltips.on",
+    "english_translation": "Advanced tooltips: shown"
+  },
+  {
+    "key": "debug.advanced_tooltips.off",
+    "english_translation": "Advanced tooltips: hidden"
+  },
+  {
+    "key": "debug.creative_spectator.error",
+    "english_translation": "Unable to switch gamemode; no permission"
+  },
+  {
+    "key": "debug.gamemodes.error",
+    "english_translation": "Unable to open game mode switcher; no permission"
+  },
+  {
+    "key": "debug.pause_focus.on",
+    "english_translation": "Pause on lost focus: enabled"
+  },
+  {
+    "key": "debug.pause_focus.off",
+    "english_translation": "Pause on lost focus: disabled"
+  },
+  {
+    "key": "debug.help.message",
+    "english_translation": "Key bindings:"
+  },
+  {
+    "key": "debug.reload_resourcepacks.message",
+    "english_translation": "Reloaded resource packs"
+  },
+  {
+    "key": "debug.crash.message",
+    "english_translation": "F3 + C is held down. This will crash the game unless released."
+  },
+  {
+    "key": "debug.crash.warning",
+    "english_translation": "Crashing in %s..."
+  },
+  {
+    "key": "debug.gamemodes.press_f4",
+    "english_translation": "[ F4 ]"
+  },
+  {
+    "key": "debug.gamemodes.select_next",
+    "english_translation": "%s Next"
+  },
+  {
+    "key": "debug.profiling.start",
+    "english_translation": "Profiling started for %s seconds. Use F3 + L to stop early"
+  },
+  {
+    "key": "debug.profiling.stop",
+    "english_translation": "Profiling ended. Saved results to %s"
+  },
+  {
+    "key": "resourcepack.downloading",
+    "english_translation": "Downloading Resource Pack"
+  },
+  {
+    "key": "resourcepack.requesting",
+    "english_translation": "Making Request..."
+  },
+  {
+    "key": "resourcepack.progress",
+    "english_translation": "Downloading file (%s MB)..."
+  },
+  {
+    "key": "tutorial.bundleInsert.title",
+    "english_translation": "Use a Bundle"
+  },
+  {
+    "key": "tutorial.bundleInsert.description",
+    "english_translation": "Right Click to add items"
+  },
+  {
+    "key": "tutorial.move.title",
+    "english_translation": "Move with %s, %s, %s and %s"
+  },
+  {
+    "key": "tutorial.move.description",
+    "english_translation": "Jump with %s"
+  },
+  {
+    "key": "tutorial.look.title",
+    "english_translation": "Look around"
+  },
+  {
+    "key": "tutorial.look.description",
+    "english_translation": "Use your mouse to turn"
+  },
+  {
+    "key": "tutorial.find_tree.title",
+    "english_translation": "Find a tree"
+  },
+  {
+    "key": "tutorial.find_tree.description",
+    "english_translation": "Punch it to collect wood"
+  },
+  {
+    "key": "tutorial.punch_tree.title",
+    "english_translation": "Destroy the tree"
+  },
+  {
+    "key": "tutorial.punch_tree.description",
+    "english_translation": "Hold down %s"
+  },
+  {
+    "key": "tutorial.open_inventory.title",
+    "english_translation": "Open your inventory"
+  },
+  {
+    "key": "tutorial.open_inventory.description",
+    "english_translation": "Press %s"
+  },
+  {
+    "key": "tutorial.craft_planks.title",
+    "english_translation": "Craft wooden planks"
+  },
+  {
+    "key": "tutorial.craft_planks.description",
+    "english_translation": "The recipe book can help"
+  },
+  {
+    "key": "tutorial.socialInteractions.title",
+    "english_translation": "Social Interactions"
+  },
+  {
+    "key": "tutorial.socialInteractions.description",
+    "english_translation": "Press %s to open"
+  },
+  {
+    "key": "advancements.adventure.adventuring_time.title",
+    "english_translation": "Adventuring Time"
+  },
+  {
+    "key": "advancements.adventure.adventuring_time.description",
+    "english_translation": "Discover every biome"
+  },
+  {
+    "key": "advancements.adventure.arbalistic.title",
+    "english_translation": "Arbalistic"
+  },
+  {
+    "key": "advancements.adventure.arbalistic.description",
+    "english_translation": "Kill five unique mobs with one crossbow shot"
+  },
+  {
+    "key": "advancements.adventure.avoid_vibration.title",
+    "english_translation": "Sneak 100"
+  },
+  {
+    "key": "advancements.adventure.avoid_vibration.description",
+    "english_translation": "Sneak near a Sculk Sensor or Warden to prevent it from detecting you"
+  },
+  {
+    "key": "advancements.adventure.bullseye.title",
+    "english_translation": "Bullseye"
+  },
+  {
+    "key": "advancements.adventure.bullseye.description",
+    "english_translation": "Hit the bullseye of a Target block from at least 30 meters away"
+  },
+  {
+    "key": "advancements.adventure.fall_from_world_height.title",
+    "english_translation": "Caves & Cliffs"
+  },
+  {
+    "key": "advancements.adventure.fall_from_world_height.description",
+    "english_translation": "Free fall from the top of the world (build limit) to the bottom of the world and survive"
+  },
+  {
+    "key": "advancements.adventure.kill_mob_near_sculk_catalyst.title",
+    "english_translation": "It Spreads"
+  },
+  {
+    "key": "advancements.adventure.kill_mob_near_sculk_catalyst.description",
+    "english_translation": "Kill a mob near a Sculk Catalyst"
+  },
+  {
+    "key": "advancements.adventure.walk_on_powder_snow_with_leather_boots.title",
+    "english_translation": "Light as a Rabbit"
+  },
+  {
+    "key": "advancements.adventure.walk_on_powder_snow_with_leather_boots.description",
+    "english_translation": "Walk on Powder Snow...without sinking in it"
+  },
+  {
+    "key": "advancements.adventure.lightning_rod_with_villager_no_fire.title",
+    "english_translation": "Surge Protector"
+  },
+  {
+    "key": "advancements.adventure.lightning_rod_with_villager_no_fire.description",
+    "english_translation": "Protect a Villager from an undesired shock without starting a fire"
+  },
+  {
+    "key": "advancements.adventure.spyglass_at_parrot.title",
+    "english_translation": "Is It a Bird?"
+  },
+  {
+    "key": "advancements.adventure.spyglass_at_parrot.description",
+    "english_translation": "Look at a Parrot through a Spyglass"
+  },
+  {
+    "key": "advancements.adventure.spyglass_at_ghast.title",
+    "english_translation": "Is It a Balloon?"
+  },
+  {
+    "key": "advancements.adventure.spyglass_at_ghast.description",
+    "english_translation": "Look at a Ghast through a Spyglass"
+  },
+  {
+    "key": "advancements.adventure.spyglass_at_dragon.title",
+    "english_translation": "Is It a Plane?"
+  },
+  {
+    "key": "advancements.adventure.spyglass_at_dragon.description",
+    "english_translation": "Look at the Ender Dragon through a Spyglass"
+  },
+  {
+    "key": "advancements.adventure.hero_of_the_village.title",
+    "english_translation": "Hero of the Village"
+  },
+  {
+    "key": "advancements.adventure.hero_of_the_village.description",
+    "english_translation": "Successfully defend a village from a raid"
+  },
+  {
+    "key": "advancements.adventure.honey_block_slide.title",
+    "english_translation": "Sticky Situation"
+  },
+  {
+    "key": "advancements.adventure.honey_block_slide.description",
+    "english_translation": "Jump into a Honey Block to break your fall"
+  },
+  {
+    "key": "advancements.adventure.kill_all_mobs.title",
+    "english_translation": "Monsters Hunted"
+  },
+  {
+    "key": "advancements.adventure.kill_all_mobs.description",
+    "english_translation": "Kill one of every hostile monster"
+  },
+  {
+    "key": "advancements.adventure.kill_a_mob.title",
+    "english_translation": "Monster Hunter"
+  },
+  {
+    "key": "advancements.adventure.kill_a_mob.description",
+    "english_translation": "Kill any hostile monster"
+  },
+  {
+    "key": "advancements.adventure.ol_betsy.title",
+    "english_translation": "Ol' Betsy"
+  },
+  {
+    "key": "advancements.adventure.ol_betsy.description",
+    "english_translation": "Shoot a Crossbow"
+  },
+  {
+    "key": "advancements.adventure.play_jukebox_in_meadows.title",
+    "english_translation": "Sound of Music"
+  },
+  {
+    "key": "advancements.adventure.play_jukebox_in_meadows.description",
+    "english_translation": "Make the Meadows come alive with the sound of music from a Jukebox"
+  },
+  {
+    "key": "advancements.adventure.root.title",
+    "english_translation": "Adventure"
+  },
+  {
+    "key": "advancements.adventure.root.description",
+    "english_translation": "Adventure, exploration and combat"
+  },
+  {
+    "key": "advancements.adventure.shoot_arrow.title",
+    "english_translation": "Take Aim"
+  },
+  {
+    "key": "advancements.adventure.shoot_arrow.description",
+    "english_translation": "Shoot something with an Arrow"
+  },
+  {
+    "key": "advancements.adventure.sleep_in_bed.title",
+    "english_translation": "Sweet Dreams"
+  },
+  {
+    "key": "advancements.adventure.sleep_in_bed.description",
+    "english_translation": "Sleep in a Bed to change your respawn point"
+  },
+  {
+    "key": "advancements.adventure.sniper_duel.title",
+    "english_translation": "Sniper Duel"
+  },
+  {
+    "key": "advancements.adventure.sniper_duel.description",
+    "english_translation": "Kill a Skeleton from at least 50 meters away"
+  },
+  {
+    "key": "advancements.adventure.summon_iron_golem.title",
+    "english_translation": "Hired Help"
+  },
+  {
+    "key": "advancements.adventure.summon_iron_golem.description",
+    "english_translation": "Summon an Iron Golem to help defend a village"
+  },
+  {
+    "key": "advancements.adventure.totem_of_undying.title",
+    "english_translation": "Postmortal"
+  },
+  {
+    "key": "advancements.adventure.totem_of_undying.description",
+    "english_translation": "Use a Totem of Undying to cheat death"
+  },
+  {
+    "key": "advancements.adventure.trade.title",
+    "english_translation": "What a Deal!"
+  },
+  {
+    "key": "advancements.adventure.trade.description",
+    "english_translation": "Successfully trade with a Villager"
+  },
+  {
+    "key": "advancements.adventure.trade_at_world_height.title",
+    "english_translation": "Star Trader"
+  },
+  {
+    "key": "advancements.adventure.trade_at_world_height.description",
+    "english_translation": "Trade with a Villager at the build height limit"
+  },
+  {
+    "key": "advancements.adventure.throw_trident.title",
+    "english_translation": "A Throwaway Joke"
+  },
+  {
+    "key": "advancements.adventure.throw_trident.description",
+    "english_translation": "Throw a Trident at something.\nNote: Throwing away your only weapon is not a good idea."
+  },
+  {
+    "key": "advancements.adventure.two_birds_one_arrow.title",
+    "english_translation": "Two Birds, One Arrow"
+  },
+  {
+    "key": "advancements.adventure.two_birds_one_arrow.description",
+    "english_translation": "Kill two Phantoms with a piercing Arrow"
+  },
+  {
+    "key": "advancements.adventure.very_very_frightening.title",
+    "english_translation": "Very Very Frightening"
+  },
+  {
+    "key": "advancements.adventure.very_very_frightening.description",
+    "english_translation": "Strike a Villager with lightning"
+  },
+  {
+    "key": "advancements.adventure.voluntary_exile.title",
+    "english_translation": "Voluntary Exile"
+  },
+  {
+    "key": "advancements.adventure.voluntary_exile.description",
+    "english_translation": "Kill a raid captain.\nMaybe consider staying away from villages for the time being..."
+  },
+  {
+    "key": "advancements.adventure.whos_the_pillager_now.title",
+    "english_translation": "Who's the Pillager Now?"
+  },
+  {
+    "key": "advancements.adventure.whos_the_pillager_now.description",
+    "english_translation": "Give a Pillager a taste of their own medicine"
+  },
+  {
+    "key": "advancements.husbandry.root.title",
+    "english_translation": "Husbandry"
+  },
+  {
+    "key": "advancements.husbandry.root.description",
+    "english_translation": "The world is full of friends and food"
+  },
+  {
+    "key": "advancements.husbandry.breed_an_animal.title",
+    "english_translation": "The Parrots and the Bats"
+  },
+  {
+    "key": "advancements.husbandry.breed_an_animal.description",
+    "english_translation": "Breed two animals together"
+  },
+  {
+    "key": "advancements.husbandry.fishy_business.title",
+    "english_translation": "Fishy Business"
+  },
+  {
+    "key": "advancements.husbandry.fishy_business.description",
+    "english_translation": "Catch a fish"
+  },
+  {
+    "key": "advancements.husbandry.make_a_sign_glow.title",
+    "english_translation": "Glow and Behold!"
+  },
+  {
+    "key": "advancements.husbandry.make_a_sign_glow.description",
+    "english_translation": "Make the text of a Sign glow"
+  },
+  {
+    "key": "advancements.husbandry.ride_a_boat_with_a_goat.title",
+    "english_translation": "Whatever Floats Your Goat!"
+  },
+  {
+    "key": "advancements.husbandry.ride_a_boat_with_a_goat.description",
+    "english_translation": "Get in a Boat and float with a Goat"
+  },
+  {
+    "key": "advancements.husbandry.tactical_fishing.title",
+    "english_translation": "Tactical Fishing"
+  },
+  {
+    "key": "advancements.husbandry.tactical_fishing.description",
+    "english_translation": "Catch a Fish... without a Fishing Rod!"
+  },
+  {
+    "key": "advancements.husbandry.axolotl_in_a_bucket.title",
+    "english_translation": "The Cutest Predator"
+  },
+  {
+    "key": "advancements.husbandry.axolotl_in_a_bucket.description",
+    "english_translation": "Catch an Axolotl in a Bucket"
+  },
+  {
+    "key": "advancements.husbandry.froglights.title",
+    "english_translation": "With Our Powers Combined!"
+  },
+  {
+    "key": "advancements.husbandry.froglights.description",
+    "english_translation": "Have all Froglights in your inventory"
+  },
+  {
+    "key": "advancements.husbandry.tadpole_in_a_bucket.title",
+    "english_translation": "Bukkit Bukkit"
+  },
+  {
+    "key": "advancements.husbandry.tadpole_in_a_bucket.description",
+    "english_translation": "Catch a Tadpole in a Bucket"
+  },
+  {
+    "key": "advancements.husbandry.leash_all_frog_variants.title",
+    "english_translation": "When the Squad Hops into Town"
+  },
+  {
+    "key": "advancements.husbandry.leash_all_frog_variants.description",
+    "english_translation": "Get each Frog variant on a Lead"
+  },
+  {
+    "key": "advancements.husbandry.kill_axolotl_target.title",
+    "english_translation": "The Healing Power of Friendship!"
+  },
+  {
+    "key": "advancements.husbandry.kill_axolotl_target.description",
+    "english_translation": "Team up with an Axolotl and win a fight"
+  },
+  {
+    "key": "advancements.husbandry.breed_all_animals.title",
+    "english_translation": "Two by Two"
+  },
+  {
+    "key": "advancements.husbandry.breed_all_animals.description",
+    "english_translation": "Breed all the animals!"
+  },
+  {
+    "key": "advancements.husbandry.tame_an_animal.title",
+    "english_translation": "Best Friends Forever"
+  },
+  {
+    "key": "advancements.husbandry.tame_an_animal.description",
+    "english_translation": "Tame an animal"
+  },
+  {
+    "key": "advancements.husbandry.plant_seed.title",
+    "english_translation": "A Seedy Place"
+  },
+  {
+    "key": "advancements.husbandry.plant_seed.description",
+    "english_translation": "Plant a seed and watch it grow"
+  },
+  {
+    "key": "advancements.husbandry.netherite_hoe.title",
+    "english_translation": "Serious Dedication"
+  },
+  {
+    "key": "advancements.husbandry.netherite_hoe.description",
+    "english_translation": "Use a Netherite Ingot to upgrade a Hoe, and then reevaluate your life choices"
+  },
+  {
+    "key": "advancements.husbandry.balanced_diet.title",
+    "english_translation": "A Balanced Diet"
+  },
+  {
+    "key": "advancements.husbandry.balanced_diet.description",
+    "english_translation": "Eat everything that is edible, even if it's not good for you"
+  },
+  {
+    "key": "advancements.husbandry.complete_catalogue.title",
+    "english_translation": "A Complete Catalogue"
+  },
+  {
+    "key": "advancements.husbandry.complete_catalogue.description",
+    "english_translation": "Tame all Cat variants!"
+  },
+  {
+    "key": "advancements.husbandry.safely_harvest_honey.title",
+    "english_translation": "Bee Our Guest"
+  },
+  {
+    "key": "advancements.husbandry.safely_harvest_honey.description",
+    "english_translation": "Use a Campfire to collect Honey from a Beehive using a Bottle without aggravating the Bees"
+  },
+  {
+    "key": "advancements.husbandry.silk_touch_nest.title",
+    "english_translation": "Total Beelocation"
+  },
+  {
+    "key": "advancements.husbandry.silk_touch_nest.description",
+    "english_translation": "Move a Bee Nest, with 3 Bees inside, using Silk Touch"
+  },
+  {
+    "key": "advancements.husbandry.wax_on.title",
+    "english_translation": "Wax On"
+  },
+  {
+    "key": "advancements.husbandry.wax_on.description",
+    "english_translation": "Apply Honeycomb to a Copper block!"
+  },
+  {
+    "key": "advancements.husbandry.wax_off.title",
+    "english_translation": "Wax Off"
+  },
+  {
+    "key": "advancements.husbandry.wax_off.description",
+    "english_translation": "Scrape Wax off of a Copper block!"
+  },
+  {
+    "key": "advancements.husbandry.allay_deliver_item_to_player.title",
+    "english_translation": "You've Got a Friend in Me"
+  },
+  {
+    "key": "advancements.husbandry.allay_deliver_item_to_player.description",
+    "english_translation": "Have an Allay deliver items to you"
+  },
+  {
+    "key": "advancements.husbandry.allay_deliver_cake_to_note_block.title",
+    "english_translation": "Birthday Song"
+  },
+  {
+    "key": "advancements.husbandry.allay_deliver_cake_to_note_block.description",
+    "english_translation": "Have an Allay drop a Cake at a Note Block"
+  },
+  {
+    "key": "advancements.end.dragon_breath.title",
+    "english_translation": "You Need a Mint"
+  },
+  {
+    "key": "advancements.end.dragon_breath.description",
+    "english_translation": "Collect Dragon's Breath in a Glass Bottle"
+  },
+  {
+    "key": "advancements.end.dragon_egg.title",
+    "english_translation": "The Next Generation"
+  },
+  {
+    "key": "advancements.end.dragon_egg.description",
+    "english_translation": "Hold the Dragon Egg"
+  },
+  {
+    "key": "advancements.end.elytra.title",
+    "english_translation": "Sky's the Limit"
+  },
+  {
+    "key": "advancements.end.elytra.description",
+    "english_translation": "Find Elytra"
+  },
+  {
+    "key": "advancements.end.enter_end_gateway.title",
+    "english_translation": "Remote Getaway"
+  },
+  {
+    "key": "advancements.end.enter_end_gateway.description",
+    "english_translation": "Escape the island"
+  },
+  {
+    "key": "advancements.end.find_end_city.title",
+    "english_translation": "The City at the End of the Game"
+  },
+  {
+    "key": "advancements.end.find_end_city.description",
+    "english_translation": "Go on in, what could happen?"
+  },
+  {
+    "key": "advancements.end.kill_dragon.title",
+    "english_translation": "Free the End"
+  },
+  {
+    "key": "advancements.end.kill_dragon.description",
+    "english_translation": "Good luck"
+  },
+  {
+    "key": "advancements.end.levitate.title",
+    "english_translation": "Great View From Up Here"
+  },
+  {
+    "key": "advancements.end.levitate.description",
+    "english_translation": "Levitate up 50 blocks from the attacks of a Shulker"
+  },
+  {
+    "key": "advancements.end.respawn_dragon.title",
+    "english_translation": "The End... Again..."
+  },
+  {
+    "key": "advancements.end.respawn_dragon.description",
+    "english_translation": "Respawn the Ender Dragon"
+  },
+  {
+    "key": "advancements.end.root.title",
+    "english_translation": "The End"
+  },
+  {
+    "key": "advancements.end.root.description",
+    "english_translation": "Or the beginning?"
+  },
+  {
+    "key": "advancements.nether.brew_potion.title",
+    "english_translation": "Local Brewery"
+  },
+  {
+    "key": "advancements.nether.brew_potion.description",
+    "english_translation": "Brew a Potion"
+  },
+  {
+    "key": "advancements.nether.all_potions.title",
+    "english_translation": "A Furious Cocktail"
+  },
+  {
+    "key": "advancements.nether.all_potions.description",
+    "english_translation": "Have every potion effect applied at the same time"
+  },
+  {
+    "key": "advancements.nether.all_effects.title",
+    "english_translation": "How Did We Get Here?"
+  },
+  {
+    "key": "advancements.nether.all_effects.description",
+    "english_translation": "Have every effect applied at the same time"
+  },
+  {
+    "key": "advancements.nether.create_beacon.title",
+    "english_translation": "Bring Home the Beacon"
+  },
+  {
+    "key": "advancements.nether.create_beacon.description",
+    "english_translation": "Construct and place a Beacon"
+  },
+  {
+    "key": "advancements.nether.create_full_beacon.title",
+    "english_translation": "Beaconator"
+  },
+  {
+    "key": "advancements.nether.create_full_beacon.description",
+    "english_translation": "Bring a Beacon to full power"
+  },
+  {
+    "key": "advancements.nether.find_fortress.title",
+    "english_translation": "A Terrible Fortress"
+  },
+  {
+    "key": "advancements.nether.find_fortress.description",
+    "english_translation": "Break your way into a Nether Fortress"
+  },
+  {
+    "key": "advancements.nether.get_wither_skull.title",
+    "english_translation": "Spooky Scary Skeleton"
+  },
+  {
+    "key": "advancements.nether.get_wither_skull.description",
+    "english_translation": "Obtain a Wither Skeleton's skull"
+  },
+  {
+    "key": "advancements.nether.obtain_blaze_rod.title",
+    "english_translation": "Into Fire"
+  },
+  {
+    "key": "advancements.nether.obtain_blaze_rod.description",
+    "english_translation": "Relieve a Blaze of its rod"
+  },
+  {
+    "key": "advancements.nether.return_to_sender.title",
+    "english_translation": "Return to Sender"
+  },
+  {
+    "key": "advancements.nether.return_to_sender.description",
+    "english_translation": "Destroy a Ghast with a fireball"
+  },
+  {
+    "key": "advancements.nether.root.title",
+    "english_translation": "Nether"
+  },
+  {
+    "key": "advancements.nether.root.description",
+    "english_translation": "Bring summer clothes"
+  },
+  {
+    "key": "advancements.nether.summon_wither.title",
+    "english_translation": "Withering Heights"
+  },
+  {
+    "key": "advancements.nether.summon_wither.description",
+    "english_translation": "Summon the Wither"
+  },
+  {
+    "key": "advancements.nether.fast_travel.title",
+    "english_translation": "Subspace Bubble"
+  },
+  {
+    "key": "advancements.nether.fast_travel.description",
+    "english_translation": "Use the Nether to travel 7 km in the Overworld"
+  },
+  {
+    "key": "advancements.nether.uneasy_alliance.title",
+    "english_translation": "Uneasy Alliance"
+  },
+  {
+    "key": "advancements.nether.uneasy_alliance.description",
+    "english_translation": "Rescue a Ghast from the Nether, bring it safely home to the Overworld... and then kill it"
+  },
+  {
+    "key": "advancements.nether.obtain_ancient_debris.title",
+    "english_translation": "Hidden in the Depths"
+  },
+  {
+    "key": "advancements.nether.obtain_ancient_debris.description",
+    "english_translation": "Obtain Ancient Debris"
+  },
+  {
+    "key": "advancements.nether.netherite_armor.title",
+    "english_translation": "Cover Me in Debris"
+  },
+  {
+    "key": "advancements.nether.netherite_armor.description",
+    "english_translation": "Get a full suit of Netherite armor"
+  },
+  {
+    "key": "advancements.nether.use_lodestone.title",
+    "english_translation": "Country Lode, Take Me Home"
+  },
+  {
+    "key": "advancements.nether.use_lodestone.description",
+    "english_translation": "Use a Compass on a Lodestone"
+  },
+  {
+    "key": "advancements.nether.obtain_crying_obsidian.title",
+    "english_translation": "Who is Cutting Onions?"
+  },
+  {
+    "key": "advancements.nether.obtain_crying_obsidian.description",
+    "english_translation": "Obtain Crying Obsidian"
+  },
+  {
+    "key": "advancements.nether.charge_respawn_anchor.title",
+    "english_translation": "Not Quite \"Nine\" Lives"
+  },
+  {
+    "key": "advancements.nether.charge_respawn_anchor.description",
+    "english_translation": "Charge a Respawn Anchor to the maximum"
+  },
+  {
+    "key": "advancements.nether.ride_strider.title",
+    "english_translation": "This Boat Has Legs"
+  },
+  {
+    "key": "advancements.nether.ride_strider.description",
+    "english_translation": "Ride a Strider with a Warped Fungus on a Stick"
+  },
+  {
+    "key": "advancements.nether.ride_strider_in_overworld_lava.title",
+    "english_translation": "Feels Like Home"
+  },
+  {
+    "key": "advancements.nether.ride_strider_in_overworld_lava.description",
+    "english_translation": "Take a Strider for a loooong ride on a lava lake in the Overworld"
+  },
+  {
+    "key": "advancements.nether.explore_nether.title",
+    "english_translation": "Hot Tourist Destinations"
+  },
+  {
+    "key": "advancements.nether.explore_nether.description",
+    "english_translation": "Explore all Nether biomes"
+  },
+  {
+    "key": "advancements.nether.find_bastion.title",
+    "english_translation": "Those Were the Days"
+  },
+  {
+    "key": "advancements.nether.find_bastion.description",
+    "english_translation": "Enter a Bastion Remnant"
+  },
+  {
+    "key": "advancements.nether.loot_bastion.title",
+    "english_translation": "War Pigs"
+  },
+  {
+    "key": "advancements.nether.loot_bastion.description",
+    "english_translation": "Loot a Chest in a Bastion Remnant"
+  },
+  {
+    "key": "advancements.nether.distract_piglin.title",
+    "english_translation": "Oh Shiny"
+  },
+  {
+    "key": "advancements.nether.distract_piglin.description",
+    "english_translation": "Distract Piglins with gold"
+  },
+  {
+    "key": "advancements.story.cure_zombie_villager.title",
+    "english_translation": "Zombie Doctor"
+  },
+  {
+    "key": "advancements.story.cure_zombie_villager.description",
+    "english_translation": "Weaken and then cure a Zombie Villager"
+  },
+  {
+    "key": "advancements.story.deflect_arrow.title",
+    "english_translation": "Not Today, Thank You"
+  },
+  {
+    "key": "advancements.story.deflect_arrow.description",
+    "english_translation": "Deflect a projectile with a Shield"
+  },
+  {
+    "key": "advancements.story.enchant_item.title",
+    "english_translation": "Enchanter"
+  },
+  {
+    "key": "advancements.story.enchant_item.description",
+    "english_translation": "Enchant an item at an Enchanting Table"
+  },
+  {
+    "key": "advancements.story.enter_the_end.title",
+    "english_translation": "The End?"
+  },
+  {
+    "key": "advancements.story.enter_the_end.description",
+    "english_translation": "Enter the End Portal"
+  },
+  {
+    "key": "advancements.story.enter_the_nether.title",
+    "english_translation": "We Need to Go Deeper"
+  },
+  {
+    "key": "advancements.story.enter_the_nether.description",
+    "english_translation": "Build, light and enter a Nether Portal"
+  },
+  {
+    "key": "advancements.story.follow_ender_eye.title",
+    "english_translation": "Eye Spy"
+  },
+  {
+    "key": "advancements.story.follow_ender_eye.description",
+    "english_translation": "Follow an Eye of Ender"
+  },
+  {
+    "key": "advancements.story.form_obsidian.title",
+    "english_translation": "Ice Bucket Challenge"
+  },
+  {
+    "key": "advancements.story.form_obsidian.description",
+    "english_translation": "Obtain a block of Obsidian"
+  },
+  {
+    "key": "advancements.story.iron_tools.title",
+    "english_translation": "Isn't It Iron Pick"
+  },
+  {
+    "key": "advancements.story.iron_tools.description",
+    "english_translation": "Upgrade your Pickaxe"
+  },
+  {
+    "key": "advancements.story.lava_bucket.title",
+    "english_translation": "Hot Stuff"
+  },
+  {
+    "key": "advancements.story.lava_bucket.description",
+    "english_translation": "Fill a Bucket with lava"
+  },
+  {
+    "key": "advancements.story.mine_diamond.title",
+    "english_translation": "Diamonds!"
+  },
+  {
+    "key": "advancements.story.mine_diamond.description",
+    "english_translation": "Acquire diamonds"
+  },
+  {
+    "key": "advancements.story.mine_stone.title",
+    "english_translation": "Stone Age"
+  },
+  {
+    "key": "advancements.story.mine_stone.description",
+    "english_translation": "Mine Stone with your new Pickaxe"
+  },
+  {
+    "key": "advancements.story.obtain_armor.title",
+    "english_translation": "Suit Up"
+  },
+  {
+    "key": "advancements.story.obtain_armor.description",
+    "english_translation": "Protect yourself with a piece of iron armor"
+  },
+  {
+    "key": "advancements.story.root.title",
+    "english_translation": "Minecraft"
+  },
+  {
+    "key": "advancements.story.root.description",
+    "english_translation": "The heart and story of the game"
+  },
+  {
+    "key": "advancements.story.shiny_gear.title",
+    "english_translation": "Cover Me with Diamonds"
+  },
+  {
+    "key": "advancements.story.shiny_gear.description",
+    "english_translation": "Diamond armor saves lives"
+  },
+  {
+    "key": "advancements.story.smelt_iron.title",
+    "english_translation": "Acquire Hardware"
+  },
+  {
+    "key": "advancements.story.smelt_iron.description",
+    "english_translation": "Smelt an Iron Ingot"
+  },
+  {
+    "key": "advancements.story.upgrade_tools.title",
+    "english_translation": "Getting an Upgrade"
+  },
+  {
+    "key": "advancements.story.upgrade_tools.description",
+    "english_translation": "Construct a better Pickaxe"
+  },
+  {
+    "key": "team.visibility.always",
+    "english_translation": "Always"
+  },
+  {
+    "key": "team.visibility.never",
+    "english_translation": "Never"
+  },
+  {
+    "key": "team.visibility.hideForOtherTeams",
+    "english_translation": "Hide for other teams"
+  },
+  {
+    "key": "team.visibility.hideForOwnTeam",
+    "english_translation": "Hide for own team"
+  },
+  {
+    "key": "team.collision.always",
+    "english_translation": "Always"
+  },
+  {
+    "key": "team.collision.never",
+    "english_translation": "Never"
+  },
+  {
+    "key": "team.collision.pushOtherTeams",
+    "english_translation": "Push other teams"
+  },
+  {
+    "key": "team.collision.pushOwnTeam",
+    "english_translation": "Push own team"
+  },
+  {
+    "key": "argument.uuid.invalid",
+    "english_translation": "Invalid UUID"
+  },
+  {
+    "key": "argument.entity.selector.nearestPlayer",
+    "english_translation": "Nearest player"
+  },
+  {
+    "key": "argument.entity.selector.randomPlayer",
+    "english_translation": "Random player"
+  },
+  {
+    "key": "argument.entity.selector.allPlayers",
+    "english_translation": "All players"
+  },
+  {
+    "key": "argument.entity.selector.allEntities",
+    "english_translation": "All entities"
+  },
+  {
+    "key": "argument.entity.selector.self",
+    "english_translation": "Current entity"
+  },
+  {
+    "key": "argument.entity.options.name.description",
+    "english_translation": "Entity name"
+  },
+  {
+    "key": "argument.entity.options.distance.description",
+    "english_translation": "Distance to entity"
+  },
+  {
+    "key": "argument.entity.options.level.description",
+    "english_translation": "Experience level"
+  },
+  {
+    "key": "argument.entity.options.x.description",
+    "english_translation": "x position"
+  },
+  {
+    "key": "argument.entity.options.y.description",
+    "english_translation": "y position"
+  },
+  {
+    "key": "argument.entity.options.z.description",
+    "english_translation": "z position"
+  },
+  {
+    "key": "argument.entity.options.dx.description",
+    "english_translation": "Entities between x and x + dx"
+  },
+  {
+    "key": "argument.entity.options.dy.description",
+    "english_translation": "Entities between y and y + dy"
+  },
+  {
+    "key": "argument.entity.options.dz.description",
+    "english_translation": "Entities between z and z + dz"
+  },
+  {
+    "key": "argument.entity.options.x_rotation.description",
+    "english_translation": "Entity's x rotation"
+  },
+  {
+    "key": "argument.entity.options.y_rotation.description",
+    "english_translation": "Entity's y rotation"
+  },
+  {
+    "key": "argument.entity.options.limit.description",
+    "english_translation": "Maximum number of entities to return"
+  },
+  {
+    "key": "argument.entity.options.sort.description",
+    "english_translation": "Sort the entities"
+  },
+  {
+    "key": "argument.entity.options.gamemode.description",
+    "english_translation": "Players with gamemode"
+  },
+  {
+    "key": "argument.entity.options.team.description",
+    "english_translation": "Entities on team"
+  },
+  {
+    "key": "argument.entity.options.type.description",
+    "english_translation": "Entities of type"
+  },
+  {
+    "key": "argument.entity.options.tag.description",
+    "english_translation": "Entities with tag"
+  },
+  {
+    "key": "argument.entity.options.nbt.description",
+    "english_translation": "Entities with NBT"
+  },
+  {
+    "key": "argument.entity.options.scores.description",
+    "english_translation": "Entities with scores"
+  },
+  {
+    "key": "argument.entity.options.advancements.description",
+    "english_translation": "Players with advancements"
+  },
+  {
+    "key": "argument.entity.options.predicate.description",
+    "english_translation": "Custom predicate"
+  },
+  {
+    "key": "command.failed",
+    "english_translation": "An unexpected error occurred trying to execute that command"
+  },
+  {
+    "key": "command.context.here",
+    "english_translation": "<--[HERE]"
+  },
+  {
+    "key": "command.context.parse_error",
+    "english_translation": "%s at position %s: %s"
+  },
+  {
+    "key": "commands.publish.started",
+    "english_translation": "Local game hosted on port %s"
+  },
+  {
+    "key": "commands.publish.failed",
+    "english_translation": "Unable to host local game"
+  },
+  {
+    "key": "commands.advancement.advancementNotFound",
+    "english_translation": "No advancement was found by the name '%1$s'"
+  },
+  {
+    "key": "commands.advancement.criterionNotFound",
+    "english_translation": "The advancement %1$s does not contain the criterion '%2$s'"
+  },
+  {
+    "key": "commands.advancement.grant.one.to.one.success",
+    "english_translation": "Granted the advancement %s to %s"
+  },
+  {
+    "key": "commands.advancement.grant.one.to.one.failure",
+    "english_translation": "Couldn't grant advancement %s to %s as they already have it"
+  },
+  {
+    "key": "commands.advancement.grant.one.to.many.success",
+    "english_translation": "Granted the advancement %s to %s players"
+  },
+  {
+    "key": "commands.advancement.grant.one.to.many.failure",
+    "english_translation": "Couldn't grant advancement %s to %s players as they already have it"
+  },
+  {
+    "key": "commands.advancement.grant.many.to.one.success",
+    "english_translation": "Granted %s advancements to %s"
+  },
+  {
+    "key": "commands.advancement.grant.many.to.one.failure",
+    "english_translation": "Couldn't grant %s advancements to %s as they already have them"
+  },
+  {
+    "key": "commands.advancement.grant.many.to.many.success",
+    "english_translation": "Granted %s advancements to %s players"
+  },
+  {
+    "key": "commands.advancement.grant.many.to.many.failure",
+    "english_translation": "Couldn't grant %s advancements to %s players as they already have them"
+  },
+  {
+    "key": "commands.advancement.grant.criterion.to.one.success",
+    "english_translation": "Granted criterion '%s' of advancement %s to %s"
+  },
+  {
+    "key": "commands.advancement.grant.criterion.to.one.failure",
+    "english_translation": "Couldn't grant criterion '%s' of advancement %s to %s as they already have it"
+  },
+  {
+    "key": "commands.advancement.grant.criterion.to.many.success",
+    "english_translation": "Granted criterion '%s' of advancement %s to %s players"
+  },
+  {
+    "key": "commands.advancement.grant.criterion.to.many.failure",
+    "english_translation": "Couldn't grant criterion '%s' of advancement %s to %s players as they already have it"
+  },
+  {
+    "key": "commands.advancement.revoke.one.to.one.success",
+    "english_translation": "Revoked the advancement %s from %s"
+  },
+  {
+    "key": "commands.advancement.revoke.one.to.one.failure",
+    "english_translation": "Couldn't revoke advancement %s from %s as they don't have it"
+  },
+  {
+    "key": "commands.advancement.revoke.one.to.many.success",
+    "english_translation": "Revoked the advancement %s from %s players"
+  },
+  {
+    "key": "commands.advancement.revoke.one.to.many.failure",
+    "english_translation": "Couldn't revoke advancement %s from %s players as they don't have it"
+  },
+  {
+    "key": "commands.advancement.revoke.many.to.one.success",
+    "english_translation": "Revoked %s advancements from %s"
+  },
+  {
+    "key": "commands.advancement.revoke.many.to.one.failure",
+    "english_translation": "Couldn't revoke %s advancements from %s as they don't have them"
+  },
+  {
+    "key": "commands.advancement.revoke.many.to.many.success",
+    "english_translation": "Revoked %s advancements from %s players"
+  },
+  {
+    "key": "commands.advancement.revoke.many.to.many.failure",
+    "english_translation": "Couldn't revoke %s advancements from %s players as they don't have them"
+  },
+  {
+    "key": "commands.advancement.revoke.criterion.to.one.success",
+    "english_translation": "Revoked criterion '%s' of advancement %s from %s"
+  },
+  {
+    "key": "commands.advancement.revoke.criterion.to.one.failure",
+    "english_translation": "Couldn't revoke criterion '%s' of advancement %s from %s as they don't have it"
+  },
+  {
+    "key": "commands.advancement.revoke.criterion.to.many.success",
+    "english_translation": "Revoked criterion '%s' of advancement %s from %s players"
+  },
+  {
+    "key": "commands.advancement.revoke.criterion.to.many.failure",
+    "english_translation": "Couldn't revoke criterion '%s' of advancement %s from %s players as they don't have it"
+  },
+  {
+    "key": "commands.attribute.failed.entity",
+    "english_translation": "%s is not a valid entity for this command"
+  },
+  {
+    "key": "commands.attribute.failed.no_attribute",
+    "english_translation": "Entity %s has no attribute %s"
+  },
+  {
+    "key": "commands.attribute.failed.no_modifier",
+    "english_translation": "Attribute %s for entity %s has no modifier %s"
+  },
+  {
+    "key": "commands.attribute.failed.modifier_already_present",
+    "english_translation": "Modifier %s is already present on attribute %s for entity %s"
+  },
+  {
+    "key": "commands.attribute.value.get.success",
+    "english_translation": "Value of attribute %s for entity %s is %s"
+  },
+  {
+    "key": "commands.attribute.base_value.get.success",
+    "english_translation": "Base value of attribute %s for entity %s is %s"
+  },
+  {
+    "key": "commands.attribute.base_value.set.success",
+    "english_translation": "Base value for attribute %s for entity %s set to %s"
+  },
+  {
+    "key": "commands.attribute.modifier.add.success",
+    "english_translation": "Added modifier %s to attribute %s for entity %s"
+  },
+  {
+    "key": "commands.attribute.modifier.remove.success",
+    "english_translation": "Removed modifier %s from attribute %s for entity %s"
+  },
+  {
+    "key": "commands.attribute.modifier.value.get.success",
+    "english_translation": "Value of modifier %s on attribute %s for entity %s is %s"
+  },
+  {
+    "key": "commands.forceload.added.failure",
+    "english_translation": "No chunks were marked for force loading"
+  },
+  {
+    "key": "commands.forceload.added.single",
+    "english_translation": "Marked chunk %s in %s to be force loaded"
+  },
+  {
+    "key": "commands.forceload.added.multiple",
+    "english_translation": "Marked %s chunks in %s from %s to %s to be force loaded"
+  },
+  {
+    "key": "commands.forceload.query.success",
+    "english_translation": "Chunk at %s in %s is marked for force loading"
+  },
+  {
+    "key": "commands.forceload.query.failure",
+    "english_translation": "Chunk at %s in %s is not marked for force loading"
+  },
+  {
+    "key": "commands.forceload.list.single",
+    "english_translation": "A force loaded chunk was found in %s at: %s"
+  },
+  {
+    "key": "commands.forceload.list.multiple",
+    "english_translation": "%s force loaded chunks were found in %s at: %s"
+  },
+  {
+    "key": "commands.forceload.added.none",
+    "english_translation": "No force loaded chunks were found in %s"
+  },
+  {
+    "key": "commands.forceload.removed.all",
+    "english_translation": "Unmarked all force loaded chunks in %s"
+  },
+  {
+    "key": "commands.forceload.removed.failure",
+    "english_translation": "No chunks were removed from force loading"
+  },
+  {
+    "key": "commands.forceload.removed.single",
+    "english_translation": "Unmarked chunk %s in %s for force loading"
+  },
+  {
+    "key": "commands.forceload.removed.multiple",
+    "english_translation": "Unmarked %s chunks in %s from %s to %s for force loading"
+  },
+  {
+    "key": "commands.forceload.toobig",
+    "english_translation": "Too many chunks in the specified area (maximum %s, specified %s)"
+  },
+  {
+    "key": "commands.clear.success.single",
+    "english_translation": "Removed %s items from player %s"
+  },
+  {
+    "key": "commands.clear.success.multiple",
+    "english_translation": "Removed %s items from %s players"
+  },
+  {
+    "key": "commands.clear.test.single",
+    "english_translation": "Found %s matching items on player %s"
+  },
+  {
+    "key": "commands.clear.test.multiple",
+    "english_translation": "Found %s matching items on %s players"
+  },
+  {
+    "key": "commands.clone.success",
+    "english_translation": "Successfully cloned %s blocks"
+  },
+  {
+    "key": "commands.debug.started",
+    "english_translation": "Started tick profiling"
+  },
+  {
+    "key": "commands.debug.stopped",
+    "english_translation": "Stopped tick profiling after %s seconds and %s ticks (%s ticks per second)"
+  },
+  {
+    "key": "commands.debug.notRunning",
+    "english_translation": "The tick profiler hasn't started"
+  },
+  {
+    "key": "commands.debug.alreadyRunning",
+    "english_translation": "The tick profiler is already started"
+  },
+  {
+    "key": "commands.debug.function.success.single",
+    "english_translation": "Traced %s commands from function '%s' to output file %s"
+  },
+  {
+    "key": "commands.debug.function.success.multiple",
+    "english_translation": "Traced %s commands from %s functions to output file %s"
+  },
+  {
+    "key": "commands.debug.function.noRecursion",
+    "english_translation": "Can't trace from inside of function"
+  },
+  {
+    "key": "commands.debug.function.traceFailed",
+    "english_translation": "Failed to trace function"
+  },
+  {
+    "key": "commands.defaultgamemode.success",
+    "english_translation": "The default game mode is now %s"
+  },
+  {
+    "key": "commands.difficulty.success",
+    "english_translation": "The difficulty has been set to %s"
+  },
+  {
+    "key": "commands.difficulty.query",
+    "english_translation": "The difficulty is %s"
+  },
+  {
+    "key": "commands.drop.no_held_items",
+    "english_translation": "Entity can't hold any items"
+  },
+  {
+    "key": "commands.drop.no_loot_table",
+    "english_translation": "Entity %s has no loot table"
+  },
+  {
+    "key": "commands.drop.success.single",
+    "english_translation": "Dropped %s %s"
+  },
+  {
+    "key": "commands.drop.success.single_with_table",
+    "english_translation": "Dropped %s %s from loot table %s"
+  },
+  {
+    "key": "commands.drop.success.multiple",
+    "english_translation": "Dropped %s items"
+  },
+  {
+    "key": "commands.drop.success.multiple_with_table",
+    "english_translation": "Dropped %s items from loot table %s"
+  },
+  {
+    "key": "commands.effect.give.success.single",
+    "english_translation": "Applied effect %s to %s"
+  },
+  {
+    "key": "commands.effect.give.success.multiple",
+    "english_translation": "Applied effect %s to %s targets"
+  },
+  {
+    "key": "commands.effect.clear.everything.success.single",
+    "english_translation": "Removed every effect from %s"
+  },
+  {
+    "key": "commands.effect.clear.everything.success.multiple",
+    "english_translation": "Removed every effect from %s targets"
+  },
+  {
+    "key": "commands.effect.clear.specific.success.single",
+    "english_translation": "Removed effect %s from %s"
+  },
+  {
+    "key": "commands.effect.clear.specific.success.multiple",
+    "english_translation": "Removed effect %s from %s targets"
+  },
+  {
+    "key": "commands.enchant.success.single",
+    "english_translation": "Applied enchantment %s to %s's item"
+  },
+  {
+    "key": "commands.enchant.success.multiple",
+    "english_translation": "Applied enchantment %s to %s entities"
+  },
+  {
+    "key": "commands.experience.add.points.success.single",
+    "english_translation": "Gave %s experience points to %s"
+  },
+  {
+    "key": "commands.experience.add.points.success.multiple",
+    "english_translation": "Gave %s experience points to %s players"
+  },
+  {
+    "key": "commands.experience.add.levels.success.single",
+    "english_translation": "Gave %s experience levels to %s"
+  },
+  {
+    "key": "commands.experience.add.levels.success.multiple",
+    "english_translation": "Gave %s experience levels to %s players"
+  },
+  {
+    "key": "commands.experience.set.points.success.single",
+    "english_translation": "Set %s experience points on %s"
+  },
+  {
+    "key": "commands.experience.set.points.success.multiple",
+    "english_translation": "Set %s experience points on %s players"
+  },
+  {
+    "key": "commands.experience.set.levels.success.single",
+    "english_translation": "Set %s experience levels on %s"
+  },
+  {
+    "key": "commands.experience.set.levels.success.multiple",
+    "english_translation": "Set %s experience levels on %s players"
+  },
+  {
+    "key": "commands.experience.query.points",
+    "english_translation": "%s has %s experience points"
+  },
+  {
+    "key": "commands.experience.query.levels",
+    "english_translation": "%s has %s experience levels"
+  },
+  {
+    "key": "commands.fill.success",
+    "english_translation": "Successfully filled %s blocks"
+  },
+  {
+    "key": "commands.function.success.single",
+    "english_translation": "Executed %s commands from function '%s'"
+  },
+  {
+    "key": "commands.function.success.multiple",
+    "english_translation": "Executed %s commands from %s functions"
+  },
+  {
+    "key": "commands.give.failed.toomanyitems",
+    "english_translation": "Can't give more than %s of %s"
+  },
+  {
+    "key": "commands.give.success.single",
+    "english_translation": "Gave %s %s to %s"
+  },
+  {
+    "key": "commands.give.success.multiple",
+    "english_translation": "Gave %s %s to %s players"
+  },
+  {
+    "key": "commands.playsound.success.single",
+    "english_translation": "Played sound %s to %s"
+  },
+  {
+    "key": "commands.playsound.success.multiple",
+    "english_translation": "Played sound %s to %s players"
+  },
+  {
+    "key": "commands.publish.success",
+    "english_translation": "Multiplayer game is now hosted on port %s"
+  },
+  {
+    "key": "commands.list.players",
+    "english_translation": "There are %s of a max of %s players online: %s"
+  },
+  {
+    "key": "commands.list.nameAndId",
+    "english_translation": "%s (%s)"
+  },
+  {
+    "key": "commands.kill.success.single",
+    "english_translation": "Killed %s"
+  },
+  {
+    "key": "commands.kill.success.multiple",
+    "english_translation": "Killed %s entities"
+  },
+  {
+    "key": "commands.kick.success",
+    "english_translation": "Kicked %s: %s"
+  },
+  {
+    "key": "commands.message.display.outgoing",
+    "english_translation": "You whisper to %s: %s"
+  },
+  {
+    "key": "commands.message.display.incoming",
+    "english_translation": "%s whispers to you: %s"
+  },
+  {
+    "key": "commands.op.success",
+    "english_translation": "Made %s a server operator"
+  },
+  {
+    "key": "commands.deop.success",
+    "english_translation": "Made %s no longer a server operator"
+  },
+  {
+    "key": "commands.ban.success",
+    "english_translation": "Banned %s: %s"
+  },
+  {
+    "key": "commands.pardon.success",
+    "english_translation": "Unbanned %s"
+  },
+  {
+    "key": "commands.particle.success",
+    "english_translation": "Displaying particle %s"
+  },
+  {
+    "key": "commands.perf.started",
+    "english_translation": "Started 10 second performance profiling run (use '/perf stop' to stop early)"
+  },
+  {
+    "key": "commands.perf.stopped",
+    "english_translation": "Stopped performance profiling after %s seconds and %s ticks (%s ticks per second)"
+  },
+  {
+    "key": "commands.perf.reportSaved",
+    "english_translation": "Created debug report in %s"
+  },
+  {
+    "key": "commands.perf.reportFailed",
+    "english_translation": "Failed to create debug report"
+  },
+  {
+    "key": "commands.perf.notRunning",
+    "english_translation": "The performance profiler hasn't started"
+  },
+  {
+    "key": "commands.perf.alreadyRunning",
+    "english_translation": "The performance profiler is already started"
+  },
+  {
+    "key": "commands.jfr.started",
+    "english_translation": "JFR profiling started"
+  },
+  {
+    "key": "commands.jfr.start.failed",
+    "english_translation": "Failed to start JFR profiling"
+  },
+  {
+    "key": "commands.jfr.stopped",
+    "english_translation": "JFR profiling stopped and dumped to %s"
+  },
+  {
+    "key": "commands.jfr.dump.failed",
+    "english_translation": "Failed to dump JFR recording: %s"
+  },
+  {
+    "key": "commands.seed.success",
+    "english_translation": "Seed: %s"
+  },
+  {
+    "key": "commands.stop.stopping",
+    "english_translation": "Stopping the server"
+  },
+  {
+    "key": "commands.time.query",
+    "english_translation": "The time is %s"
+  },
+  {
+    "key": "commands.time.set",
+    "english_translation": "Set the time to %s"
+  },
+  {
+    "key": "commands.schedule.created.function",
+    "english_translation": "Scheduled function '%s' in %s ticks at gametime %s"
+  },
+  {
+    "key": "commands.schedule.created.tag",
+    "english_translation": "Scheduled tag '%s' in %s ticks at gametime %s"
+  },
+  {
+    "key": "commands.schedule.cleared.success",
+    "english_translation": "Removed %s schedules with id %s"
+  },
+  {
+    "key": "commands.schedule.cleared.failure",
+    "english_translation": "No schedules with id %s"
+  },
+  {
+    "key": "commands.schedule.same_tick",
+    "english_translation": "Can't schedule for current tick"
+  },
+  {
+    "key": "commands.gamemode.success.self",
+    "english_translation": "Set own game mode to %s"
+  },
+  {
+    "key": "commands.gamemode.success.other",
+    "english_translation": "Set %s's game mode to %s"
+  },
+  {
+    "key": "commands.gamerule.query",
+    "english_translation": "Gamerule %s is currently set to: %s"
+  },
+  {
+    "key": "commands.gamerule.set",
+    "english_translation": "Gamerule %s is now set to: %s"
+  },
+  {
+    "key": "commands.save.disabled",
+    "english_translation": "Automatic saving is now disabled"
+  },
+  {
+    "key": "commands.save.enabled",
+    "english_translation": "Automatic saving is now enabled"
+  },
+  {
+    "key": "commands.save.saving",
+    "english_translation": "Saving the game (this may take a moment!)"
+  },
+  {
+    "key": "commands.save.success",
+    "english_translation": "Saved the game"
+  },
+  {
+    "key": "commands.setidletimeout.success",
+    "english_translation": "The player idle timeout is now %s minutes"
+  },
+  {
+    "key": "commands.banlist.none",
+    "english_translation": "There are no bans"
+  },
+  {
+    "key": "commands.banlist.list",
+    "english_translation": "There are %s bans:"
+  },
+  {
+    "key": "commands.banlist.entry",
+    "english_translation": "%s was banned by %s: %s"
+  },
+  {
+    "key": "commands.bossbar.create.success",
+    "english_translation": "Created custom bossbar %s"
+  },
+  {
+    "key": "commands.bossbar.remove.success",
+    "english_translation": "Removed custom bossbar %s"
+  },
+  {
+    "key": "commands.bossbar.list.bars.none",
+    "english_translation": "There are no custom bossbars active"
+  },
+  {
+    "key": "commands.bossbar.list.bars.some",
+    "english_translation": "There are %s custom bossbars active: %s"
+  },
+  {
+    "key": "commands.bossbar.set.players.success.none",
+    "english_translation": "Custom bossbar %s no longer has any players"
+  },
+  {
+    "key": "commands.bossbar.set.players.success.some",
+    "english_translation": "Custom bossbar %s now has %s players: %s"
+  },
+  {
+    "key": "commands.bossbar.set.name.success",
+    "english_translation": "Custom bossbar %s has been renamed"
+  },
+  {
+    "key": "commands.bossbar.set.color.success",
+    "english_translation": "Custom bossbar %s has changed color"
+  },
+  {
+    "key": "commands.bossbar.set.style.success",
+    "english_translation": "Custom bossbar %s has changed style"
+  },
+  {
+    "key": "commands.bossbar.set.value.success",
+    "english_translation": "Custom bossbar %s has changed value to %s"
+  },
+  {
+    "key": "commands.bossbar.set.max.success",
+    "english_translation": "Custom bossbar %s has changed maximum to %s"
+  },
+  {
+    "key": "commands.bossbar.set.visible.success.visible",
+    "english_translation": "Custom bossbar %s is now visible"
+  },
+  {
+    "key": "commands.bossbar.set.visible.success.hidden",
+    "english_translation": "Custom bossbar %s is now hidden"
+  },
+  {
+    "key": "commands.bossbar.get.value",
+    "english_translation": "Custom bossbar %s has a value of %s"
+  },
+  {
+    "key": "commands.bossbar.get.max",
+    "english_translation": "Custom bossbar %s has a maximum of %s"
+  },
+  {
+    "key": "commands.bossbar.get.visible.visible",
+    "english_translation": "Custom bossbar %s is currently shown"
+  },
+  {
+    "key": "commands.bossbar.get.visible.hidden",
+    "english_translation": "Custom bossbar %s is currently hidden"
+  },
+  {
+    "key": "commands.bossbar.get.players.none",
+    "english_translation": "Custom bossbar %s has no players currently online"
+  },
+  {
+    "key": "commands.bossbar.get.players.some",
+    "english_translation": "Custom bossbar %s has %s players currently online: %s"
+  },
+  {
+    "key": "commands.recipe.give.success.single",
+    "english_translation": "Unlocked %s recipes for %s"
+  },
+  {
+    "key": "commands.recipe.give.success.multiple",
+    "english_translation": "Unlocked %s recipes for %s players"
+  },
+  {
+    "key": "commands.recipe.take.success.single",
+    "english_translation": "Took %s recipes from %s"
+  },
+  {
+    "key": "commands.recipe.take.success.multiple",
+    "english_translation": "Took %s recipes from %s players"
+  },
+  {
+    "key": "commands.summon.success",
+    "english_translation": "Summoned new %s"
+  },
+  {
+    "key": "commands.whitelist.enabled",
+    "english_translation": "Whitelist is now turned on"
+  },
+  {
+    "key": "commands.whitelist.disabled",
+    "english_translation": "Whitelist is now turned off"
+  },
+  {
+    "key": "commands.whitelist.none",
+    "english_translation": "There are no whitelisted players"
+  },
+  {
+    "key": "commands.whitelist.list",
+    "english_translation": "There are %s whitelisted players: %s"
+  },
+  {
+    "key": "commands.whitelist.add.success",
+    "english_translation": "Added %s to the whitelist"
+  },
+  {
+    "key": "commands.whitelist.remove.success",
+    "english_translation": "Removed %s from the whitelist"
+  },
+  {
+    "key": "commands.whitelist.reloaded",
+    "english_translation": "Reloaded the whitelist"
+  },
+  {
+    "key": "commands.weather.set.clear",
+    "english_translation": "Set the weather to clear"
+  },
+  {
+    "key": "commands.weather.set.rain",
+    "english_translation": "Set the weather to rain"
+  },
+  {
+    "key": "commands.weather.set.thunder",
+    "english_translation": "Set the weather to rain & thunder"
+  },
+  {
+    "key": "commands.spawnpoint.success.single",
+    "english_translation": "Set spawn point to %s, %s, %s [%s] in %s for %s"
+  },
+  {
+    "key": "commands.spawnpoint.success.multiple",
+    "english_translation": "Set spawn point to %s, %s, %s [%s] in %s for %s players"
+  },
+  {
+    "key": "commands.stopsound.success.source.sound",
+    "english_translation": "Stopped sound '%s' on source '%s'"
+  },
+  {
+    "key": "commands.stopsound.success.source.any",
+    "english_translation": "Stopped all '%s' sounds"
+  },
+  {
+    "key": "commands.stopsound.success.sourceless.sound",
+    "english_translation": "Stopped sound '%s'"
+  },
+  {
+    "key": "commands.stopsound.success.sourceless.any",
+    "english_translation": "Stopped all sounds"
+  },
+  {
+    "key": "commands.setworldspawn.success",
+    "english_translation": "Set the world spawn point to %s, %s, %s [%s]"
+  },
+  {
+    "key": "commands.spreadplayers.success.teams",
+    "english_translation": "Spread %s teams around %s, %s with an average distance of %s blocks apart"
+  },
+  {
+    "key": "commands.spreadplayers.success.entities",
+    "english_translation": "Spread %s players around %s, %s with an average distance of %s blocks apart"
+  },
+  {
+    "key": "commands.setblock.success",
+    "english_translation": "Changed the block at %s, %s, %s"
+  },
+  {
+    "key": "commands.banip.success",
+    "english_translation": "Banned IP %s: %s"
+  },
+  {
+    "key": "commands.banip.info",
+    "english_translation": "This ban affects %s players: %s"
+  },
+  {
+    "key": "commands.pardonip.success",
+    "english_translation": "Unbanned IP %s"
+  },
+  {
+    "key": "commands.teleport.success.entity.single",
+    "english_translation": "Teleported %s to %s"
+  },
+  {
+    "key": "commands.teleport.success.entity.multiple",
+    "english_translation": "Teleported %s entities to %s"
+  },
+  {
+    "key": "commands.teleport.success.location.single",
+    "english_translation": "Teleported %s to %s, %s, %s"
+  },
+  {
+    "key": "commands.teleport.success.location.multiple",
+    "english_translation": "Teleported %s entities to %s, %s, %s"
+  },
+  {
+    "key": "commands.teleport.invalidPosition",
+    "english_translation": "Invalid position for teleport"
+  },
+  {
+    "key": "commands.title.cleared.single",
+    "english_translation": "Cleared titles for %s"
+  },
+  {
+    "key": "commands.title.cleared.multiple",
+    "english_translation": "Cleared titles for %s players"
+  },
+  {
+    "key": "commands.title.reset.single",
+    "english_translation": "Reset title options for %s"
+  },
+  {
+    "key": "commands.title.reset.multiple",
+    "english_translation": "Reset title options for %s players"
+  },
+  {
+    "key": "commands.title.show.title.single",
+    "english_translation": "Showing new title for %s"
+  },
+  {
+    "key": "commands.title.show.title.multiple",
+    "english_translation": "Showing new title for %s players"
+  },
+  {
+    "key": "commands.title.show.subtitle.single",
+    "english_translation": "Showing new subtitle for %s"
+  },
+  {
+    "key": "commands.title.show.subtitle.multiple",
+    "english_translation": "Showing new subtitle for %s players"
+  },
+  {
+    "key": "commands.title.show.actionbar.single",
+    "english_translation": "Showing new actionbar title for %s"
+  },
+  {
+    "key": "commands.title.show.actionbar.multiple",
+    "english_translation": "Showing new actionbar title for %s players"
+  },
+  {
+    "key": "commands.title.times.single",
+    "english_translation": "Changed title display times for %s"
+  },
+  {
+    "key": "commands.title.times.multiple",
+    "english_translation": "Changed title display times for %s players"
+  },
+  {
+    "key": "commands.worldborder.set.grow",
+    "english_translation": "Growing the world border to %s blocks wide over %s seconds"
+  },
+  {
+    "key": "commands.worldborder.set.shrink",
+    "english_translation": "Shrinking the world border to %s blocks wide over %s seconds"
+  },
+  {
+    "key": "commands.worldborder.set.immediate",
+    "english_translation": "Set the world border to %s blocks wide"
+  },
+  {
+    "key": "commands.worldborder.center.success",
+    "english_translation": "Set the center of the world border to %s, %s"
+  },
+  {
+    "key": "commands.worldborder.get",
+    "english_translation": "The world border is currently %s blocks wide"
+  },
+  {
+    "key": "commands.worldborder.damage.buffer.success",
+    "english_translation": "Set the world border damage buffer to %s blocks"
+  },
+  {
+    "key": "commands.worldborder.damage.amount.success",
+    "english_translation": "Set the world border damage to %s per block each second"
+  },
+  {
+    "key": "commands.worldborder.warning.time.success",
+    "english_translation": "Set the world border warning time to %s seconds"
+  },
+  {
+    "key": "commands.worldborder.warning.distance.success",
+    "english_translation": "Set the world border warning distance to %s blocks"
+  },
+  {
+    "key": "commands.tag.add.success.single",
+    "english_translation": "Added tag '%s' to %s"
+  },
+  {
+    "key": "commands.tag.add.success.multiple",
+    "english_translation": "Added tag '%s' to %s entities"
+  },
+  {
+    "key": "commands.tag.remove.success.single",
+    "english_translation": "Removed tag '%s' from %s"
+  },
+  {
+    "key": "commands.tag.remove.success.multiple",
+    "english_translation": "Removed tag '%s' from %s entities"
+  },
+  {
+    "key": "commands.tag.list.single.empty",
+    "english_translation": "%s has no tags"
+  },
+  {
+    "key": "commands.tag.list.single.success",
+    "english_translation": "%s has %s tags: %s"
+  },
+  {
+    "key": "commands.tag.list.multiple.empty",
+    "english_translation": "There are no tags on the %s entities"
+  },
+  {
+    "key": "commands.tag.list.multiple.success",
+    "english_translation": "The %s entities have %s total tags: %s"
+  },
+  {
+    "key": "commands.team.list.members.empty",
+    "english_translation": "There are no members on team %s"
+  },
+  {
+    "key": "commands.team.list.members.success",
+    "english_translation": "Team %s has %s members: %s"
+  },
+  {
+    "key": "commands.team.list.teams.empty",
+    "english_translation": "There are no teams"
+  },
+  {
+    "key": "commands.team.list.teams.success",
+    "english_translation": "There are %s teams: %s"
+  },
+  {
+    "key": "commands.team.add.success",
+    "english_translation": "Created team %s"
+  },
+  {
+    "key": "commands.team.remove.success",
+    "english_translation": "Removed team %s"
+  },
+  {
+    "key": "commands.team.empty.success",
+    "english_translation": "Removed %s members from team %s"
+  },
+  {
+    "key": "commands.team.option.color.success",
+    "english_translation": "Updated the color for team %s to %s"
+  },
+  {
+    "key": "commands.team.option.name.success",
+    "english_translation": "Updated the name of team %s"
+  },
+  {
+    "key": "commands.team.option.friendlyfire.enabled",
+    "english_translation": "Enabled friendly fire for team %s"
+  },
+  {
+    "key": "commands.team.option.friendlyfire.disabled",
+    "english_translation": "Disabled friendly fire for team %s"
+  },
+  {
+    "key": "commands.team.option.seeFriendlyInvisibles.enabled",
+    "english_translation": "Team %s can now see invisible teammates"
+  },
+  {
+    "key": "commands.team.option.seeFriendlyInvisibles.disabled",
+    "english_translation": "Team %s can no longer see invisible teammates"
+  },
+  {
+    "key": "commands.team.option.nametagVisibility.success",
+    "english_translation": "Nametag visibility for team %s is now \"%s\""
+  },
+  {
+    "key": "commands.team.option.deathMessageVisibility.success",
+    "english_translation": "Death message visibility for team %s is now \"%s\""
+  },
+  {
+    "key": "commands.team.option.collisionRule.success",
+    "english_translation": "Collision rule for team %s is now \"%s\""
+  },
+  {
+    "key": "commands.team.option.prefix.success",
+    "english_translation": "Team prefix set to %s"
+  },
+  {
+    "key": "commands.team.option.suffix.success",
+    "english_translation": "Team suffix set to %s"
+  },
+  {
+    "key": "commands.team.join.success.single",
+    "english_translation": "Added %s to team %s"
+  },
+  {
+    "key": "commands.team.join.success.multiple",
+    "english_translation": "Added %s members to team %s"
+  },
+  {
+    "key": "commands.team.leave.success.single",
+    "english_translation": "Removed %s from any team"
+  },
+  {
+    "key": "commands.team.leave.success.multiple",
+    "english_translation": "Removed %s members from any team"
+  },
+  {
+    "key": "commands.trigger.simple.success",
+    "english_translation": "Triggered %s"
+  },
+  {
+    "key": "commands.trigger.add.success",
+    "english_translation": "Triggered %s (added %s to value)"
+  },
+  {
+    "key": "commands.trigger.set.success",
+    "english_translation": "Triggered %s (set value to %s)"
+  },
+  {
+    "key": "commands.scoreboard.objectives.list.empty",
+    "english_translation": "There are no objectives"
+  },
+  {
+    "key": "commands.scoreboard.objectives.list.success",
+    "english_translation": "There are %s objectives: %s"
+  },
+  {
+    "key": "commands.scoreboard.objectives.add.success",
+    "english_translation": "Created new objective %s"
+  },
+  {
+    "key": "commands.scoreboard.objectives.remove.success",
+    "english_translation": "Removed objective %s"
+  },
+  {
+    "key": "commands.scoreboard.objectives.display.cleared",
+    "english_translation": "Cleared any objectives in display slot %s"
+  },
+  {
+    "key": "commands.scoreboard.objectives.display.set",
+    "english_translation": "Set display slot %s to show objective %s"
+  },
+  {
+    "key": "commands.scoreboard.objectives.modify.displayname",
+    "english_translation": "Changed the display name of %s to %s"
+  },
+  {
+    "key": "commands.scoreboard.objectives.modify.rendertype",
+    "english_translation": "Changed the render type of objective %s"
+  },
+  {
+    "key": "commands.scoreboard.players.list.empty",
+    "english_translation": "There are no tracked entities"
+  },
+  {
+    "key": "commands.scoreboard.players.list.success",
+    "english_translation": "There are %s tracked entities: %s"
+  },
+  {
+    "key": "commands.scoreboard.players.list.entity.empty",
+    "english_translation": "%s has no scores to show"
+  },
+  {
+    "key": "commands.scoreboard.players.list.entity.success",
+    "english_translation": "%s has %s scores:"
+  },
+  {
+    "key": "commands.scoreboard.players.list.entity.entry",
+    "english_translation": "%s: %s"
+  },
+  {
+    "key": "commands.scoreboard.players.set.success.single",
+    "english_translation": "Set %s for %s to %s"
+  },
+  {
+    "key": "commands.scoreboard.players.set.success.multiple",
+    "english_translation": "Set %s for %s entities to %s"
+  },
+  {
+    "key": "commands.scoreboard.players.add.success.single",
+    "english_translation": "Added %s to %s for %s (now %s)"
+  },
+  {
+    "key": "commands.scoreboard.players.add.success.multiple",
+    "english_translation": "Added %s to %s for %s entities"
+  },
+  {
+    "key": "commands.scoreboard.players.remove.success.single",
+    "english_translation": "Removed %s from %s for %s (now %s)"
+  },
+  {
+    "key": "commands.scoreboard.players.remove.success.multiple",
+    "english_translation": "Removed %s from %s for %s entities"
+  },
+  {
+    "key": "commands.scoreboard.players.reset.all.single",
+    "english_translation": "Reset all scores for %s"
+  },
+  {
+    "key": "commands.scoreboard.players.reset.all.multiple",
+    "english_translation": "Reset all scores for %s entities"
+  },
+  {
+    "key": "commands.scoreboard.players.reset.specific.single",
+    "english_translation": "Reset %s for %s"
+  },
+  {
+    "key": "commands.scoreboard.players.reset.specific.multiple",
+    "english_translation": "Reset %s for %s entities"
+  },
+  {
+    "key": "commands.scoreboard.players.enable.success.single",
+    "english_translation": "Enabled trigger %s for %s"
+  },
+  {
+    "key": "commands.scoreboard.players.enable.success.multiple",
+    "english_translation": "Enabled trigger %s for %s entities"
+  },
+  {
+    "key": "commands.scoreboard.players.operation.success.single",
+    "english_translation": "Set %s for %s to %s"
+  },
+  {
+    "key": "commands.scoreboard.players.operation.success.multiple",
+    "english_translation": "Updated %s for %s entities"
+  },
+  {
+    "key": "commands.scoreboard.players.get.success",
+    "english_translation": "%s has %s %s"
+  },
+  {
+    "key": "commands.reload.success",
+    "english_translation": "Reloading!"
+  },
+  {
+    "key": "commands.reload.failure",
+    "english_translation": "Reload failed; keeping old data"
+  },
+  {
+    "key": "commands.data.entity.modified",
+    "english_translation": "Modified entity data of %s"
+  },
+  {
+    "key": "commands.data.entity.query",
+    "english_translation": "%s has the following entity data: %s"
+  },
+  {
+    "key": "commands.data.entity.get",
+    "english_translation": "%s on %s after scale factor of %s is %s"
+  },
+  {
+    "key": "commands.data.block.modified",
+    "english_translation": "Modified block data of %s, %s, %s"
+  },
+  {
+    "key": "commands.data.block.query",
+    "english_translation": "%s, %s, %s has the following block data: %s"
+  },
+  {
+    "key": "commands.data.block.get",
+    "english_translation": "%s on block %s, %s, %s after scale factor of %s is %s"
+  },
+  {
+    "key": "commands.data.storage.modified",
+    "english_translation": "Modified storage %s"
+  },
+  {
+    "key": "commands.data.storage.query",
+    "english_translation": "Storage %s has the following contents: %s"
+  },
+  {
+    "key": "commands.data.storage.get",
+    "english_translation": "%s in storage %s after scale factor of %s is %s"
+  },
+  {
+    "key": "commands.datapack.list.enabled.success",
+    "english_translation": "There are %s data packs enabled: %s"
+  },
+  {
+    "key": "commands.datapack.list.enabled.none",
+    "english_translation": "There are no data packs enabled"
+  },
+  {
+    "key": "commands.datapack.list.available.success",
+    "english_translation": "There are %s data packs available: %s"
+  },
+  {
+    "key": "commands.datapack.list.available.none",
+    "english_translation": "There are no more data packs available"
+  },
+  {
+    "key": "commands.datapack.modify.enable",
+    "english_translation": "Enabling data pack %s"
+  },
+  {
+    "key": "commands.datapack.modify.disable",
+    "english_translation": "Disabling data pack %s"
+  },
+  {
+    "key": "commands.spectate.success.stopped",
+    "english_translation": "No longer spectating an entity"
+  },
+  {
+    "key": "commands.spectate.success.started",
+    "english_translation": "Now spectating %s"
+  },
+  {
+    "key": "commands.spectate.not_spectator",
+    "english_translation": "%s is not in spectator mode"
+  },
+  {
+    "key": "commands.spectate.self",
+    "english_translation": "Cannot spectate yourself"
+  },
+  {
+    "key": "commands.item.target.not_a_container",
+    "english_translation": "Target position %s, %s, %s is not a container"
+  },
+  {
+    "key": "commands.item.source.not_a_container",
+    "english_translation": "Source position %s, %s, %s is not a container"
+  },
+  {
+    "key": "commands.item.target.no_such_slot",
+    "english_translation": "The target does not have slot %s"
+  },
+  {
+    "key": "commands.item.source.no_such_slot",
+    "english_translation": "The source does not have slot %s"
+  },
+  {
+    "key": "commands.item.target.no_changes",
+    "english_translation": "No targets accepted item into slot %s"
+  },
+  {
+    "key": "commands.item.target.no_changed.known_item",
+    "english_translation": "No targets accepted item %s into slot %s"
+  },
+  {
+    "key": "commands.item.block.set.success",
+    "english_translation": "Replaced a slot at %s, %s, %s with %s"
+  },
+  {
+    "key": "commands.item.entity.set.success.single",
+    "english_translation": "Replaced a slot on %s with %s"
+  },
+  {
+    "key": "commands.item.entity.set.success.multiple",
+    "english_translation": "Replaced a slot on %s entities with %s"
+  },
+  {
+    "key": "argument.range.empty",
+    "english_translation": "Expected value or range of values"
+  },
+  {
+    "key": "argument.range.ints",
+    "english_translation": "Only whole numbers allowed, not decimals"
+  },
+  {
+    "key": "argument.range.swapped",
+    "english_translation": "Min cannot be bigger than max"
+  },
+  {
+    "key": "permissions.requires.player",
+    "english_translation": "A player is required to run this command here"
+  },
+  {
+    "key": "permissions.requires.entity",
+    "english_translation": "An entity is required to run this command here"
+  },
+  {
+    "key": "argument.angle.incomplete",
+    "english_translation": "Incomplete (expected 1 angle)"
+  },
+  {
+    "key": "argument.angle.invalid",
+    "english_translation": "Invalid angle"
+  },
+  {
+    "key": "argument.entity.toomany",
+    "english_translation": "Only one entity is allowed, but the provided selector allows more than one"
+  },
+  {
+    "key": "argument.player.toomany",
+    "english_translation": "Only one player is allowed, but the provided selector allows more than one"
+  },
+  {
+    "key": "argument.player.entities",
+    "english_translation": "Only players may be affected by this command, but the provided selector includes entities"
+  },
+  {
+    "key": "argument.entity.notfound.entity",
+    "english_translation": "No entity was found"
+  },
+  {
+    "key": "argument.entity.notfound.player",
+    "english_translation": "No player was found"
+  },
+  {
+    "key": "argument.player.unknown",
+    "english_translation": "That player does not exist"
+  },
+  {
+    "key": "arguments.nbtpath.node.invalid",
+    "english_translation": "Invalid NBT path element"
+  },
+  {
+    "key": "arguments.nbtpath.nothing_found",
+    "english_translation": "Found no elements matching %s"
+  },
+  {
+    "key": "arguments.operation.invalid",
+    "english_translation": "Invalid operation"
+  },
+  {
+    "key": "arguments.operation.div0",
+    "english_translation": "Cannot divide by zero"
+  },
+  {
+    "key": "argument.scoreHolder.empty",
+    "english_translation": "No relevant score holders could be found"
+  },
+  {
+    "key": "argument.block.tag.disallowed",
+    "english_translation": "Tags aren't allowed here, only actual blocks"
+  },
+  {
+    "key": "argument.block.property.unclosed",
+    "english_translation": "Expected closing ] for block state properties"
+  },
+  {
+    "key": "argument.pos.unloaded",
+    "english_translation": "That position is not loaded"
+  },
+  {
+    "key": "argument.pos.outofworld",
+    "english_translation": "That position is out of this world!"
+  },
+  {
+    "key": "argument.pos.outofbounds",
+    "english_translation": "That position is outside the allowed boundaries."
+  },
+  {
+    "key": "argument.rotation.incomplete",
+    "english_translation": "Incomplete (expected 2 coordinates)"
+  },
+  {
+    "key": "arguments.swizzle.invalid",
+    "english_translation": "Invalid swizzle, expected combination of 'x', 'y' and 'z'"
+  },
+  {
+    "key": "argument.pos2d.incomplete",
+    "english_translation": "Incomplete (expected 2 coordinates)"
+  },
+  {
+    "key": "argument.pos3d.incomplete",
+    "english_translation": "Incomplete (expected 3 coordinates)"
+  },
+  {
+    "key": "argument.pos.mixed",
+    "english_translation": "Cannot mix world & local coordinates (everything must either use ^ or not)"
+  },
+  {
+    "key": "argument.pos.missing.double",
+    "english_translation": "Expected a coordinate"
+  },
+  {
+    "key": "argument.pos.missing.int",
+    "english_translation": "Expected a block position"
+  },
+  {
+    "key": "argument.item.tag.disallowed",
+    "english_translation": "Tags aren't allowed here, only actual items"
+  },
+  {
+    "key": "argument.entity.invalid",
+    "english_translation": "Invalid name or UUID"
+  },
+  {
+    "key": "argument.entity.selector.missing",
+    "english_translation": "Missing selector type"
+  },
+  {
+    "key": "argument.entity.selector.not_allowed",
+    "english_translation": "Selector not allowed"
+  },
+  {
+    "key": "argument.entity.options.unterminated",
+    "english_translation": "Expected end of options"
+  },
+  {
+    "key": "argument.entity.options.distance.negative",
+    "english_translation": "Distance cannot be negative"
+  },
+  {
+    "key": "argument.entity.options.level.negative",
+    "english_translation": "Level shouldn't be negative"
+  },
+  {
+    "key": "argument.entity.options.limit.toosmall",
+    "english_translation": "Limit must be at least 1"
+  },
+  {
+    "key": "argument.nbt.trailing",
+    "english_translation": "Unexpected trailing data"
+  },
+  {
+    "key": "argument.nbt.expected.key",
+    "english_translation": "Expected key"
+  },
+  {
+    "key": "argument.nbt.expected.value",
+    "english_translation": "Expected value"
+  },
+  {
+    "key": "argument.id.invalid",
+    "english_translation": "Invalid ID"
+  },
+  {
+    "key": "argument.time.invalid_unit",
+    "english_translation": "Invalid unit"
+  },
+  {
+    "key": "argument.time.invalid_tick_count",
+    "english_translation": "Tick count must be non-negative"
+  },
+  {
+    "key": "argument.enum.invalid",
+    "english_translation": "Invalid value \"%s\""
+  },
+  {
+    "key": "commands.banip.invalid",
+    "english_translation": "Invalid IP address or unknown player"
+  },
+  {
+    "key": "commands.banip.failed",
+    "english_translation": "Nothing changed. That IP is already banned"
+  },
+  {
+    "key": "commands.ban.failed",
+    "english_translation": "Nothing changed. The player is already banned"
+  },
+  {
+    "key": "commands.bossbar.set.players.unchanged",
+    "english_translation": "Nothing changed. Those players are already on the bossbar with nobody to add or remove"
+  },
+  {
+    "key": "commands.bossbar.set.name.unchanged",
+    "english_translation": "Nothing changed. That's already the name of this bossbar"
+  },
+  {
+    "key": "commands.bossbar.set.color.unchanged",
+    "english_translation": "Nothing changed. That's already the color of this bossbar"
+  },
+  {
+    "key": "commands.bossbar.set.style.unchanged",
+    "english_translation": "Nothing changed. That's already the style of this bossbar"
+  },
+  {
+    "key": "commands.bossbar.set.value.unchanged",
+    "english_translation": "Nothing changed. That's already the value of this bossbar"
+  },
+  {
+    "key": "commands.bossbar.set.max.unchanged",
+    "english_translation": "Nothing changed. That's already the max of this bossbar"
+  },
+  {
+    "key": "commands.bossbar.set.visibility.unchanged.hidden",
+    "english_translation": "Nothing changed. The bossbar is already hidden"
+  },
+  {
+    "key": "commands.bossbar.set.visibility.unchanged.visible",
+    "english_translation": "Nothing changed. The bossbar is already visible"
+  },
+  {
+    "key": "commands.clone.overlap",
+    "english_translation": "The source and destination areas cannot overlap"
+  },
+  {
+    "key": "commands.clone.failed",
+    "english_translation": "No blocks were cloned"
+  },
+  {
+    "key": "commands.deop.failed",
+    "english_translation": "Nothing changed. The player is not an operator"
+  },
+  {
+    "key": "commands.effect.give.failed",
+    "english_translation": "Unable to apply this effect (target is either immune to effects, or has something stronger)"
+  },
+  {
+    "key": "commands.effect.clear.everything.failed",
+    "english_translation": "Target has no effects to remove"
+  },
+  {
+    "key": "commands.effect.clear.specific.failed",
+    "english_translation": "Target doesn't have the requested effect"
+  },
+  {
+    "key": "commands.enchant.failed",
+    "english_translation": "Nothing changed. Targets either have no item in their hands or the enchantment could not be applied"
+  },
+  {
+    "key": "commands.experience.set.points.invalid",
+    "english_translation": "Cannot set experience points above the maximum points for the player's current level"
+  },
+  {
+    "key": "commands.fill.failed",
+    "english_translation": "No blocks were filled"
+  },
+  {
+    "key": "commands.help.failed",
+    "english_translation": "Unknown command or insufficient permissions"
+  },
+  {
+    "key": "commands.locate.structure.success",
+    "english_translation": "The nearest %s is at %s (%s blocks away)"
+  },
+  {
+    "key": "commands.locate.structure.not_found",
+    "english_translation": "Could not find a structure of type \"%s\" nearby"
+  },
+  {
+    "key": "commands.locate.structure.invalid",
+    "english_translation": "There is no structure with type \"%s\""
+  },
+  {
+    "key": "commands.locate.biome.success",
+    "english_translation": "The nearest %s is at %s (%s blocks away)"
+  },
+  {
+    "key": "commands.locate.biome.not_found",
+    "english_translation": "Could not find a biome of type \"%s\" within reasonable distance"
+  },
+  {
+    "key": "commands.locate.biome.invalid",
+    "english_translation": "There is no biome with type \"%s\""
+  },
+  {
+    "key": "commands.locate.poi.success",
+    "english_translation": "The nearest %s is at %s (%s blocks away)"
+  },
+  {
+    "key": "commands.locate.poi.not_found",
+    "english_translation": "Could not find a point of interest of type \"%s\" within reasonable distance"
+  },
+  {
+    "key": "commands.locate.poi.invalid",
+    "english_translation": "There is no point of interest with type \"%s\""
+  },
+  {
+    "key": "commands.op.failed",
+    "english_translation": "Nothing changed. The player already is an operator"
+  },
+  {
+    "key": "commands.pardon.failed",
+    "english_translation": "Nothing changed. The player isn't banned"
+  },
+  {
+    "key": "commands.pardonip.invalid",
+    "english_translation": "Invalid IP address"
+  },
+  {
+    "key": "commands.pardonip.failed",
+    "english_translation": "Nothing changed. That IP isn't banned"
+  },
+  {
+    "key": "commands.particle.failed",
+    "english_translation": "The particle was not visible for anybody"
+  },
+  {
+    "key": "commands.place.feature.failed",
+    "english_translation": "Failed to place feature"
+  },
+  {
+    "key": "commands.place.feature.invalid",
+    "english_translation": "There is no feature with type \"%s\""
+  },
+  {
+    "key": "commands.place.feature.success",
+    "english_translation": "Placed \"%s\" at %s, %s, %s"
+  },
+  {
+    "key": "commands.place.jigsaw.failed",
+    "english_translation": "Failed to generate jigsaw"
+  },
+  {
+    "key": "commands.place.jigsaw.invalid",
+    "english_translation": "There is no template pool with type \"%s\""
+  },
+  {
+    "key": "commands.place.jigsaw.success",
+    "english_translation": "Generated jigsaw at %s, %s, %s"
+  },
+  {
+    "key": "commands.place.structure.failed",
+    "english_translation": "Failed to place structure"
+  },
+  {
+    "key": "commands.place.structure.invalid",
+    "english_translation": "There is no structure with type \"%s\""
+  },
+  {
+    "key": "commands.place.structure.success",
+    "english_translation": "Generated structure \"%s\" at %s, %s, %s"
+  },
+  {
+    "key": "commands.place.template.failed",
+    "english_translation": "Failed to place template"
+  },
+  {
+    "key": "commands.place.template.invalid",
+    "english_translation": "There is no template with id \"%s\""
+  },
+  {
+    "key": "commands.place.template.success",
+    "english_translation": "Loaded template \"%s\" at %s, %s, %s"
+  },
+  {
+    "key": "commands.playsound.failed",
+    "english_translation": "The sound is too far away to be heard"
+  },
+  {
+    "key": "commands.recipe.give.failed",
+    "english_translation": "No new recipes were learned"
+  },
+  {
+    "key": "commands.recipe.take.failed",
+    "english_translation": "No recipes could be forgotten"
+  },
+  {
+    "key": "commands.save.failed",
+    "english_translation": "Unable to save the game (is there enough disk space?)"
+  },
+  {
+    "key": "commands.save.alreadyOff",
+    "english_translation": "Saving is already turned off"
+  },
+  {
+    "key": "commands.save.alreadyOn",
+    "english_translation": "Saving is already turned on"
+  },
+  {
+    "key": "commands.scoreboard.objectives.add.duplicate",
+    "english_translation": "An objective already exists by that name"
+  },
+  {
+    "key": "commands.scoreboard.objectives.display.alreadyEmpty",
+    "english_translation": "Nothing changed. That display slot is already empty"
+  },
+  {
+    "key": "commands.scoreboard.objectives.display.alreadySet",
+    "english_translation": "Nothing changed. That display slot is already showing that objective"
+  },
+  {
+    "key": "commands.scoreboard.players.enable.failed",
+    "english_translation": "Nothing changed. That trigger is already enabled"
+  },
+  {
+    "key": "commands.scoreboard.players.enable.invalid",
+    "english_translation": "Enable only works on trigger-objectives"
+  },
+  {
+    "key": "commands.setblock.failed",
+    "english_translation": "Could not set the block"
+  },
+  {
+    "key": "commands.summon.failed",
+    "english_translation": "Unable to summon entity"
+  },
+  {
+    "key": "commands.summon.failed.uuid",
+    "english_translation": "Unable to summon entity due to duplicate UUIDs"
+  },
+  {
+    "key": "commands.summon.invalidPosition",
+    "english_translation": "Invalid position for summon"
+  },
+  {
+    "key": "commands.tag.add.failed",
+    "english_translation": "Target either already has the tag or has too many tags"
+  },
+  {
+    "key": "commands.tag.remove.failed",
+    "english_translation": "Target does not have this tag"
+  },
+  {
+    "key": "commands.team.add.duplicate",
+    "english_translation": "A team already exists by that name"
+  },
+  {
+    "key": "commands.team.empty.unchanged",
+    "english_translation": "Nothing changed. That team is already empty"
+  },
+  {
+    "key": "commands.team.option.color.unchanged",
+    "english_translation": "Nothing changed. That team already has that color"
+  },
+  {
+    "key": "commands.team.option.name.unchanged",
+    "english_translation": "Nothing changed. That team already has that name"
+  },
+  {
+    "key": "commands.team.option.friendlyfire.alreadyEnabled",
+    "english_translation": "Nothing changed. Friendly fire is already enabled for that team"
+  },
+  {
+    "key": "commands.team.option.friendlyfire.alreadyDisabled",
+    "english_translation": "Nothing changed. Friendly fire is already disabled for that team"
+  },
+  {
+    "key": "commands.team.option.seeFriendlyInvisibles.alreadyEnabled",
+    "english_translation": "Nothing changed. That team can already see invisible teammates"
+  },
+  {
+    "key": "commands.team.option.seeFriendlyInvisibles.alreadyDisabled",
+    "english_translation": "Nothing changed. That team already can't see invisible teammates"
+  },
+  {
+    "key": "commands.team.option.nametagVisibility.unchanged",
+    "english_translation": "Nothing changed. Nametag visibility is already that value"
+  },
+  {
+    "key": "commands.team.option.deathMessageVisibility.unchanged",
+    "english_translation": "Nothing changed. Death message visibility is already that value"
+  },
+  {
+    "key": "commands.team.option.collisionRule.unchanged",
+    "english_translation": "Nothing changed. Collision rule is already that value"
+  },
+  {
+    "key": "commands.trigger.failed.unprimed",
+    "english_translation": "You cannot trigger this objective yet"
+  },
+  {
+    "key": "commands.trigger.failed.invalid",
+    "english_translation": "You can only trigger objectives that are 'trigger' type"
+  },
+  {
+    "key": "commands.whitelist.alreadyOn",
+    "english_translation": "Whitelist is already turned on"
+  },
+  {
+    "key": "commands.whitelist.alreadyOff",
+    "english_translation": "Whitelist is already turned off"
+  },
+  {
+    "key": "commands.whitelist.add.failed",
+    "english_translation": "Player is already whitelisted"
+  },
+  {
+    "key": "commands.whitelist.remove.failed",
+    "english_translation": "Player is not whitelisted"
+  },
+  {
+    "key": "commands.worldborder.center.failed",
+    "english_translation": "Nothing changed. The world border is already centered there"
+  },
+  {
+    "key": "commands.worldborder.set.failed.nochange",
+    "english_translation": "Nothing changed. The world border is already that size"
+  },
+  {
+    "key": "commands.worldborder.set.failed.small",
+    "english_translation": "World border cannot be smaller than 1 block wide"
+  },
+  {
+    "key": "commands.worldborder.set.failed.big",
+    "english_translation": "World border cannot be bigger than %s blocks wide"
+  },
+  {
+    "key": "commands.worldborder.set.failed.far",
+    "english_translation": "World border cannot be further out than %s blocks"
+  },
+  {
+    "key": "commands.worldborder.warning.time.failed",
+    "english_translation": "Nothing changed. The world border warning is already that amount of time"
+  },
+  {
+    "key": "commands.worldborder.warning.distance.failed",
+    "english_translation": "Nothing changed. The world border warning is already that distance"
+  },
+  {
+    "key": "commands.worldborder.damage.buffer.failed",
+    "english_translation": "Nothing changed. The world border damage buffer is already that distance"
+  },
+  {
+    "key": "commands.worldborder.damage.amount.failed",
+    "english_translation": "Nothing changed. The world border damage is already that amount"
+  },
+  {
+    "key": "commands.data.block.invalid",
+    "english_translation": "The target block is not a block entity"
+  },
+  {
+    "key": "commands.data.merge.failed",
+    "english_translation": "Nothing changed. The specified properties already have these values"
+  },
+  {
+    "key": "commands.data.modify.expected_list",
+    "english_translation": "Expected list, got: %s"
+  },
+  {
+    "key": "commands.data.modify.expected_object",
+    "english_translation": "Expected object, got: %s"
+  },
+  {
+    "key": "commands.data.modify.invalid_index",
+    "english_translation": "Invalid list index: %s"
+  },
+  {
+    "key": "commands.data.get.multiple",
+    "english_translation": "This argument accepts a single NBT value"
+  },
+  {
+    "key": "commands.data.entity.invalid",
+    "english_translation": "Unable to modify player data"
+  },
+  {
+    "key": "commands.teammsg.failed.noteam",
+    "english_translation": "You must be on a team to message your team"
+  },
+  {
+    "key": "argument.color.invalid",
+    "english_translation": "Unknown color '%s'"
+  },
+  {
+    "key": "argument.dimension.invalid",
+    "english_translation": "Unknown dimension '%s'"
+  },
+  {
+    "key": "argument.component.invalid",
+    "english_translation": "Invalid chat component: %s"
+  },
+  {
+    "key": "argument.anchor.invalid",
+    "english_translation": "Invalid entity anchor position %s"
+  },
+  {
+    "key": "enchantment.unknown",
+    "english_translation": "Unknown enchantment: %s"
+  },
+  {
+    "key": "lectern.take_book",
+    "english_translation": "Take Book"
+  },
+  {
+    "key": "effect.effectNotFound",
+    "english_translation": "Unknown effect: %s"
+  },
+  {
+    "key": "arguments.objective.notFound",
+    "english_translation": "Unknown scoreboard objective '%s'"
+  },
+  {
+    "key": "arguments.objective.readonly",
+    "english_translation": "Scoreboard objective '%s' is read-only"
+  },
+  {
+    "key": "argument.criteria.invalid",
+    "english_translation": "Unknown criterion '%s'"
+  },
+  {
+    "key": "particle.notFound",
+    "english_translation": "Unknown particle: %s"
+  },
+  {
+    "key": "argument.id.unknown",
+    "english_translation": "Unknown ID: %s"
+  },
+  {
+    "key": "advancement.advancementNotFound",
+    "english_translation": "Unknown advancement: %s"
+  },
+  {
+    "key": "recipe.notFound",
+    "english_translation": "Unknown recipe: %s"
+  },
+  {
+    "key": "entity.notFound",
+    "english_translation": "Unknown entity: %s"
+  },
+  {
+    "key": "predicate.unknown",
+    "english_translation": "Unknown predicate: %s"
+  },
+  {
+    "key": "item_modifier.unknown",
+    "english_translation": "Unknown item modifier: %s"
+  },
+  {
+    "key": "argument.scoreboardDisplaySlot.invalid",
+    "english_translation": "Unknown display slot '%s'"
+  },
+  {
+    "key": "slot.unknown",
+    "english_translation": "Unknown slot '%s'"
+  },
+  {
+    "key": "team.notFound",
+    "english_translation": "Unknown team '%s'"
+  },
+  {
+    "key": "arguments.block.tag.unknown",
+    "english_translation": "Unknown block tag '%s'"
+  },
+  {
+    "key": "argument.block.id.invalid",
+    "english_translation": "Unknown block type '%s'"
+  },
+  {
+    "key": "argument.block.property.unknown",
+    "english_translation": "Block %s does not have property '%s'"
+  },
+  {
+    "key": "argument.block.property.duplicate",
+    "english_translation": "Property '%s' can only be set once for block %s"
+  },
+  {
+    "key": "argument.block.property.invalid",
+    "english_translation": "Block %s does not accept '%s' for %s property"
+  },
+  {
+    "key": "argument.block.property.novalue",
+    "english_translation": "Expected value for property '%s' on block %s"
+  },
+  {
+    "key": "arguments.function.tag.unknown",
+    "english_translation": "Unknown function tag '%s'"
+  },
+  {
+    "key": "arguments.function.unknown",
+    "english_translation": "Unknown function %s"
+  },
+  {
+    "key": "arguments.item.overstacked",
+    "english_translation": "%s can only stack up to %s"
+  },
+  {
+    "key": "argument.item.id.invalid",
+    "english_translation": "Unknown item '%s'"
+  },
+  {
+    "key": "arguments.item.tag.unknown",
+    "english_translation": "Unknown item tag '%s'"
+  },
+  {
+    "key": "argument.entity.selector.unknown",
+    "english_translation": "Unknown selector type '%s'"
+  },
+  {
+    "key": "argument.entity.options.valueless",
+    "english_translation": "Expected value for option '%s'"
+  },
+  {
+    "key": "argument.entity.options.unknown",
+    "english_translation": "Unknown option '%s'"
+  },
+  {
+    "key": "argument.entity.options.inapplicable",
+    "english_translation": "Option '%s' isn't applicable here"
+  },
+  {
+    "key": "argument.entity.options.sort.irreversible",
+    "english_translation": "Invalid or unknown sort type '%s'"
+  },
+  {
+    "key": "argument.entity.options.mode.invalid",
+    "english_translation": "Invalid or unknown game mode '%s'"
+  },
+  {
+    "key": "argument.entity.options.type.invalid",
+    "english_translation": "Invalid or unknown entity type '%s'"
+  },
+  {
+    "key": "argument.nbt.list.mixed",
+    "english_translation": "Can't insert %s into list of %s"
+  },
+  {
+    "key": "argument.nbt.array.mixed",
+    "english_translation": "Can't insert %s into %s"
+  },
+  {
+    "key": "argument.nbt.array.invalid",
+    "english_translation": "Invalid array type '%s'"
+  },
+  {
+    "key": "commands.bossbar.create.failed",
+    "english_translation": "A bossbar already exists with the ID '%s'"
+  },
+  {
+    "key": "commands.bossbar.unknown",
+    "english_translation": "No bossbar exists with the ID '%s'"
+  },
+  {
+    "key": "clear.failed.single",
+    "english_translation": "No items were found on player %s"
+  },
+  {
+    "key": "clear.failed.multiple",
+    "english_translation": "No items were found on %s players"
+  },
+  {
+    "key": "commands.clone.toobig",
+    "english_translation": "Too many blocks in the specified area (maximum %s, specified %s)"
+  },
+  {
+    "key": "commands.datapack.unknown",
+    "english_translation": "Unknown data pack '%s'"
+  },
+  {
+    "key": "commands.datapack.enable.failed",
+    "english_translation": "Pack '%s' is already enabled!"
+  },
+  {
+    "key": "commands.datapack.disable.failed",
+    "english_translation": "Pack '%s' is not enabled!"
+  },
+  {
+    "key": "commands.difficulty.failure",
+    "english_translation": "The difficulty did not change; it is already set to %s"
+  },
+  {
+    "key": "commands.enchant.failed.entity",
+    "english_translation": "%s is not a valid entity for this command"
+  },
+  {
+    "key": "commands.enchant.failed.itemless",
+    "english_translation": "%s is not holding any item"
+  },
+  {
+    "key": "commands.enchant.failed.incompatible",
+    "english_translation": "%s cannot support that enchantment"
+  },
+  {
+    "key": "commands.enchant.failed.level",
+    "english_translation": "%s is higher than the maximum level of %s supported by that enchantment"
+  },
+  {
+    "key": "commands.execute.blocks.toobig",
+    "english_translation": "Too many blocks in the specified area (maximum %s, specified %s)"
+  },
+  {
+    "key": "commands.execute.conditional.pass",
+    "english_translation": "Test passed"
+  },
+  {
+    "key": "commands.execute.conditional.pass_count",
+    "english_translation": "Test passed, count: %s"
+  },
+  {
+    "key": "commands.execute.conditional.fail",
+    "english_translation": "Test failed"
+  },
+  {
+    "key": "commands.execute.conditional.fail_count",
+    "english_translation": "Test failed, count: %s"
+  },
+  {
+    "key": "commands.fill.toobig",
+    "english_translation": "Too many blocks in the specified area (maximum %s, specified %s)"
+  },
+  {
+    "key": "commands.publish.alreadyPublished",
+    "english_translation": "Multiplayer game is already hosted on port %s"
+  },
+  {
+    "key": "commands.scoreboard.players.get.null",
+    "english_translation": "Can't get value of %s for %s; none is set"
+  },
+  {
+    "key": "commands.spreadplayers.failed.teams",
+    "english_translation": "Could not spread %s teams around %s, %s (too many entities for space - try using spread of at most %s)"
+  },
+  {
+    "key": "commands.spreadplayers.failed.entities",
+    "english_translation": "Could not spread %s entities around %s, %s (too many entities for space - try using spread of at most %s)"
+  },
+  {
+    "key": "commands.spreadplayers.failed.invalid.height",
+    "english_translation": "Invalid maxHeight %s; expected higher than world minimum %s"
+  },
+  {
+    "key": "commands.data.get.invalid",
+    "english_translation": "Can't get %s; only numeric tags are allowed"
+  },
+  {
+    "key": "commands.data.get.unknown",
+    "english_translation": "Can't get %s; tag doesn't exist"
+  },
+  {
+    "key": "argument.double.low",
+    "english_translation": "Double must not be less than %s, found %s"
+  },
+  {
+    "key": "argument.double.big",
+    "english_translation": "Double must not be more than %s, found %s"
+  },
+  {
+    "key": "argument.float.low",
+    "english_translation": "Float must not be less than %s, found %s"
+  },
+  {
+    "key": "argument.float.big",
+    "english_translation": "Float must not be more than %s, found %s"
+  },
+  {
+    "key": "argument.integer.low",
+    "english_translation": "Integer must not be less than %s, found %s"
+  },
+  {
+    "key": "argument.integer.big",
+    "english_translation": "Integer must not be more than %s, found %s"
+  },
+  {
+    "key": "argument.long.low",
+    "english_translation": "Long must not be less than %s, found %s"
+  },
+  {
+    "key": "argument.long.big",
+    "english_translation": "Long must not be more than %s, found %s"
+  },
+  {
+    "key": "argument.literal.incorrect",
+    "english_translation": "Expected literal %s"
+  },
+  {
+    "key": "parsing.quote.expected.start",
+    "english_translation": "Expected quote to start a string"
+  },
+  {
+    "key": "parsing.quote.expected.end",
+    "english_translation": "Unclosed quoted string"
+  },
+  {
+    "key": "parsing.quote.escape",
+    "english_translation": "Invalid escape sequence '\\%s' in quoted string"
+  },
+  {
+    "key": "parsing.bool.invalid",
+    "english_translation": "Invalid boolean, expected 'true' or 'false' but found '%s'"
+  },
+  {
+    "key": "parsing.int.invalid",
+    "english_translation": "Invalid integer '%s'"
+  },
+  {
+    "key": "parsing.int.expected",
+    "english_translation": "Expected integer"
+  },
+  {
+    "key": "parsing.long.invalid",
+    "english_translation": "Invalid long '%s'"
+  },
+  {
+    "key": "parsing.long.expected",
+    "english_translation": "Expected long"
+  },
+  {
+    "key": "command.exception",
+    "english_translation": "Could not parse command: %s"
+  },
+  {
+    "key": "parsing.double.invalid",
+    "english_translation": "Invalid double '%s'"
+  },
+  {
+    "key": "parsing.double.expected",
+    "english_translation": "Expected double"
+  },
+  {
+    "key": "parsing.float.invalid",
+    "english_translation": "Invalid float '%s'"
+  },
+  {
+    "key": "parsing.float.expected",
+    "english_translation": "Expected float"
+  },
+  {
+    "key": "parsing.bool.expected",
+    "english_translation": "Expected boolean"
+  },
+  {
+    "key": "parsing.expected",
+    "english_translation": "Expected '%s'"
+  },
+  {
+    "key": "command.unknown.command",
+    "english_translation": "Unknown or incomplete command, see below for error"
+  },
+  {
+    "key": "command.unknown.argument",
+    "english_translation": "Incorrect argument for command"
+  },
+  {
+    "key": "command.expected.separator",
+    "english_translation": "Expected whitespace to end one argument, but found trailing data"
+  },
+  {
+    "key": "biome.minecraft.badlands",
+    "english_translation": "Badlands"
+  },
+  {
+    "key": "biome.minecraft.bamboo_jungle",
+    "english_translation": "Bamboo Jungle"
+  },
+  {
+    "key": "biome.minecraft.basalt_deltas",
+    "english_translation": "Basalt Deltas"
+  },
+  {
+    "key": "biome.minecraft.beach",
+    "english_translation": "Beach"
+  },
+  {
+    "key": "biome.minecraft.birch_forest",
+    "english_translation": "Birch Forest"
+  },
+  {
+    "key": "biome.minecraft.cold_ocean",
+    "english_translation": "Cold Ocean"
+  },
+  {
+    "key": "biome.minecraft.crimson_forest",
+    "english_translation": "Crimson Forest"
+  },
+  {
+    "key": "biome.minecraft.dark_forest",
+    "english_translation": "Dark Forest"
+  },
+  {
+    "key": "biome.minecraft.deep_cold_ocean",
+    "english_translation": "Deep Cold Ocean"
+  },
+  {
+    "key": "biome.minecraft.deep_dark",
+    "english_translation": "Deep Dark"
+  },
+  {
+    "key": "biome.minecraft.deep_frozen_ocean",
+    "english_translation": "Deep Frozen Ocean"
+  },
+  {
+    "key": "biome.minecraft.deep_lukewarm_ocean",
+    "english_translation": "Deep Lukewarm Ocean"
+  },
+  {
+    "key": "biome.minecraft.deep_ocean",
+    "english_translation": "Deep Ocean"
+  },
+  {
+    "key": "biome.minecraft.desert",
+    "english_translation": "Desert"
+  },
+  {
+    "key": "biome.minecraft.dripstone_caves",
+    "english_translation": "Dripstone Caves"
+  },
+  {
+    "key": "biome.minecraft.old_growth_birch_forest",
+    "english_translation": "Old Growth Birch Forest"
+  },
+  {
+    "key": "biome.minecraft.old_growth_pine_taiga",
+    "english_translation": "Old Growth Pine Taiga"
+  },
+  {
+    "key": "biome.minecraft.old_growth_spruce_taiga",
+    "english_translation": "Old Growth Spruce Taiga"
+  },
+  {
+    "key": "biome.minecraft.end_barrens",
+    "english_translation": "End Barrens"
+  },
+  {
+    "key": "biome.minecraft.end_highlands",
+    "english_translation": "End Highlands"
+  },
+  {
+    "key": "biome.minecraft.end_midlands",
+    "english_translation": "End Midlands"
+  },
+  {
+    "key": "biome.minecraft.eroded_badlands",
+    "english_translation": "Eroded Badlands"
+  },
+  {
+    "key": "biome.minecraft.flower_forest",
+    "english_translation": "Flower Forest"
+  },
+  {
+    "key": "biome.minecraft.forest",
+    "english_translation": "Forest"
+  },
+  {
+    "key": "biome.minecraft.frozen_ocean",
+    "english_translation": "Frozen Ocean"
+  },
+  {
+    "key": "biome.minecraft.frozen_peaks",
+    "english_translation": "Frozen Peaks"
+  },
+  {
+    "key": "biome.minecraft.frozen_river",
+    "english_translation": "Frozen River"
+  },
+  {
+    "key": "biome.minecraft.grove",
+    "english_translation": "Grove"
+  },
+  {
+    "key": "biome.minecraft.ice_spikes",
+    "english_translation": "Ice Spikes"
+  },
+  {
+    "key": "biome.minecraft.jagged_peaks",
+    "english_translation": "Jagged Peaks"
+  },
+  {
+    "key": "biome.minecraft.jungle",
+    "english_translation": "Jungle"
+  },
+  {
+    "key": "biome.minecraft.lukewarm_ocean",
+    "english_translation": "Lukewarm Ocean"
+  },
+  {
+    "key": "biome.minecraft.lush_caves",
+    "english_translation": "Lush Caves"
+  },
+  {
+    "key": "biome.minecraft.mangrove_swamp",
+    "english_translation": "Mangrove Swamp"
+  },
+  {
+    "key": "biome.minecraft.meadow",
+    "english_translation": "Meadow"
+  },
+  {
+    "key": "biome.minecraft.mushroom_fields",
+    "english_translation": "Mushroom Fields"
+  },
+  {
+    "key": "biome.minecraft.nether_wastes",
+    "english_translation": "Nether Wastes"
+  },
+  {
+    "key": "biome.minecraft.ocean",
+    "english_translation": "Ocean"
+  },
+  {
+    "key": "biome.minecraft.plains",
+    "english_translation": "Plains"
+  },
+  {
+    "key": "biome.minecraft.river",
+    "english_translation": "River"
+  },
+  {
+    "key": "biome.minecraft.savanna_plateau",
+    "english_translation": "Savanna Plateau"
+  },
+  {
+    "key": "biome.minecraft.savanna",
+    "english_translation": "Savanna"
+  },
+  {
+    "key": "biome.minecraft.small_end_islands",
+    "english_translation": "Small End Islands"
+  },
+  {
+    "key": "biome.minecraft.snowy_beach",
+    "english_translation": "Snowy Beach"
+  },
+  {
+    "key": "biome.minecraft.snowy_plains",
+    "english_translation": "Snowy Plains"
+  },
+  {
+    "key": "biome.minecraft.snowy_slopes",
+    "english_translation": "Snowy Slopes"
+  },
+  {
+    "key": "biome.minecraft.snowy_taiga",
+    "english_translation": "Snowy Taiga"
+  },
+  {
+    "key": "biome.minecraft.soul_sand_valley",
+    "english_translation": "Soul Sand Valley"
+  },
+  {
+    "key": "biome.minecraft.sparse_jungle",
+    "english_translation": "Sparse Jungle"
+  },
+  {
+    "key": "biome.minecraft.stony_peaks",
+    "english_translation": "Stony Peaks"
+  },
+  {
+    "key": "biome.minecraft.stony_shore",
+    "english_translation": "Stony Shore"
+  },
+  {
+    "key": "biome.minecraft.sunflower_plains",
+    "english_translation": "Sunflower Plains"
+  },
+  {
+    "key": "biome.minecraft.swamp",
+    "english_translation": "Swamp"
+  },
+  {
+    "key": "biome.minecraft.taiga",
+    "english_translation": "Taiga"
+  },
+  {
+    "key": "biome.minecraft.the_end",
+    "english_translation": "The End"
+  },
+  {
+    "key": "biome.minecraft.the_void",
+    "english_translation": "The Void"
+  },
+  {
+    "key": "biome.minecraft.warm_ocean",
+    "english_translation": "Warm Ocean"
+  },
+  {
+    "key": "biome.minecraft.warped_forest",
+    "english_translation": "Warped Forest"
+  },
+  {
+    "key": "biome.minecraft.windswept_forest",
+    "english_translation": "Windswept Forest"
+  },
+  {
+    "key": "biome.minecraft.windswept_gravelly_hills",
+    "english_translation": "Windswept Gravelly Hills"
+  },
+  {
+    "key": "biome.minecraft.windswept_hills",
+    "english_translation": "Windswept Hills"
+  },
+  {
+    "key": "biome.minecraft.windswept_savanna",
+    "english_translation": "Windswept Savanna"
+  },
+  {
+    "key": "biome.minecraft.wooded_badlands",
+    "english_translation": "Wooded Badlands"
+  },
+  {
+    "key": "realms.missing.module.error.text",
+    "english_translation": "Realms could not be opened right now, please try again later"
+  },
+  {
+    "key": "realms.missing.snapshot.error.text",
+    "english_translation": "Realms is currently not supported in snapshots"
+  },
+  {
+    "key": "color.minecraft.white",
+    "english_translation": "White"
+  },
+  {
+    "key": "color.minecraft.orange",
+    "english_translation": "Orange"
+  },
+  {
+    "key": "color.minecraft.magenta",
+    "english_translation": "Magenta"
+  },
+  {
+    "key": "color.minecraft.light_blue",
+    "english_translation": "Light Blue"
+  },
+  {
+    "key": "color.minecraft.yellow",
+    "english_translation": "Yellow"
+  },
+  {
+    "key": "color.minecraft.lime",
+    "english_translation": "Lime"
+  },
+  {
+    "key": "color.minecraft.pink",
+    "english_translation": "Pink"
+  },
+  {
+    "key": "color.minecraft.gray",
+    "english_translation": "Gray"
+  },
+  {
+    "key": "color.minecraft.light_gray",
+    "english_translation": "Light Gray"
+  },
+  {
+    "key": "color.minecraft.cyan",
+    "english_translation": "Cyan"
+  },
+  {
+    "key": "color.minecraft.purple",
+    "english_translation": "Purple"
+  },
+  {
+    "key": "color.minecraft.blue",
+    "english_translation": "Blue"
+  },
+  {
+    "key": "color.minecraft.brown",
+    "english_translation": "Brown"
+  },
+  {
+    "key": "color.minecraft.green",
+    "english_translation": "Green"
+  },
+  {
+    "key": "color.minecraft.red",
+    "english_translation": "Red"
+  },
+  {
+    "key": "color.minecraft.black",
+    "english_translation": "Black"
+  },
+  {
+    "key": "title.singleplayer",
+    "english_translation": "Singleplayer"
+  },
+  {
+    "key": "title.multiplayer.realms",
+    "english_translation": "Multiplayer (Realms)"
+  },
+  {
+    "key": "title.multiplayer.lan",
+    "english_translation": "Multiplayer (LAN)"
+  },
+  {
+    "key": "title.multiplayer.other",
+    "english_translation": "Multiplayer (3rd-party Server)"
+  },
+  {
+    "key": "gamerule.announceAdvancements",
+    "english_translation": "Announce advancements"
+  },
+  {
+    "key": "gamerule.commandBlockOutput",
+    "english_translation": "Broadcast command block output"
+  },
+  {
+    "key": "gamerule.disableElytraMovementCheck",
+    "english_translation": "Disable elytra movement check"
+  },
+  {
+    "key": "gamerule.disableRaids",
+    "english_translation": "Disable raids"
+  },
+  {
+    "key": "gamerule.doDaylightCycle",
+    "english_translation": "Advance time of day"
+  },
+  {
+    "key": "gamerule.doEntityDrops",
+    "english_translation": "Drop entity equipment"
+  },
+  {
+    "key": "gamerule.doEntityDrops.description",
+    "english_translation": "Controls drops from minecarts (including inventories), item frames, boats, etc."
+  },
+  {
+    "key": "gamerule.doFireTick",
+    "english_translation": "Update fire"
+  },
+  {
+    "key": "gamerule.doImmediateRespawn",
+    "english_translation": "Respawn immediately"
+  },
+  {
+    "key": "gamerule.doInsomnia",
+    "english_translation": "Spawn phantoms"
+  },
+  {
+    "key": "gamerule.doLimitedCrafting",
+    "english_translation": "Require recipe for crafting"
+  },
+  {
+    "key": "gamerule.doLimitedCrafting.description",
+    "english_translation": "If enabled, players will be able to craft only unlocked recipes"
+  },
+  {
+    "key": "gamerule.doMobLoot",
+    "english_translation": "Drop mob loot"
+  },
+  {
+    "key": "gamerule.doMobLoot.description",
+    "english_translation": "Controls resource drops from mobs, including experience orbs"
+  },
+  {
+    "key": "gamerule.doMobSpawning",
+    "english_translation": "Spawn mobs"
+  },
+  {
+    "key": "gamerule.doMobSpawning.description",
+    "english_translation": "Some entities might have separate rules"
+  },
+  {
+    "key": "gamerule.doPatrolSpawning",
+    "english_translation": "Spawn pillager patrols"
+  },
+  {
+    "key": "gamerule.doTileDrops",
+    "english_translation": "Drop blocks"
+  },
+  {
+    "key": "gamerule.doTileDrops.description",
+    "english_translation": "Controls resource drops from blocks, including experience orbs"
+  },
+  {
+    "key": "gamerule.doTraderSpawning",
+    "english_translation": "Spawn Wandering Traders"
+  },
+  {
+    "key": "gamerule.doWardenSpawning",
+    "english_translation": "Spawn Wardens"
+  },
+  {
+    "key": "gamerule.doWeatherCycle",
+    "english_translation": "Update weather"
+  },
+  {
+    "key": "gamerule.drowningDamage",
+    "english_translation": "Deal drowning damage"
+  },
+  {
+    "key": "gamerule.fallDamage",
+    "english_translation": "Deal fall damage"
+  },
+  {
+    "key": "gamerule.fireDamage",
+    "english_translation": "Deal fire damage"
+  },
+  {
+    "key": "gamerule.freezeDamage",
+    "english_translation": "Deal freeze damage"
+  },
+  {
+    "key": "gamerule.forgiveDeadPlayers",
+    "english_translation": "Forgive dead players"
+  },
+  {
+    "key": "gamerule.forgiveDeadPlayers.description",
+    "english_translation": "Angered neutral mobs stop being angry when the targeted player dies nearby."
+  },
+  {
+    "key": "gamerule.keepInventory",
+    "english_translation": "Keep inventory after death"
+  },
+  {
+    "key": "gamerule.logAdminCommands",
+    "english_translation": "Broadcast admin commands"
+  },
+  {
+    "key": "gamerule.maxCommandChainLength",
+    "english_translation": "Command chain size limit"
+  },
+  {
+    "key": "gamerule.maxCommandChainLength.description",
+    "english_translation": "Applies to command block chains and functions"
+  },
+  {
+    "key": "gamerule.maxEntityCramming",
+    "english_translation": "Entity cramming threshold"
+  },
+  {
+    "key": "gamerule.mobGriefing",
+    "english_translation": "Allow destructive mob actions"
+  },
+  {
+    "key": "gamerule.naturalRegeneration",
+    "english_translation": "Regenerate health"
+  },
+  {
+    "key": "gamerule.randomTickSpeed",
+    "english_translation": "Random tick speed rate"
+  },
+  {
+    "key": "gamerule.reducedDebugInfo",
+    "english_translation": "Reduce debug info"
+  },
+  {
+    "key": "gamerule.reducedDebugInfo.description",
+    "english_translation": "Limits contents of debug screen"
+  },
+  {
+    "key": "gamerule.sendCommandFeedback",
+    "english_translation": "Send command feedback"
+  },
+  {
+    "key": "gamerule.showDeathMessages",
+    "english_translation": "Show death messages"
+  },
+  {
+    "key": "gamerule.playersSleepingPercentage",
+    "english_translation": "Sleep percentage"
+  },
+  {
+    "key": "gamerule.playersSleepingPercentage.description",
+    "english_translation": "The percentage of players who must be sleeping to skip the night."
+  },
+  {
+    "key": "gamerule.spawnRadius",
+    "english_translation": "Respawn location radius"
+  },
+  {
+    "key": "gamerule.spectatorsGenerateChunks",
+    "english_translation": "Allow spectators to generate terrain"
+  },
+  {
+    "key": "gamerule.universalAnger",
+    "english_translation": "Universal anger"
+  },
+  {
+    "key": "gamerule.universalAnger.description",
+    "english_translation": "Angered neutral mobs attack any nearby player, not just the player that angered them. Works best if forgiveDeadPlayers is disabled."
+  },
+  {
+    "key": "gamerule.category.chat",
+    "english_translation": "Chat"
+  },
+  {
+    "key": "gamerule.category.spawning",
+    "english_translation": "Spawning"
+  },
+  {
+    "key": "gamerule.category.updates",
+    "english_translation": "World Updates"
+  },
+  {
+    "key": "gamerule.category.drops",
+    "english_translation": "Drops"
+  },
+  {
+    "key": "gamerule.category.mobs",
+    "english_translation": "Mobs"
+  },
+  {
+    "key": "gamerule.category.player",
+    "english_translation": "Player"
+  },
+  {
+    "key": "gamerule.category.misc",
+    "english_translation": "Miscellaneous"
+  },
+  {
+    "key": "pack.source.builtin",
+    "english_translation": "built-in"
+  },
+  {
+    "key": "pack.source.world",
+    "english_translation": "world"
+  },
+  {
+    "key": "pack.source.local",
+    "english_translation": "local"
+  },
+  {
+    "key": "pack.source.server",
+    "english_translation": "server"
+  },
+  {
+    "key": "mirror.none",
+    "english_translation": "|"
+  },
+  {
+    "key": "mirror.left_right",
+    "english_translation": "← →"
+  },
+  {
+    "key": "mirror.front_back",
+    "english_translation": "↑ ↓"
+  },
+  {
+    "key": "sleep.not_possible",
+    "english_translation": "No amount of rest can pass this night"
+  },
+  {
+    "key": "sleep.players_sleeping",
+    "english_translation": "%s/%s players sleeping"
+  },
+  {
+    "key": "sleep.skipping_night",
+    "english_translation": "Sleeping through this night"
+  },
+  {
+    "key": "compliance.playtime.greaterThan24Hours",
+    "english_translation": "You've been playing for greater than 24 hours"
+  },
+  {
+    "key": "compliance.playtime.message",
+    "english_translation": "Excessive gaming may interfere with normal daily life"
+  },
+  {
+    "key": "compliance.playtime.hours",
+    "english_translation": "You've been playing for %s hour(s)"
+  },
+  {
+    "key": "outOfMemory.title",
+    "english_translation": "Out of memory!"
+  },
+  {
+    "key": "outOfMemory.message",
+    "english_translation": "Minecraft has run out of memory.\n\nThis could be caused by a bug in the game or by the Java Virtual Machine not being allocated enough memory.\n\nTo prevent level corruption, the current game has quit. We've tried to free up enough memory to let you go back to the main menu and back to playing, but this may not have worked.\n\nPlease restart the game if you see this message again."
+  }
+]

--- a/extractor/src/main/java/rs/valence/extractor/Main.java
+++ b/extractor/src/main/java/rs/valence/extractor/Main.java
@@ -37,7 +37,15 @@ public class Main implements ModInitializer {
     public void onInitialize() {
         LOGGER.info("Starting extractors...");
 
-        var extractors = new Extractor[]{new Blocks(), new Entities(), new EntityData(), new Packets(), new Items(), new Enchants()};
+        var extractors = new Extractor[]{
+               new Blocks(),
+               new Enchants(),
+               new Entities(),
+               new EntityData(),
+               new Items(),
+               new Packets(),
+               new TranslationKeys(),
+        };
 
         Path outputDirectory;
         try {

--- a/extractor/src/main/java/rs/valence/extractor/extractors/TranslationKeys.java
+++ b/extractor/src/main/java/rs/valence/extractor/extractors/TranslationKeys.java
@@ -1,0 +1,56 @@
+package rs.valence.extractor.extractors;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import net.minecraft.util.Language;
+import rs.valence.extractor.Main;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+public class TranslationKeys implements Main.Extractor {
+
+    @Override
+    public String fileName() {
+        return "translation_keys.json";
+    }
+
+    @Override
+    public JsonElement extract() {
+        JsonArray translationsJson = new JsonArray();
+
+        Map<String, String> translations = extractTranslations();
+        for (var translation : translations.entrySet()) {
+            String translationKey = translation.getKey();
+            String translationValue = translation.getValue();
+
+            var translationJson = new JsonObject();
+            translationJson.addProperty("key", translationKey);
+            translationJson.addProperty("english_translation", translationValue);
+
+            translationsJson.add(translationJson);
+        }
+
+        return translationsJson;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, String> extractTranslations() {
+        Language language = Language.getInstance();
+
+        Class<? extends Language> anonymousClass = language.getClass();
+        for (Field field : anonymousClass.getDeclaredFields()) {
+            try {
+                Object fieldValue = field.get(language);
+                if (fieldValue instanceof Map<?, ?>) {
+                    return (Map<String, String>) fieldValue;
+                }
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException("Failed reflection on field '" + field + "' on class '" + anonymousClass + "'", e);
+            }
+        }
+
+        throw new RuntimeException("Did not find anonymous map under 'net.minecraft.util.Language.create()'");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,7 @@ pub mod prelude {
     pub use valence_protocol::ident::IdentError;
     pub use valence_protocol::packets::s2c::play::SetTitleAnimationTimes;
     pub use valence_protocol::text::Color;
+    pub use valence_protocol::translation_key::TranslationKey;
     pub use valence_protocol::types::{GameMode, Hand, SoundCategory};
     pub use valence_protocol::{
         ident, BlockKind, BlockPos, BlockState, Ident, ItemKind, ItemStack, Text, TextFormat,

--- a/src/server/login.rs
+++ b/src/server/login.rs
@@ -19,6 +19,7 @@ use valence_protocol::packets::c2s::login::{EncryptionResponse, LoginPluginRespo
 use valence_protocol::packets::s2c::login::{
     DisconnectLogin, EncryptionRequest, LoginPluginRequest,
 };
+use valence_protocol::translation_key::TranslationKey;
 use valence_protocol::types::{MsgSigOrVerifyToken, SignedProperty, SignedPropertyOwned};
 use valence_protocol::{Decode, Ident, RawBytes, Text, Username, VarInt};
 
@@ -95,7 +96,8 @@ pub(super) async fn online(
     match resp.status() {
         StatusCode::OK => {}
         StatusCode::NO_CONTENT => {
-            let reason = Text::translate("multiplayer.disconnect.unverified_username", []);
+            let reason =
+                Text::translate(TranslationKey::MultiplayerDisconnectUnverifiedUsername, []);
             ctrl.send_packet(&DisconnectLogin { reason }).await?;
             bail!("session server could not verify username");
         }

--- a/valence_protocol/build/main.rs
+++ b/valence_protocol/build/main.rs
@@ -8,14 +8,21 @@ use proc_macro2::{Ident, Span};
 mod block;
 mod enchant;
 mod item;
+mod translation_key;
 
 pub fn main() -> anyhow::Result<()> {
     println!("cargo:rerun-if-changed=../extracted/");
 
     let generators = [
         (block::build as fn() -> _, "block.rs"),
-        (item::build, "item.rs"),
         (enchant::build, "enchant.rs"),
+        (item::build, "item.rs"),
+        (translation_key::build_consts, "translation_key_consts.rs"),
+        (translation_key::build_enum, "translation_key_enum.rs"),
+        (
+            translation_key::build_enum_display,
+            "translation_key_enum_display.rs",
+        ),
     ];
 
     let out_dir = env::var_os("OUT_DIR").context("failed to get OUT_DIR env var")?;

--- a/valence_protocol/build/translation_key.rs
+++ b/valence_protocol/build/translation_key.rs
@@ -1,0 +1,108 @@
+use anyhow::Ok;
+use heck::{ToShoutySnakeCase, ToUpperCamelCase};
+use proc_macro2::TokenStream;
+use quote::quote;
+use serde::Deserialize;
+
+use crate::ident;
+
+#[derive(Deserialize, Clone, Debug)]
+struct Translation {
+    key: String,
+    english_translation: String,
+}
+
+/// Escapes characters that have special meaning inside docs.
+fn escape(text: &str) -> String {
+    text.replace('[', "\\[").replace(']', "\\]")
+}
+
+pub fn build_consts() -> anyhow::Result<TokenStream> {
+    let translations = serde_json::from_str::<Vec<Translation>>(include_str!(
+        "../../extracted/translation_keys.json"
+    ))?;
+
+    let translation_key_consts = translations
+        .iter()
+        .map(|translation| {
+            let const_id = ident(translation.key.to_shouty_snake_case());
+            let key = &translation.key;
+            let english_translation = &translation.english_translation;
+            let doc = escape(english_translation);
+
+            quote! {
+                #[doc = #doc]
+                pub const #const_id: &str = #key;
+            }
+        })
+        .collect::<Vec<TokenStream>>();
+
+    Ok(quote! {
+        #(#translation_key_consts)*
+    })
+}
+
+pub fn build_enum() -> anyhow::Result<TokenStream> {
+    let translations = serde_json::from_str::<Vec<Translation>>(include_str!(
+        "../../extracted/translation_keys.json"
+    ))?;
+
+    let translation_key_variants = translations
+        .iter()
+        .map(|translation| {
+            let variant_id = ident(translation.key.to_upper_camel_case());
+            let key = &translation.key;
+            let english_translation = &translation.english_translation;
+            let doc = format!("{} ({})", escape(key), escape(english_translation));
+
+            quote! {
+                #[doc = #doc]
+                #variant_id
+            }
+        })
+        .collect::<Vec<TokenStream>>();
+
+    Ok(quote! {
+        pub enum TranslationKey {
+            #(#translation_key_variants,)*
+
+            /// A custom translation key not available in the bundled language resource pack.
+            Custom(String),
+        }
+    })
+}
+
+pub fn build_enum_display() -> anyhow::Result<TokenStream> {
+    let translations = serde_json::from_str::<Vec<Translation>>(include_str!(
+        "../../extracted/translation_keys.json"
+    ))?;
+
+    let translation_key_matches = translations
+        .iter()
+        .map(|translation| {
+            let variant_id = ident(translation.key.to_upper_camel_case());
+            let const_id = ident(translation.key.to_shouty_snake_case());
+
+            quote! {
+                #variant_id => #const_id
+            }
+        })
+        .collect::<Vec<TokenStream>>();
+
+    Ok(quote! {
+        impl TranslationKey {
+            pub fn translation_key(&self) -> &str {
+                match self {
+                    #(Self::#translation_key_matches,)*
+                    Self::Custom(key) => key.as_ref(),
+                }
+            }
+        }
+
+        impl std::fmt::Display for TranslationKey {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(self.translation_key())
+            }
+        }
+    })
+}

--- a/valence_protocol/src/lib.rs
+++ b/valence_protocol/src/lib.rs
@@ -112,6 +112,7 @@ mod item;
 pub mod packets;
 mod raw_bytes;
 pub mod text;
+pub mod translation_key;
 pub mod types;
 pub mod username;
 mod var_int;

--- a/valence_protocol/src/translation_key.rs
+++ b/valence_protocol/src/translation_key.rs
@@ -1,0 +1,3 @@
+include!(concat!(env!("OUT_DIR"), "/translation_key_consts.rs"));
+include!(concat!(env!("OUT_DIR"), "/translation_key_enum.rs"));
+include!(concat!(env!("OUT_DIR"), "/translation_key_enum_display.rs"));


### PR DESCRIPTION
Generates a new `translation_key.rs` with all bundled translations. Closes #158.

Decided to split the translation keys into tree files, as the generated code spans over 30K lines. The files are  [`translation_key_consts.rs`](https://paste.ee/r/y5YXz/0), [`translation_key_enum.rs`](https://paste.ee/r/y5YXz/1) and [`translation_key_enum_display.rs`](https://paste.ee/r/y5YXz/2).

Here's an example on how to use it:
```rust
// with enum
Text::translate(TranslationKey::NarratorJoining, [])

// with constant
Text::translate(TranslationKey::Custom(NARRATOR_JOINING), [])

// feeling adventurous
Text::translate(TranslationKey::Custom("custom.translation_key".to_string()), [])
```