### PR TITLE
[ECS] Add Inventory component, re-implement player inventories

### DIFF
--- a/crates/valence_new/src/inventory.rs
+++ b/crates/valence_new/src/inventory.rs
@@ -1,0 +1,98 @@
+use std::iter::FusedIterator;
+use std::num::Wrapping;
+
+use bevy_ecs::prelude::*;
+use valence_protocol::{InventoryKind, ItemStack, Text};
+
+#[derive(Debug, Clone, Component)]
+pub struct Inventory {
+    title: Text,
+    kind: InventoryKind,
+    slots: Box<[Option<ItemStack>]>,
+    /// Contains a set bit for each modified slot in `slots`.
+    modified: u64,
+    state_id: Wrapping<i32>,
+}
+
+impl Inventory {
+    pub fn new(kind: InventoryKind, title: Option<impl Into<Text>>) -> Self {
+        Inventory {
+            // TODO: default to the correct translation key instead
+            title: title.map(Into::into).unwrap_or("Inventory".into()),
+            kind,
+            slots: vec![None; kind.slot_count()].into(),
+            modified: 0,
+            state_id: Wrapping(0),
+        }
+    }
+
+    pub fn slot(&self, idx: u16) -> Option<&ItemStack> {
+        self.slots
+            .get(idx as usize)
+            .expect("slot index out of range")
+            .as_ref()
+    }
+
+    pub fn replace_slot(
+        &mut self,
+        idx: u16,
+        item: impl Into<Option<ItemStack>>,
+    ) -> Option<ItemStack> {
+        assert!(idx < self.slot_count(), "slot index out of range");
+
+        let new = item.into();
+        let old = &mut self.slots[idx as usize];
+
+        if new != *old {
+            self.modified |= 1 << idx;
+        }
+
+        std::mem::replace(old, new)
+    }
+
+    pub fn swap_slot(&mut self, idx_a: u16, idx_b: u16) {
+        assert!(idx_a < self.slot_count(), "slot index out of range");
+        assert!(idx_b < self.slot_count(), "slot index out of range");
+
+        if idx_a == idx_b || self.slots[idx_a as usize] == self.slots[idx_b as usize] {
+            // Nothing to do here, ignore.
+            return;
+        }
+
+        self.modified |= 1 << idx_a;
+        self.modified |= 1 << idx_b;
+
+        self.slots.swap(idx_a as usize, idx_b as usize);
+    }
+
+    pub fn slot_count(&self) -> u16 {
+        self.slots.len() as u16
+    }
+
+    pub fn slots(
+        &self,
+    ) -> impl ExactSizeIterator<Item = Option<&ItemStack>>
+           + DoubleEndedIterator
+           + FusedIterator
+           + Clone
+           + '_ {
+        self.slots.iter().map(|item| item.as_ref())
+    }
+
+    pub fn kind(&self) -> InventoryKind {
+        self.kind
+    }
+
+    pub fn title(&self) -> &Text {
+        &self.title
+    }
+
+    pub fn replace_title(&mut self, title: impl Into<Text>) -> Text {
+        // TODO: set title modified flag
+        std::mem::replace(&mut self.title, title.into())
+    }
+
+    pub(crate) fn slot_slice(&self) -> &[Option<ItemStack>] {
+        self.slots.as_ref()
+    }
+}

--- a/crates/valence_new/src/inventory.rs
+++ b/crates/valence_new/src/inventory.rs
@@ -2,6 +2,7 @@ use std::iter::FusedIterator;
 use std::num::Wrapping;
 
 use bevy_ecs::prelude::*;
+use tracing::warn;
 use valence_protocol::packets::s2c::play::{SetContainerContentEncode, SetContainerSlotEncode};
 use valence_protocol::{InventoryKind, ItemStack, Text, VarInt};
 
@@ -106,6 +107,10 @@ impl Inventory {
 
 pub(crate) fn update_player_inventories(mut query: Query<(&mut Inventory, &mut Client)>) {
     for (mut inventory, mut client) in query.iter_mut() {
+        if inventory.kind != InventoryKind::Player {
+            warn!("Inventory on client entity is not a player inventory");
+        }
+
         if inventory.modified != 0 {
             if inventory.modified == u64::MAX && client.cursor_item_modified {
                 // Update the whole inventory.

--- a/crates/valence_new/src/inventory.rs
+++ b/crates/valence_new/src/inventory.rs
@@ -15,10 +15,14 @@ pub struct Inventory {
 }
 
 impl Inventory {
-    pub fn new(kind: InventoryKind, title: Option<impl Into<Text>>) -> Self {
+    pub fn new(kind: InventoryKind) -> Self {
+        // TODO: default title to the correct translation key instead
+        Self::new_with_title(kind, "Inventory")
+    }
+
+    pub fn new_with_title(kind: InventoryKind, title: impl Into<Text>) -> Self {
         Inventory {
-            // TODO: default to the correct translation key instead
-            title: title.map(Into::into).unwrap_or("Inventory".into()),
+            title: title.into(),
             kind,
             slots: vec![None; kind.slot_count()].into(),
             modified: 0,

--- a/crates/valence_new/src/inventory.rs
+++ b/crates/valence_new/src/inventory.rs
@@ -20,10 +20,10 @@ pub struct Inventory {
 impl Inventory {
     pub fn new(kind: InventoryKind) -> Self {
         // TODO: default title to the correct translation key instead
-        Self::new_with_title(kind, "Inventory")
+        Self::with_title(kind, "Inventory")
     }
 
-    pub fn new_with_title(kind: InventoryKind, title: impl Into<Text>) -> Self {
+    pub fn with_title(kind: InventoryKind, title: impl Into<Text>) -> Self {
         Inventory {
             title: title.into(),
             kind,
@@ -104,7 +104,7 @@ impl Inventory {
     }
 }
 
-pub fn update_player_inventories(mut query: Query<(&mut Inventory, &mut Client)>) {
+pub(crate) fn update_player_inventories(mut query: Query<(&mut Inventory, &mut Client)>) {
     for (mut inventory, mut client) in query.iter_mut() {
         if inventory.modified != 0 {
             if inventory.modified == u64::MAX && client.cursor_item_modified {

--- a/crates/valence_new/src/lib.rs
+++ b/crates/valence_new/src/lib.rs
@@ -9,6 +9,7 @@ pub mod config;
 pub mod dimension;
 pub mod entity;
 pub mod instance;
+pub mod inventory;
 pub mod math;
 mod packet;
 pub mod player_textures;

--- a/crates/valence_new/src/server.rs
+++ b/crates/valence_new/src/server.rs
@@ -15,7 +15,7 @@ use tokio::runtime::{Handle, Runtime};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use uuid::Uuid;
 use valence_nbt::{compound, Compound, List};
-use valence_protocol::{ident, Username};
+use valence_protocol::{ident, InventoryKind, Username};
 
 use crate::biome::{Biome, BiomeId};
 use crate::client::event::{dispatch_client_events, register_client_events};
@@ -24,6 +24,7 @@ use crate::config::{AsyncCallbacks, Config, ConnectionMode};
 use crate::dimension::{Dimension, DimensionId};
 use crate::entity::{deinit_despawned_entities, init_entities, McEntityManager};
 use crate::instance::{update_instances_post_client, update_instances_pre_client, Instance};
+use crate::inventory::Inventory;
 use crate::player_textures::SignedPlayerTextures;
 use crate::server::connect::do_accept_loop;
 use crate::Despawned;
@@ -359,8 +360,10 @@ pub fn run_server(
                 break
             };
 
-            cfg.world
-                .spawn(Client::new(msg.send, msg.recv, msg.permit, msg.info));
+            cfg.world.spawn((
+                Client::new(msg.send, msg.recv, msg.permit, msg.info),
+                Inventory::new(InventoryKind::Player),
+            ));
         }
 
         // Run the scheduled stages.

--- a/crates/valence_new/src/server.rs
+++ b/crates/valence_new/src/server.rs
@@ -24,7 +24,7 @@ use crate::config::{AsyncCallbacks, Config, ConnectionMode};
 use crate::dimension::{Dimension, DimensionId};
 use crate::entity::{deinit_despawned_entities, init_entities, McEntityManager};
 use crate::instance::{update_instances_post_client, update_instances_pre_client, Instance};
-use crate::inventory::Inventory;
+use crate::inventory::{update_player_inventories, Inventory};
 use crate::player_textures::SignedPlayerTextures;
 use crate::server::connect::do_accept_loop;
 use crate::Despawned;
@@ -341,7 +341,8 @@ pub fn run_server(
             .with_system(update_clients.after(update_instances_pre_client))
             .with_system(update_instances_post_client.after(update_clients))
             .with_system(deinit_despawned_entities.after(update_instances_post_client))
-            .with_system(despawn_entities.after(deinit_despawned_entities)),
+            .with_system(despawn_entities.after(deinit_despawned_entities))
+            .with_system(update_player_inventories),
     );
 
     let mut tick_start = Instant::now();

--- a/crates/valence_protocol/src/inventory.rs
+++ b/crates/valence_protocol/src/inventory.rs
@@ -1,6 +1,65 @@
 use valence_derive::{Decode, Encode};
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Encode, Decode)]
+pub enum WindowType {
+    Generic9x1,
+    Generic9x2,
+    Generic9x3,
+    Generic9x4,
+    Generic9x5,
+    Generic9x6,
+    Generic3x3,
+    Anvil,
+    Beacon,
+    BlastFurnace,
+    BrewingStand,
+    Crafting,
+    Enchantment,
+    Furnace,
+    Grindstone,
+    Hopper,
+    Lectern,
+    Loom,
+    Merchant,
+    ShulkerBox,
+    Smithing,
+    Smoker,
+    Cartography,
+    Stonecutter,
+}
+
+impl From<WindowType> for InventoryKind {
+    fn from(value: WindowType) -> Self {
+        match value {
+            WindowType::Generic9x1 => InventoryKind::Generic9x1,
+            WindowType::Generic9x2 => InventoryKind::Generic9x2,
+            WindowType::Generic9x3 => InventoryKind::Generic9x3,
+            WindowType::Generic9x4 => InventoryKind::Generic9x4,
+            WindowType::Generic9x5 => InventoryKind::Generic9x5,
+            WindowType::Generic9x6 => InventoryKind::Generic9x6,
+            WindowType::Generic3x3 => InventoryKind::Generic3x3,
+            WindowType::Anvil => InventoryKind::Anvil,
+            WindowType::Beacon => InventoryKind::Beacon,
+            WindowType::BlastFurnace => InventoryKind::BlastFurnace,
+            WindowType::BrewingStand => InventoryKind::BrewingStand,
+            WindowType::Crafting => InventoryKind::Crafting,
+            WindowType::Enchantment => InventoryKind::Enchantment,
+            WindowType::Furnace => InventoryKind::Furnace,
+            WindowType::Grindstone => InventoryKind::Grindstone,
+            WindowType::Hopper => InventoryKind::Hopper,
+            WindowType::Lectern => InventoryKind::Lectern,
+            WindowType::Loom => InventoryKind::Loom,
+            WindowType::Merchant => InventoryKind::Merchant,
+            WindowType::ShulkerBox => InventoryKind::ShulkerBox,
+            WindowType::Smithing => InventoryKind::Smithing,
+            WindowType::Smoker => InventoryKind::Smoker,
+            WindowType::Cartography => InventoryKind::Cartography,
+            WindowType::Stonecutter => InventoryKind::Stonecutter,
+        }
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum InventoryKind {
     Generic9x1,
     Generic9x2,
@@ -30,8 +89,8 @@ pub enum InventoryKind {
 }
 
 impl InventoryKind {
-    /// The number of slots in this inventory, not counting the player's main
-    /// inventory slots.
+    /// The number of slots in this inventory. When the inventory is shown to
+    /// clients, this number does not include the player's main inventory slots.
     pub const fn slot_count(self) -> usize {
         match self {
             InventoryKind::Generic9x1 => 9,
@@ -59,6 +118,40 @@ impl InventoryKind {
             InventoryKind::Cartography => 3,
             InventoryKind::Stonecutter => 2,
             InventoryKind::Player => 45,
+        }
+    }
+}
+
+impl From<InventoryKind> for WindowType {
+    fn from(value: InventoryKind) -> Self {
+        match value {
+            InventoryKind::Generic9x1 => WindowType::Generic9x1,
+            InventoryKind::Generic9x2 => WindowType::Generic9x2,
+            InventoryKind::Generic9x3 => WindowType::Generic9x3,
+            InventoryKind::Generic9x4 => WindowType::Generic9x4,
+            InventoryKind::Generic9x5 => WindowType::Generic9x5,
+            InventoryKind::Generic9x6 => WindowType::Generic9x6,
+            InventoryKind::Generic3x3 => WindowType::Generic3x3,
+            InventoryKind::Anvil => WindowType::Anvil,
+            InventoryKind::Beacon => WindowType::Beacon,
+            InventoryKind::BlastFurnace => WindowType::BlastFurnace,
+            InventoryKind::BrewingStand => WindowType::BrewingStand,
+            InventoryKind::Crafting => WindowType::Crafting,
+            InventoryKind::Enchantment => WindowType::Enchantment,
+            InventoryKind::Furnace => WindowType::Furnace,
+            InventoryKind::Grindstone => WindowType::Grindstone,
+            InventoryKind::Hopper => WindowType::Hopper,
+            InventoryKind::Lectern => WindowType::Lectern,
+            InventoryKind::Loom => WindowType::Loom,
+            InventoryKind::Merchant => WindowType::Merchant,
+            InventoryKind::ShulkerBox => WindowType::ShulkerBox,
+            InventoryKind::Smithing => WindowType::Smithing,
+            InventoryKind::Smoker => WindowType::Smoker,
+            InventoryKind::Cartography => WindowType::Cartography,
+            InventoryKind::Stonecutter => WindowType::Stonecutter,
+            // arbitrarily chosen, because a player inventory technically does not have a window
+            // type
+            InventoryKind::Player => WindowType::Generic9x4,
         }
     }
 }

--- a/crates/valence_protocol/src/inventory.rs
+++ b/crates/valence_protocol/src/inventory.rs
@@ -2,6 +2,7 @@ use valence_derive::{Decode, Encode};
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Encode, Decode)]
 pub enum InventoryKind {
+    Player,
     Generic9x1,
     Generic9x2,
     Generic9x3,
@@ -33,6 +34,7 @@ impl InventoryKind {
     /// inventory slots.
     pub const fn slot_count(self) -> usize {
         match self {
+            InventoryKind::Player => 45,
             InventoryKind::Generic9x1 => 9,
             InventoryKind::Generic9x2 => 9 * 2,
             InventoryKind::Generic9x3 => 9 * 3,

--- a/crates/valence_protocol/src/inventory.rs
+++ b/crates/valence_protocol/src/inventory.rs
@@ -2,7 +2,6 @@ use valence_derive::{Decode, Encode};
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Encode, Decode)]
 pub enum InventoryKind {
-    Player,
     Generic9x1,
     Generic9x2,
     Generic9x3,
@@ -27,6 +26,7 @@ pub enum InventoryKind {
     Smoker,
     Cartography,
     Stonecutter,
+    Player,
 }
 
 impl InventoryKind {
@@ -34,7 +34,6 @@ impl InventoryKind {
     /// inventory slots.
     pub const fn slot_count(self) -> usize {
         match self {
-            InventoryKind::Player => 45,
             InventoryKind::Generic9x1 => 9,
             InventoryKind::Generic9x2 => 9 * 2,
             InventoryKind::Generic9x3 => 9 * 3,
@@ -59,6 +58,7 @@ impl InventoryKind {
             InventoryKind::Smoker => 3,
             InventoryKind::Cartography => 3,
             InventoryKind::Stonecutter => 2,
+            InventoryKind::Player => 45,
         }
     }
 }


### PR DESCRIPTION
- add missing field preventing build, format
- add Inventory ECS component
- add cursor_item fields, getters, setters to Client
- add new_with_title to Inventory instead of using an Option
- add Inventory component to client entities when they connect
- add system update_player_inventories

This does not implement opening other inventories yet, planning to do that in a follow up PR.

The idea here is to have an `Inventory` component that can be used for all inventories. If you want a chest to have an inventory, give the corresponding block entity an `Inventory`. If you don't want any inventory update systems to run, simply don't give clients a player inventory.

<details>

<summary>Code used to test</summary>

```rust
use bevy_ecs::prelude::*;
use bevy_ecs::schedule::ShouldRun;
use valence_new::client::Client;
use valence_new::config::Config;
use valence_new::dimension::DimensionId;
use valence_new::protocol::types::GameMode;
use valence_new::server::Server;

#[derive(Resource)]
struct GameState {
    instance: Entity,
}

fn main() -> anyhow::Result<()> {
    tracing_subscriber::fmt().init();

    valence_new::run_server(
        Config::default(),
        SystemStage::parallel()
            .with_system(setup.with_run_criteria(ShouldRun::once))
            .with_system(init_clients),
        (),
    )
}

fn setup(world: &mut World) {
    let instance = world
        .resource::<Server>()
        .new_instance(DimensionId::default());

    let id = world.spawn(instance).id();
    world.insert_resource(GameState { instance: id })
}

fn init_clients(mut clients: Query<&mut Client, Added<Client>>, state: Res<GameState>) {
    for mut client in &mut clients {
        client.set_instance(state.instance);
        client.set_game_mode(GameMode::Creative);
    }
}

```

</details>
