### PR TITLE
[ECS] Inventory interactions

### DIFF
--- a/crates/valence_new/examples/inventory_test.rs
+++ b/crates/valence_new/examples/inventory_test.rs
@@ -77,7 +77,7 @@ fn setup(world: &mut World) {
     // create inventories to view
     let mut inventories = [
         Inventory::new(InventoryKind::Generic9x2),
-        Inventory::new(InventoryKind::Generic9x3),
+        Inventory::new(InventoryKind::Generic9x6),
         Inventory::new(InventoryKind::Crafting),
     ];
 

--- a/crates/valence_new/examples/inventory_test.rs
+++ b/crates/valence_new/examples/inventory_test.rs
@@ -18,7 +18,9 @@ struct GameState {
 }
 
 fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt().init();
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        .init();
 
     valence_new::run_server(
         Config::default().with_connection_mode(ConnectionMode::Offline),

--- a/crates/valence_new/examples/inventory_test.rs
+++ b/crates/valence_new/examples/inventory_test.rs
@@ -1,10 +1,8 @@
 use bevy_ecs::prelude::*;
 use bevy_ecs::schedule::ShouldRun;
 use tracing::info;
-use valence_new::client::event::{
-    default_event_handler, InteractWithEntity, StartSneaking, UseItemOnBlock,
-};
-use valence_new::client::{despawn_disconnected_clients, Client, Client};
+use valence_new::client::event::{default_event_handler, StartSneaking, UseItemOnBlock};
+use valence_new::client::{despawn_disconnected_clients, Client};
 use valence_new::config::{Config, ConnectionMode};
 use valence_new::dimension::DimensionId;
 use valence_new::instance::Chunk;

--- a/crates/valence_new/src/client.rs
+++ b/crates/valence_new/src/client.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::net::IpAddr;
+use std::num::Wrapping;
 
 use anyhow::{bail, Context};
 use bevy_ecs::prelude::*;
@@ -79,6 +80,7 @@ pub struct Client {
     pub(crate) cursor_item_modified: bool,
     /// The current window ID. Incremented when inventories are opened.
     pub(crate) window_id: u8,
+    pub(crate) inventory_state_id: Wrapping<i32>,
 }
 
 impl Client {
@@ -124,6 +126,7 @@ impl Client {
             cursor_item: None,
             cursor_item_modified: false,
             window_id: 0,
+            inventory_state_id: Wrapping(0),
         }
     }
 

--- a/crates/valence_new/src/client.rs
+++ b/crates/valence_new/src/client.rs
@@ -81,6 +81,9 @@ pub struct Client {
     /// The current window ID. Incremented when inventories are opened.
     pub(crate) window_id: u8,
     pub(crate) inventory_state_id: Wrapping<i32>,
+    /// Tracks what slots have been modified by this client in this tick, so we
+    /// don't need to send updates for them.
+    pub(crate) inventory_slots_modified: u64,
 }
 
 impl Client {
@@ -127,6 +130,7 @@ impl Client {
             cursor_item_modified: false,
             window_id: 0,
             inventory_state_id: Wrapping(0),
+            inventory_slots_modified: 0,
         }
     }
 

--- a/crates/valence_new/src/inventory.rs
+++ b/crates/valence_new/src/inventory.rs
@@ -7,7 +7,7 @@ use valence_protocol::packets::s2c::play::{
 };
 use valence_protocol::{ItemStack, Text, VarInt, WindowType};
 
-use crate::client::event::{ClickContainer, CloseContainer};
+use crate::client::event::{ClickContainer, CloseContainer, SetCreativeModeSlot};
 use crate::client::Client;
 
 #[derive(Debug, Clone, Component)]
@@ -513,6 +513,17 @@ pub(crate) fn handle_click_container(
                     continue;
                 }
             }
+        }
+    }
+}
+
+pub(crate) fn handle_set_slot_creative(
+    mut clients: Query<&mut Inventory, With<Client>>,
+    mut events: EventReader<SetCreativeModeSlot>,
+) {
+    for event in events.iter() {
+        if let Ok(mut inventory) = clients.get_mut(event.client) {
+            inventory.replace_slot(event.slot as u16, event.clicked_item.clone());
         }
     }
 }

--- a/crates/valence_new/src/inventory.rs
+++ b/crates/valence_new/src/inventory.rs
@@ -134,9 +134,9 @@ pub(crate) fn update_player_inventories(
                 client.cursor_item_modified = false;
             } else {
                 // send the modified slots
-                let state_id = client.inventory_state_id.0;
                 if inventory.modified & !client.inventory_slots_modified != 0 {
                     client.inventory_state_id += 1;
+                    let state_id = client.inventory_state_id.0;
                     for (i, slot) in inventory.slots.iter().enumerate() {
                         if (inventory.modified >> i) & 1 == 1 {
                             if (client.inventory_slots_modified >> i) & 1 == 1 {
@@ -386,9 +386,9 @@ pub(crate) fn update_open_inventories(
             } else {
                 // send the modified slots
                 let window_id = client.window_id as i8;
-                let state_id = client.inventory_state_id.0;
                 if inventory.modified & !open_inventory.client_modified != 0 {
                     client.inventory_state_id += 1;
+                    let state_id = client.inventory_state_id.0;
                     for (i, slot) in inventory.slots.iter().enumerate() {
                         if (inventory.modified >> i) & 1 == 1 {
                             if (open_inventory.client_modified >> i) & 1 == 1 {

--- a/crates/valence_new/src/inventory.rs
+++ b/crates/valence_new/src/inventory.rs
@@ -313,10 +313,10 @@ impl OpenInventory {
 /// Handles the `OpenInventory` component being added to a client, which
 /// indicates that the client is now viewing an inventory.
 pub(crate) fn update_client_on_open_inventory(
-    mut clients: Query<(&mut Client, &OpenInventory, Added<OpenInventory>)>,
+    mut clients: Query<(&mut Client, &OpenInventory), Added<OpenInventory>>,
     inventories: Query<&Inventory>,
 ) {
-    for (mut client, open_inventory, _) in clients.iter_mut() {
+    for (mut client, open_inventory) in clients.iter_mut() {
         // validate that the inventory exists
         if let Ok(inventory) = inventories.get_component::<Inventory>(open_inventory.entity) {
             // send the inventory to the client

--- a/crates/valence_new/src/inventory.rs
+++ b/crates/valence_new/src/inventory.rs
@@ -233,7 +233,7 @@ impl InventoryKind {
             InventoryKind::Smoker => 3,
             InventoryKind::Cartography => 3,
             InventoryKind::Stonecutter => 2,
-            InventoryKind::Player => 45,
+            InventoryKind::Player => 46,
         }
     }
 }

--- a/crates/valence_new/src/inventory.rs
+++ b/crates/valence_new/src/inventory.rs
@@ -106,7 +106,9 @@ impl Inventory {
 }
 
 /// Send updates for each client's player inventory.
-pub(crate) fn update_player_inventories(mut query: Query<(&mut Inventory, &mut Client)>) {
+pub(crate) fn update_player_inventories(
+    mut query: Query<(&mut Inventory, &mut Client), Without<OpenInventory>>,
+) {
     for (mut inventory, mut client) in query.iter_mut() {
         if inventory.kind != InventoryKind::Player {
             warn!("Inventory on client entity is not a player inventory");

--- a/crates/valence_new/src/inventory.rs
+++ b/crates/valence_new/src/inventory.rs
@@ -1,7 +1,7 @@
 use std::iter::FusedIterator;
 
 use bevy_ecs::prelude::*;
-use tracing::warn;
+use tracing::{debug, warn};
 use valence_protocol::packets::s2c::play::{
     CloseContainerS2c, OpenScreen, SetContainerContentEncode, SetContainerSlotEncode,
 };
@@ -510,7 +510,7 @@ pub(crate) fn handle_click_container(
                 {
                     if client.inventory_state_id.0 != event.state_id {
                         // client is out of sync, resync, ignore click
-                        warn!("Client state id mismatch, marking dirty");
+                        debug!("Client state id mismatch, marking dirty");
                         client_inventory.modified = u64::MAX;
                         continue;
                     }

--- a/crates/valence_new/src/inventory.rs
+++ b/crates/valence_new/src/inventory.rs
@@ -134,16 +134,14 @@ pub(crate) fn update_player_inventories(
                 client.cursor_item_modified = false;
             } else {
                 // send the modified slots
-                if inventory.modified & !client.inventory_slots_modified != 0 {
+
+                // The slots that were NOT modified by this client, and they need to be sent
+                let modified_filtered = inventory.modified & !client.inventory_slots_modified;
+                if modified_filtered != 0 {
                     client.inventory_state_id += 1;
                     let state_id = client.inventory_state_id.0;
                     for (i, slot) in inventory.slots.iter().enumerate() {
-                        if (inventory.modified >> i) & 1 == 1 {
-                            if (client.inventory_slots_modified >> i) & 1 == 1 {
-                                // This slot was modified by this client, so we don't need to
-                                // send it
-                                continue;
-                            }
+                        if (modified_filtered >> 1) & 1 == 1 {
                             client.write_packet(&SetContainerSlotEncode {
                                 window_id: 0,
                                 state_id: VarInt(state_id),
@@ -386,16 +384,13 @@ pub(crate) fn update_open_inventories(
             } else {
                 // send the modified slots
                 let window_id = client.window_id as i8;
-                if inventory.modified & !open_inventory.client_modified != 0 {
+                // The slots that were NOT modified by this client, and they need to be sent
+                let modified_filtered = inventory.modified & !open_inventory.client_modified;
+                if modified_filtered != 0 {
                     client.inventory_state_id += 1;
                     let state_id = client.inventory_state_id.0;
                     for (i, slot) in inventory.slots.iter().enumerate() {
-                        if (inventory.modified >> i) & 1 == 1 {
-                            if (open_inventory.client_modified >> i) & 1 == 1 {
-                                // This slot was modified by this client, so we don't need to
-                                // send it
-                                continue;
-                            }
+                        if (modified_filtered >> i) & 1 == 1 {
                             client.write_packet(&SetContainerSlotEncode {
                                 window_id,
                                 state_id: VarInt(state_id),

--- a/crates/valence_new/src/inventory.rs
+++ b/crates/valence_new/src/inventory.rs
@@ -134,7 +134,7 @@ pub(crate) fn update_player_inventories(
             } else {
                 // send the modified slots
                 let state_id = client.inventory_state_id.0;
-                if inventory.modified ^ client.inventory_slots_modified != 0 {
+                if inventory.modified & !client.inventory_slots_modified != 0 {
                     client.inventory_state_id += 1;
                     for (i, slot) in inventory.slots.iter().enumerate() {
                         if (inventory.modified >> i) & 1 == 1 {
@@ -386,7 +386,7 @@ pub(crate) fn update_open_inventories(
                 // send the modified slots
                 let window_id = client.window_id as i8;
                 let state_id = client.inventory_state_id.0;
-                if inventory.modified ^ open_inventory.client_modified != 0 {
+                if inventory.modified & !open_inventory.client_modified != 0 {
                     client.inventory_state_id += 1;
                     for (i, slot) in inventory.slots.iter().enumerate() {
                         if (inventory.modified >> i) & 1 == 1 {

--- a/crates/valence_new/src/inventory.rs
+++ b/crates/valence_new/src/inventory.rs
@@ -5,6 +5,7 @@ use tracing::{debug, warn};
 use valence_protocol::packets::s2c::play::{
     CloseContainerS2c, OpenScreen, SetContainerContentEncode, SetContainerSlotEncode,
 };
+use valence_protocol::types::GameMode;
 use valence_protocol::{ItemStack, Text, VarInt, WindowType};
 
 use crate::client::event::{ClickContainer, CloseContainer, SetCreativeModeSlot};
@@ -544,6 +545,10 @@ pub(crate) fn handle_set_slot_creative(
 ) {
     for event in events.iter() {
         if let Ok((mut client, mut inventory)) = clients.get_mut(event.client) {
+            if client.game_mode() != GameMode::Creative {
+                // the client is not in creative mode, ignore
+                continue;
+            }
             client.inventory_slots_modified |= 1 << (event.slot as u16);
             inventory.replace_slot(event.slot as u16, event.clicked_item.clone());
         }

--- a/crates/valence_new/src/inventory.rs
+++ b/crates/valence_new/src/inventory.rs
@@ -550,6 +550,7 @@ pub(crate) fn handle_set_slot_creative(
                 continue;
             }
             inventory.replace_slot(event.slot as u16, event.clicked_item.clone());
+            inventory.modified &= !(1 << event.slot); // clear the modified bit, since we are about to send the update
             client.inventory_state_id += 1;
             let state_id = client.inventory_state_id.0;
             // HACK: notchian clients rely on the server to send the slot update when in

--- a/crates/valence_new/src/inventory.rs
+++ b/crates/valence_new/src/inventory.rs
@@ -103,7 +103,7 @@ impl Inventory {
         std::mem::replace(&mut self.title, title.into())
     }
 
-    pub(crate) fn slot_slice(&self) -> &[Option<ItemStack>] {
+    fn slot_slice(&self) -> &[Option<ItemStack>] {
         self.slots.as_ref()
     }
 }

--- a/crates/valence_new/src/inventory.rs
+++ b/crates/valence_new/src/inventory.rs
@@ -477,7 +477,7 @@ pub(crate) fn handle_click_container(
             if client.inventory_state_id.0 != event.state_id {
                 // client is out of sync, resync, ignore click
                 debug!("Client state id mismatch, resyncing");
-                client.inventory_state_id.0 += 1;
+                client.inventory_state_id += 1;
                 let packet = SetContainerContentEncode {
                     window_id: client.window_id,
                     state_id: VarInt(client.inventory_state_id.0),
@@ -508,7 +508,7 @@ pub(crate) fn handle_click_container(
             if client.inventory_state_id.0 != event.state_id {
                 // client is out of sync, resync, and ignore the click
                 debug!("Client state id mismatch, resyncing");
-                client.inventory_state_id.0 += 1;
+                client.inventory_state_id += 1;
                 let packet = SetContainerContentEncode {
                     window_id: client.window_id,
                     state_id: VarInt(client.inventory_state_id.0),

--- a/crates/valence_new/src/inventory.rs
+++ b/crates/valence_new/src/inventory.rs
@@ -333,10 +333,6 @@ pub(crate) fn update_open_inventories(
     mut clients: Query<(Entity, &mut Client, &mut OpenInventory)>,
     mut inventories: Query<&mut Inventory>,
 ) {
-    if clients.is_empty() {
-        return;
-    }
-
     // These operations need to happen in this order.
 
     // send the inventory contents to all clients that are viewing an inventory
@@ -369,9 +365,6 @@ pub(crate) fn update_open_inventories(
             client.write_packet(&packet);
         } else {
             // the client is already viewing the inventory
-            if inventory.modified == 0 {
-                continue;
-            }
             if inventory.modified == u64::MAX {
                 // send the entire inventory
                 client.inventory_state_id += 1;

--- a/crates/valence_new/src/inventory.rs
+++ b/crates/valence_new/src/inventory.rs
@@ -118,10 +118,9 @@ pub(crate) fn update_player_inventories(
         }
 
         if inventory.modified != 0 {
-            client.inventory_state_id += 1;
-
             if inventory.modified == u64::MAX {
                 // Update the whole inventory.
+                client.inventory_state_id += 1;
                 let cursor_item = client.cursor_item.clone();
                 let state_id = client.inventory_state_id.0;
                 client.write_packet(&SetContainerContentEncode {
@@ -136,6 +135,7 @@ pub(crate) fn update_player_inventories(
                 // send the modified slots
                 let state_id = client.inventory_state_id.0;
                 if inventory.modified ^ client.inventory_slots_modified != 0 {
+                    client.inventory_state_id += 1;
                     for (i, slot) in inventory.slots.iter().enumerate() {
                         if (inventory.modified >> i) & 1 == 1 {
                             if (client.inventory_slots_modified >> i) & 1 == 1 {
@@ -151,9 +151,6 @@ pub(crate) fn update_player_inventories(
                             });
                         }
                     }
-                } else {
-                    // we don't need to send any updates, decrement the state id to stay in sync
-                    client.inventory_state_id -= 1;
                 }
             }
 

--- a/crates/valence_new/src/inventory.rs
+++ b/crates/valence_new/src/inventory.rs
@@ -375,9 +375,9 @@ pub(crate) fn update_open_inventories(
             if inventory.modified == 0 {
                 continue;
             }
-            client.inventory_state_id += 1;
             if inventory.modified == u64::MAX {
                 // send the entire inventory
+                client.inventory_state_id += 1;
                 let packet = SetContainerContentEncode {
                     window_id: client.window_id,
                     state_id: VarInt(client.inventory_state_id.0),
@@ -390,6 +390,7 @@ pub(crate) fn update_open_inventories(
                 let window_id = client.window_id as i8;
                 let state_id = client.inventory_state_id.0;
                 if inventory.modified ^ open_inventory.client_modified != 0 {
+                    client.inventory_state_id += 1;
                     for (i, slot) in inventory.slots.iter().enumerate() {
                         if (inventory.modified >> i) & 1 == 1 {
                             if (open_inventory.client_modified >> i) & 1 == 1 {
@@ -405,9 +406,6 @@ pub(crate) fn update_open_inventories(
                             });
                         }
                     }
-                } else {
-                    // we don't need to send any updates, decrement the state id to stay in sync
-                    client.inventory_state_id -= 1;
                 }
             }
         }

--- a/crates/valence_new/src/inventory.rs
+++ b/crates/valence_new/src/inventory.rs
@@ -467,16 +467,16 @@ pub(crate) fn handle_click_container(
 
                     // TODO: do more validation on the click
                     client.cursor_item = event.carried_item.clone();
-                    for slot_change in event.slot_changes.clone() {
-                        if (0i16..inventory.slot_count() as i16).contains(&slot_change.0) {
-                            inventory.replace_slot(slot_change.0 as u16, slot_change.1);
-                            client.inventory_slots_modified |= 1 << slot_change.0;
+                    for (slot_id, item) in event.slot_changes.clone() {
+                        if (0i16..inventory.slot_count() as i16).contains(&slot_id) {
+                            inventory.replace_slot(slot_id as u16, item);
+                            client.inventory_slots_modified |= 1 << slot_id;
                         } else {
                             // the client is trying to interact with a slot that does not exist,
                             // ignore
                             warn!(
                                 "Client attempted to interact with slot {} which does not exist",
-                                slot_change.0
+                                slot_id
                             );
                         }
                     }
@@ -517,20 +517,18 @@ pub(crate) fn handle_click_container(
 
                     client.cursor_item = event.carried_item.clone();
 
-                    for slot_change in event.slot_changes.clone() {
-                        if (0i16..target_inventory.slot_count() as i16).contains(&slot_change.0) {
+                    for (slot_id, item) in event.slot_changes.clone() {
+                        if (0i16..target_inventory.slot_count() as i16).contains(&slot_id) {
                             // the client is interacting with a slot in the target inventory
-                            target_inventory.replace_slot(slot_change.0 as u16, slot_change.1);
+                            target_inventory.replace_slot(slot_id as u16, item);
                             if let Some(open_inventory) = open_inventory.as_mut() {
-                                open_inventory.client_modified |= 1 << slot_change.0;
+                                open_inventory.client_modified |= 1 << slot_id;
                             }
                         } else {
                             // the client is interacting with a slot in their own inventory
-                            let slot_id = convert_to_player_slot_id(
-                                target_inventory.kind,
-                                slot_change.0 as u16,
-                            );
-                            client_inventory.replace_slot(slot_id, slot_change.1);
+                            let slot_id =
+                                convert_to_player_slot_id(target_inventory.kind, slot_id as u16);
+                            client_inventory.replace_slot(slot_id, item);
                             client.inventory_slots_modified |= 1 << slot_id;
                         }
                     }

--- a/crates/valence_new/src/inventory.rs
+++ b/crates/valence_new/src/inventory.rs
@@ -425,3 +425,24 @@ pub(crate) fn update_client_on_close_inventory(
         }
     }
 }
+
+/// Convert a slot that is outside a target inventory's range to a slot that is
+/// inside the player's inventory.
+fn convert_to_player_slot_id(target_kind: InventoryKind, slot_id: u16) -> u16 {
+    // the first slot in the player's general inventory
+    let offset = target_kind.slot_count() as u16;
+    slot_id - offset + 9
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_convert_to_player_slot() {
+        assert_eq!(convert_to_player_slot_id(InventoryKind::Generic9x3, 27), 9);
+        assert_eq!(convert_to_player_slot_id(InventoryKind::Generic9x3, 36), 18);
+        assert_eq!(convert_to_player_slot_id(InventoryKind::Generic9x3, 54), 36);
+        assert_eq!(convert_to_player_slot_id(InventoryKind::Generic9x1, 9), 9);
+    }
+}

--- a/crates/valence_new/src/inventory.rs
+++ b/crates/valence_new/src/inventory.rs
@@ -34,6 +34,7 @@ impl Inventory {
         }
     }
 
+    #[track_caller]
     pub fn slot(&self, idx: u16) -> Option<&ItemStack> {
         self.slots
             .get(idx as usize)
@@ -41,6 +42,7 @@ impl Inventory {
             .as_ref()
     }
 
+    #[track_caller]
     pub fn replace_slot(
         &mut self,
         idx: u16,
@@ -58,6 +60,7 @@ impl Inventory {
         std::mem::replace(old, new)
     }
 
+    #[track_caller]
     pub fn swap_slot(&mut self, idx_a: u16, idx_b: u16) {
         assert!(idx_a < self.slot_count(), "slot index out of range");
         assert!(idx_b < self.slot_count(), "slot index out of range");

--- a/crates/valence_new/src/inventory.rs
+++ b/crates/valence_new/src/inventory.rs
@@ -351,6 +351,7 @@ pub(crate) fn update_open_inventories(
         if open_inventory.is_added() {
             // send the inventory to the client if the client just opened the inventory
             client.window_id = client.window_id % 100 + 1;
+            open_inventory.client_modified = 0;
 
             let packet = OpenScreen {
                 window_id: VarInt(client.window_id.into()),

--- a/crates/valence_new/src/inventory.rs
+++ b/crates/valence_new/src/inventory.rs
@@ -481,8 +481,8 @@ pub(crate) fn handle_click_container(
                 _ => {
                     // the client or inventory does not exist, ignore
                     warn!(
-                        "Client attempted to interact with their own
-    inventory, but it does not exist"
+                        "Client attempted to interact with their own inventory, but it does not \
+                         exist"
                     );
                 }
             }
@@ -495,10 +495,7 @@ pub(crate) fn handle_click_container(
 
             if open_inventory.is_none() {
                 // the client is not viewing an inventory, ignore
-                warn!(
-                    "Client attempted to interact with an inventory, but is
-    not viewing one"
-                );
+                warn!("Client attempted to interact with an inventory, but is not viewing one");
                 continue;
             }
 

--- a/crates/valence_new/src/server.rs
+++ b/crates/valence_new/src/server.rs
@@ -28,8 +28,9 @@ use crate::entity::{
 };
 use crate::instance::{update_instances_post_client, update_instances_pre_client, Instance};
 use crate::inventory::{
-    handle_close_container, update_client_on_close_inventory, update_client_on_open_inventory,
-    update_open_inventories, update_player_inventories, Inventory, InventoryKind,
+    handle_click_container, handle_close_container, update_client_on_close_inventory,
+    update_client_on_open_inventory, update_open_inventories, update_player_inventories, Inventory,
+    InventoryKind,
 };
 use crate::player_textures::SignedPlayerTextures;
 use crate::server::connect::do_accept_loop;
@@ -357,7 +358,8 @@ pub fn run_server(
             .with_system(update_open_inventories)
             .with_system(handle_close_container)
             .with_system(update_client_on_close_inventory.after(update_open_inventories))
-            .with_system(update_player_inventories),
+            .with_system(update_player_inventories)
+            .with_system(handle_click_container),
     );
 
     let mut tick_start = Instant::now();

--- a/crates/valence_new/src/server.rs
+++ b/crates/valence_new/src/server.rs
@@ -29,8 +29,8 @@ use crate::entity::{
 use crate::instance::{update_instances_post_client, update_instances_pre_client, Instance};
 use crate::inventory::{
     handle_click_container, handle_close_container, handle_set_slot_creative,
-    update_client_on_close_inventory, update_client_on_open_inventory, update_open_inventories,
-    update_player_inventories, Inventory, InventoryKind,
+    update_client_on_close_inventory, update_open_inventories, update_player_inventories,
+    Inventory, InventoryKind,
 };
 use crate::player_textures::SignedPlayerTextures;
 use crate::server::connect::do_accept_loop;
@@ -354,7 +354,6 @@ pub fn run_server(
             .with_system(deinit_despawned_entities.after(update_instances_post_client))
             .with_system(despawn_entities.after(deinit_despawned_entities))
             .with_system(update_entities.after(despawn_entities))
-            .with_system(update_client_on_open_inventory)
             .with_system(update_open_inventories)
             .with_system(handle_close_container)
             .with_system(update_client_on_close_inventory.after(update_open_inventories))

--- a/crates/valence_new/src/server.rs
+++ b/crates/valence_new/src/server.rs
@@ -28,9 +28,9 @@ use crate::entity::{
 };
 use crate::instance::{update_instances_post_client, update_instances_pre_client, Instance};
 use crate::inventory::{
-    handle_click_container, handle_close_container, update_client_on_close_inventory,
-    update_client_on_open_inventory, update_open_inventories, update_player_inventories, Inventory,
-    InventoryKind,
+    handle_click_container, handle_close_container, handle_set_slot_creative,
+    update_client_on_close_inventory, update_client_on_open_inventory, update_open_inventories,
+    update_player_inventories, Inventory, InventoryKind,
 };
 use crate::player_textures::SignedPlayerTextures;
 use crate::server::connect::do_accept_loop;
@@ -361,6 +361,11 @@ pub fn run_server(
             .with_system(update_player_inventories)
             .with_system(
                 handle_click_container
+                    .before(update_open_inventories)
+                    .before(update_player_inventories),
+            )
+            .with_system(
+                handle_set_slot_creative
                     .before(update_open_inventories)
                     .before(update_player_inventories),
             ),

--- a/crates/valence_new/src/server.rs
+++ b/crates/valence_new/src/server.rs
@@ -359,7 +359,11 @@ pub fn run_server(
             .with_system(handle_close_container)
             .with_system(update_client_on_close_inventory.after(update_open_inventories))
             .with_system(update_player_inventories)
-            .with_system(handle_click_container),
+            .with_system(
+                handle_click_container
+                    .before(update_open_inventories)
+                    .before(update_player_inventories),
+            ),
     );
 
     let mut tick_start = Instant::now();


### PR DESCRIPTION
- add helper to convert slot ids
- implement system to handle click container events
- update inventory_test example with block platform and some chests to open
- add toggle_gamemode_on_sneak system to example
- fix query filter that was causing clients to get spammed with OpenScreen
- move state_id to `Client` component
- only send modified slots when observed inventories are changed
- force all click container packets to be handled before update packets are built and sent
- mark inventories as dirty instead of just sending the contents
- add handle_set_slot_creative to handle SetCreativeModeSlot events
- exclude clients with currently open inventories from being updated by `update_player_inventories`

### Test plan

1. Start the `inventory_test` example

```bash
cargo run --example inventory_test
```

2. Join the server
3. Walk to the small brick square
4. The copper, iron, and gold blocks have chests on top of them (they are invisible until we have block entities)
5. Give yourself some items
6. Place those items in one of the inventories
7. Give yourself some more items
8. Sneak to change game mode to survival
9. Open the same inventory and move some items between your inventory and the chest's inventory.
10. Repeat 5-9, but have another client join and observe the chest you're interacting with.
11. The second client should be able to see the inventory update in real time.
