### PR TITLE
reimpl chest example

### DIFF
--- a/examples/chest.rs
+++ b/examples/chest.rs
@@ -204,7 +204,7 @@ impl Config for Game {
                              slot_changes: {:?}, carried_item: {:?}",
                             window_id, state_id, slot_id, mode, slot_changes, carried_item
                         );
-                        client.replace_cursor_item(carried_item);
+                        // client.replace_cursor_item(carried_item); // unnecessary, handled automatically by valence
                         if let Some(id) = client.open_inventory() {
                             if let Some(obj_inv) =
                                 server.inventories.get_mut(id)

--- a/src/client.rs
+++ b/src/client.rs
@@ -892,7 +892,7 @@ impl<C: Config> Client<C> {
     pub fn replace_cursor_item(&mut self, item: impl Into<Option<ItemStack>>) -> Option<ItemStack> {
         let new = item.into();
         if self.cursor_item != new {
-            todo!("set cursor item bit");
+            self.bits.set_cursor_item_modified(true);
         }
 
         mem::replace(&mut self.cursor_item, new)

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -1,7 +1,7 @@
 use std::iter::FusedIterator;
 use std::mem;
 use std::num::Wrapping;
-use std::ops::{Deref, DerefMut, Index, IndexMut};
+use std::ops::{Deref, DerefMut, Index, IndexMut, Range};
 
 use valence_protocol::packets::s2c::play::SetContainerSlotEncode;
 use valence_protocol::{InventoryKind, ItemStack, Text, VarInt};
@@ -9,6 +9,13 @@ use valence_protocol::{InventoryKind, ItemStack, Text, VarInt};
 use crate::config::Config;
 use crate::server::PlayPacketSender;
 use crate::slab_versioned::{Key, VersionedSlab};
+
+/// The range of slot ids that represent a player's general inventory, excluding the hotbar and offhand.
+pub const GENERAL_SLOTS: Range<u16> = 9..36;
+/// The range of slot ids that represent a player's hotbar inventory, excluding the offhand.
+pub const HOTBAR_SLOTS: Range<u16> = 36..44;
+/// The slot id that represents a player's offhand.
+pub const OFFHAND_SLOT: u16 = 45;
 
 pub struct Inventories<C: Config> {
     slab: VersionedSlab<Inventory<C>>,

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -10,6 +10,8 @@ use crate::config::Config;
 use crate::server::PlayPacketSender;
 use crate::slab_versioned::{Key, VersionedSlab};
 
+/// The range of slot ids that represent all of a player's inventory.
+pub const PLAYER_INVENTORY_SLOTS: Range<u16> = 0..46;
 /// The range of slot ids that represent a player's general inventory, excluding the hotbar and offhand.
 pub const GENERAL_SLOTS: Range<u16> = 9..36;
 /// The range of slot ids that represent a player's hotbar inventory, excluding the offhand.


### PR DESCRIPTION
- add `GENERAL_SLOTS`, `HOTBAR_SLOTS`, and `OFFHAND_SLOT` constants
- update the chest example so it compiles and runs
- add `PLAYER_INVENTORY_SLOTS` constant
- set dirty bit when replace_cursor_item is called
- update the default packet handler for ClickContainer to not crash when the player changes an open inventory

### Test plan

1. run `chest` example - `cargo r -r --example chest`
2. sneak to give yourself a stone block
3. open the chest (it's invisible on top of the stone block)
4. place stone in chest
5. see the stone moving around in the chest
