### PR TITLE
Add a simple SNBT parser

### DIFF
--- a/crates/valence_nbt/src/lib.rs
+++ b/crates/valence_nbt/src/lib.rs
@@ -76,9 +76,9 @@ pub mod compound;
 mod error;
 mod from_binary_slice;
 mod modified_utf8;
+pub mod snbt;
 mod to_binary_writer;
 pub mod value;
-pub mod snbt;
 
 mod tag;
 #[cfg(test)]

--- a/crates/valence_nbt/src/lib.rs
+++ b/crates/valence_nbt/src/lib.rs
@@ -69,6 +69,7 @@
 pub use compound::Compound;
 pub use error::Error;
 pub use from_binary_slice::from_binary_slice;
+pub use tag::Tag;
 pub use to_binary_writer::to_binary_writer;
 pub use value::{List, Value};
 

--- a/crates/valence_nbt/src/lib.rs
+++ b/crates/valence_nbt/src/lib.rs
@@ -78,6 +78,7 @@ mod from_binary_slice;
 mod modified_utf8;
 mod to_binary_writer;
 pub mod value;
+pub mod snbt;
 
 mod tag;
 #[cfg(test)]

--- a/crates/valence_nbt/src/snbt.rs
+++ b/crates/valence_nbt/src/snbt.rs
@@ -698,7 +698,7 @@ mod tests {
         );
         #[cfg(feature = "preserve_order")]
         assert_eq!(
-            stringify(&value),
+            to_snbt_string(&value),
             "{foo:1,bar:1d,baz:1f,\"hello'\":\"hello \
              world\",world:\"hello\\\"world\",1.5f:1.5d,3b:2f,bool:0b,more:{iarr:[I;1,2,3],larr:\
              [L;1l,2l,3l]},empty:[Bibabo]}"

--- a/crates/valence_nbt/src/snbt.rs
+++ b/crates/valence_nbt/src/snbt.rs
@@ -1,0 +1,536 @@
+use std::{
+    fmt::{Display, Formatter},
+    iter::Peekable,
+    str::Chars, error::Error,
+};
+
+use crate::{tag::Tag, Compound, List, Value};
+
+const STRING_MAX_LEN: usize = 32767;
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
+pub enum SNBTErrorType {
+    ReachEndOfStream,
+    InvalidEscapeSequence,
+    EmptyKeyInCompound,
+    ExpectColon,
+    ExpectValue,
+    ExpectComma,
+    WrongTypeInArray,
+    DifferentTypesInList,
+    LongString,
+    TrailingData,
+}
+
+impl Display for SNBTErrorType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        use SNBTErrorType::*;
+        match self {
+            ReachEndOfStream => write!(f, "Reach end of stream"),
+            InvalidEscapeSequence => write!(f, "Invalid escape sequence"),
+            EmptyKeyInCompound => write!(f, "Empty key in compound"),
+            ExpectColon => write!(f, "Expect colon"),
+            ExpectValue => write!(f, "Expect value"),
+            ExpectComma => write!(f, "Expect comma"),
+            WrongTypeInArray => write!(f, "Wrong type in array"),
+            DifferentTypesInList => write!(f, "Different types in list"),
+            LongString => write!(f, "Long string"),
+            TrailingData => write!(f, "Extra data after end"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
+pub struct SNBTError {
+    pub error_type: SNBTErrorType,
+    pub line: usize,
+    pub column: usize,
+}
+
+impl SNBTError {
+    pub fn new(error_type: SNBTErrorType, line: usize, column: usize) -> Self {
+        Self {
+            error_type,
+            line,
+            column,
+        }
+    }
+}
+
+impl Display for SNBTError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "@ {},{}: {}", self.line, self.column, self.error_type)
+    }
+}
+
+impl Error for SNBTError {
+}
+
+type Result<T> = std::result::Result<T, SNBTError>;
+
+pub struct SNBTReader<'a> {
+    line: usize,
+    column: usize,
+	pub index: usize,
+    iter: Peekable<Chars<'a>>,
+    pushed_back: Option<char>,
+}
+
+impl<'a> SNBTReader<'a> {
+    pub fn new(input: &'a str) -> Self {
+        Self {
+            line: 1,
+            column: 1,
+			index: 0,
+            iter: input.chars().peekable(),
+            pushed_back: None,
+        }
+    }
+
+    fn make_error(&self, error_type: SNBTErrorType) -> SNBTError {
+        SNBTError::new(error_type, self.line, self.column)
+    }
+
+    fn peek(&mut self) -> Result<char> {
+        if let Some(c) = self.pushed_back {
+            Ok(c)
+        } else {
+            self.iter
+                .peek()
+                .map(|c| *c)
+                .ok_or_else(|| self.make_error(SNBTErrorType::ReachEndOfStream))
+        }
+    }
+
+    fn next(&mut self) {
+        if let Some(_) = self.pushed_back {
+            self.pushed_back = None;
+            return;
+        }
+        let result = self.iter.next();
+        if let Some(c) = result {
+            if c == '\n' {
+                self.line += 1;
+                self.column = 1;
+            } else {
+                self.column += 1;
+            }
+			self.index += c.len_utf8();
+        }
+    }
+
+    /// Push back a char, only one char can be pushed back
+    fn push_back(&mut self, c: char) {
+		if c == '\n' {
+			self.line -= 1;
+			self.column = 1;
+		} else {
+			self.column -= 1;
+		}
+		self.index -= c.len_utf8();
+        match self.pushed_back {
+            Some(_) => panic!("Can't push back two chars"),
+            None => self.pushed_back = Some(c),
+        };
+    }
+
+    fn skip_whitespace(&mut self) {
+        loop {
+            match self.peek() {
+                Ok(c) if c.is_whitespace() => self.next(),
+                _ => break,
+            };
+        }
+    }
+
+    fn read_string(&mut self) -> Result<String> {
+        let first = self.peek()?;
+        let str = match first {
+            '\"' | '\'' => self.read_quoted_string(),
+            _ => self.read_unquoted_string(),
+        }?;
+        if str.len() > STRING_MAX_LEN {
+            return Err(self.make_error(SNBTErrorType::LongString));
+        }
+        Ok(str)
+    }
+
+    fn read_unquoted_string(&mut self) -> Result<String> {
+        let mut result = String::new();
+        loop {
+            let input = self.peek();
+            match input {
+                Ok('a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '-' | '+' | '.') => {
+                    result.push(input?);
+                    self.next();
+                }
+                _ => break,
+            }
+        }
+        Ok(result)
+    }
+
+    fn read_quoted_string(&mut self) -> Result<String> {
+        let quote = self.peek()?;
+        self.next();
+        let mut result = String::new();
+        loop {
+            let input = self.peek();
+            match input {
+                Ok(c) if c == quote => {
+                    self.next();
+                    break;
+                }
+                Ok('\\') => {
+                    self.next();
+                    let escape = self.peek()?;
+                    if escape == quote || escape == '\\' {
+                        result.push(escape);
+                    } else {
+                        return Err(self.make_error(SNBTErrorType::InvalidEscapeSequence));
+                    }
+                    self.next();
+                }
+                Ok(c) => {
+                    result.push(c);
+                    self.next();
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        if result.len() > STRING_MAX_LEN {
+            return Err(self.make_error(SNBTErrorType::LongString));
+        }
+        Ok(result)
+    }
+
+    fn parse_compound(&mut self) -> Result<Compound> {
+        self.next();
+        self.skip_whitespace();
+        let mut cpd = Compound::new();
+        while self.peek()? != '}' {
+            let key = self.read_string()?;
+            self.skip_whitespace();
+            if key.len() == 0 {
+                return Err(self.make_error(SNBTErrorType::EmptyKeyInCompound));
+            }
+            if self.peek()? != ':' {
+                return Err(self.make_error(SNBTErrorType::ExpectColon));
+            }
+            self.next();
+            self.skip_whitespace();
+            let value = self.parse_element()?;
+            self.skip_whitespace();
+            if self.peek()? == ',' {
+                self.next();
+                self.skip_whitespace();
+            } else if self.peek()? != '}' {
+                return Err(self.make_error(SNBTErrorType::ExpectComma));
+            }
+            cpd.insert(key, value);
+        }
+        self.next();
+        Ok(cpd)
+    }
+
+    fn continue_parse_list(&mut self) -> Result<List> {
+        self.skip_whitespace();
+        let mut list = vec![];
+        let mut element_type = Tag::End;
+        while self.peek()? != ']' {
+            let value = self.parse_element()?;
+            self.skip_whitespace();
+            if element_type == Tag::End {
+                element_type = value.get_type();
+            } else if value.get_type() != element_type {
+                return Err(self.make_error(SNBTErrorType::DifferentTypesInList));
+            }
+            if self.peek()? == ',' {
+                self.next();
+                self.skip_whitespace();
+            } else if self.peek()? != ']' {
+                return Err(self.make_error(SNBTErrorType::ExpectComma));
+            }
+            list.push(value);
+        }
+        self.next();
+
+        // Since the type of elements is known, feel free to unwrap them
+        match element_type {
+            Tag::End => Ok(List::End),
+            Tag::Byte => Ok(List::Byte(
+                list.into_iter().map(|v| v.into_byte().unwrap()).collect(),
+            )),
+            Tag::Short => Ok(List::Short(
+                list.into_iter().map(|v| v.into_short().unwrap()).collect(),
+            )),
+            Tag::Int => Ok(List::Int(
+                list.into_iter().map(|v| v.into_int().unwrap()).collect(),
+            )),
+            Tag::Long => Ok(List::Long(
+                list.into_iter().map(|v| v.into_long().unwrap()).collect(),
+            )),
+            Tag::Float => Ok(List::Float(
+                list.into_iter().map(|v| v.into_float().unwrap()).collect(),
+            )),
+            Tag::Double => Ok(List::Double(
+                list.into_iter().map(|v| v.into_double().unwrap()).collect(),
+            )),
+            Tag::String => Ok(List::String(
+                list.into_iter().map(|v| v.into_string().unwrap()).collect(),
+            )),
+            Tag::ByteArray => Ok(List::ByteArray(
+                list.into_iter()
+                    .map(|v| v.into_byte_array().unwrap())
+                    .collect(),
+            )),
+            Tag::List => Ok(List::List(
+                list.into_iter().map(|v| v.into_list().unwrap()).collect(),
+            )),
+            Tag::Compound => Ok(List::Compound(
+                list.into_iter()
+                    .map(|v| v.into_compound().unwrap())
+                    .collect(),
+            )),
+            Tag::IntArray => Ok(List::IntArray(
+                list.into_iter()
+                    .map(|v| v.into_int_array().unwrap())
+                    .collect(),
+            )),
+            Tag::LongArray => Ok(List::LongArray(
+                list.into_iter()
+                    .map(|v| v.into_long_array().unwrap())
+                    .collect(),
+            )),
+        }
+    }
+
+    fn parse_list_like(&mut self) -> Result<Value> {
+        self.next();
+        let type_char = self.peek()?;
+        let etype = match type_char {
+            'B' => Tag::Byte,
+            'I' => Tag::Int,
+            'L' => Tag::Long,
+            _ => return self.continue_parse_list().map(|l| l.into()),
+        };
+        self.next();
+        if self.peek()? != ';' {
+            self.push_back(type_char);
+            return self.continue_parse_list().map(|l| l.into());
+        }
+        self.next();
+        self.skip_whitespace();
+        let mut values = vec![];
+        while self.peek()? != ']' {
+            let value = self.parse_element()?;
+            if value.get_type() != etype {
+                return Err(self.make_error(SNBTErrorType::WrongTypeInArray));
+            }
+            values.push(value);
+            self.skip_whitespace();
+            if self.peek()? == ',' {
+                self.next();
+                self.skip_whitespace();
+            } else if self.peek()? != ']' {
+                return Err(self.make_error(SNBTErrorType::ExpectComma));
+            }
+        }
+        self.next();
+        match etype {
+            Tag::Byte => Ok(Value::ByteArray(
+                values.into_iter().map(|v| v.into_byte().unwrap()).collect(),
+            )),
+            Tag::Int => Ok(Value::IntArray(
+                values.into_iter().map(|v| v.into_int().unwrap()).collect(),
+            )),
+            Tag::Long => Ok(Value::LongArray(
+                values.into_iter().map(|v| v.into_long().unwrap()).collect(),
+            )),
+            _ => unreachable!(),
+        }
+    }
+
+    fn parse_primitive(&mut self) -> Result<Value> {
+        macro_rules! try_ret {
+            // Try possible solution until one works
+            ($v:expr) => {{
+                match $v {
+                    Ok(v) => return Ok(v.into()),
+                    Err(_) => (),
+                }
+            }};
+        }
+        let target = self.read_unquoted_string()?;
+        match target
+            .bytes()
+            .last()
+            .ok_or_else(|| self.make_error(SNBTErrorType::ExpectValue))?
+        {
+            b'b' | b'B' => try_ret!(target[..target.len() - 1].parse::<i8>()),
+            b's' | b'S' => try_ret!(target[..target.len() - 1].parse::<i16>()),
+            b'l' | b'L' => try_ret!(target[..target.len() - 1].parse::<i64>()),
+            b'f' | b'F' => try_ret!(target[..target.len() - 1].parse::<f32>()),
+            b'd' | b'D' => try_ret!(target[..target.len() - 1].parse::<f64>()),
+            _ => (),
+        }
+        match target.as_str() {
+            "true" => return Ok(Value::Byte(1)),
+            "false" => return Ok(Value::Byte(0)),
+            _ => {
+                try_ret!(target.parse::<i32>());
+                try_ret!(target.parse::<f64>());
+            }
+        };
+        if target.len() > STRING_MAX_LEN {
+            return Err(self.make_error(SNBTErrorType::LongString));
+        }
+        Ok(Value::String(target))
+    }
+
+	/// Read the next element in the SNBT string.
+	/// [`SNBTErrorType::TrailingData`] is impossible to be returned since it doesnot consider it's an error.
+    pub fn parse_element(&mut self) -> Result<Value> {
+        self.skip_whitespace();
+        match self.peek()? {
+            '{' => self.parse_compound().map(|c| c.into()),
+            '[' => self.parse_list_like(),
+            '"' | '\'' => self.read_quoted_string().map(|s| s.into()),
+            _ => self.parse_primitive(),
+        }
+    }
+	
+    pub fn read(&mut self) -> Result<Value> {
+        let value = self.parse_element()?;
+        self.skip_whitespace();
+        if self.peek().is_ok() {
+            return Err(self.make_error(SNBTErrorType::TrailingData));
+        }
+        Ok(value)
+    }
+
+	/// Get the number of bytes readed.
+	/// It's useful when you want to read a SNBT string from an command argument since there may be trailing data.
+	pub fn bytes_readed(&self) -> usize {
+		self.index
+	}
+
+	/// Parse a string in SNBT format into a `Value`.
+	/// Assert that the string has no trailing data.
+	/// SNBT is quite similar to JSON, but with some differences.
+	/// See [the wiki](https://minecraft.gamepedia.com/NBT_format#SNBT_format) for more information.
+	/// # Example
+	/// ```
+	/// use nbt::Value;
+	/// use nbt::SNBTReader;
+	/// let value = SNBTReader::from_snbt("1f").unwrap();
+	/// assert_eq!(value, Value::Float(1.0));
+	/// ```
+    pub fn from_snbt(snbt: &str) -> Result<Value> {
+        SNBTReader::new(snbt).read()
+    }
+
+
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_parse() {
+        let str = r#"
+			{
+				foo: 1,
+				'bar': 1.0,
+				"baz": 1.0f,
+				"hello'": "hello world",
+				"world": "hello\"world",
+				1.5f: 1.5d,
+				3b: 2f,
+				bool: false,
+				more: {
+					iarr: [I; 1, 2, 3],
+					larr: [L; 1L, 2L, 3L],
+				},
+				empty: [Bibabo ],
+			}
+		"#;
+        let value = SNBTReader::from_snbt(str).unwrap();
+        let cpd = value.as_compound().unwrap();
+        assert_eq!(*cpd.get("foo").unwrap().as_int().unwrap(), 1);
+        assert_eq!(*cpd.get("bar").unwrap().as_double().unwrap(), 1.0);
+        assert_eq!(*cpd.get("baz").unwrap().as_float().unwrap(), 1.0);
+        assert_eq!(
+            *cpd.get("hello'").unwrap().as_string().unwrap(),
+            "hello world"
+        );
+        assert_eq!(
+            *cpd.get("world").unwrap().as_string().unwrap(),
+            "hello\"world"
+        );
+        assert_eq!(*cpd.get("1.5f").unwrap().as_double().unwrap(), 1.5);
+        assert_eq!(*cpd.get("3b").unwrap().as_float().unwrap(), 2.0);
+        assert_eq!(*cpd.get("bool").unwrap().as_byte().unwrap(), 0);
+        let more = cpd.get("more").unwrap().as_compound().unwrap();
+        assert_eq!(
+            *more.get("iarr").unwrap().as_int_array().unwrap(),
+            vec![1, 2, 3]
+        );
+        assert_eq!(
+            *more.get("larr").unwrap().as_long_array().unwrap(),
+            vec![1, 2, 3]
+        );
+		println!("{:?}", more);
+		let List::String(list) = cpd.get("empty").unwrap().as_list().unwrap() else { panic!() };
+		assert_eq!(list[0], "Bibabo");
+        assert_eq!(
+            SNBTReader::from_snbt("\"\\n\"").unwrap_err().error_type,
+            SNBTErrorType::InvalidEscapeSequence
+        );
+        assert_eq!(
+            SNBTReader::from_snbt("[L; 1]").unwrap_err().error_type,
+            SNBTErrorType::WrongTypeInArray
+        );
+        assert_eq!(
+            SNBTReader::from_snbt("[L; 1L, 2L, 3L")
+                .unwrap_err()
+                .error_type,
+            SNBTErrorType::ReachEndOfStream
+        );
+        assert_eq!(
+            SNBTReader::from_snbt("[L; 1L, 2L, 3L,]dewdwe")
+                .unwrap_err()
+                .error_type,
+            SNBTErrorType::TrailingData
+        );
+        assert_eq!(
+            SNBTReader::from_snbt("{ foo: }").unwrap_err().error_type,
+            SNBTErrorType::ExpectValue
+        );
+        assert_eq!(
+            SNBTReader::from_snbt("{ {}, }").unwrap_err().error_type,
+            SNBTErrorType::EmptyKeyInCompound
+        );
+        assert_eq!(
+            SNBTReader::from_snbt("{ foo 1 }").unwrap_err().error_type,
+            SNBTErrorType::ExpectColon
+        );
+        assert_eq!(
+            SNBTReader::from_snbt("{ foo: 1 bar: 2 }")
+                .unwrap_err()
+                .error_type,
+            SNBTErrorType::ExpectComma
+        );
+        assert_eq!(
+            SNBTReader::from_snbt("[{}, []]").unwrap_err().error_type,
+            SNBTErrorType::DifferentTypesInList
+        );
+        assert_eq!(
+            SNBTReader::from_snbt(&String::from_utf8(vec![b'e'; 32768]).unwrap())
+                .unwrap_err()
+                .error_type,
+            SNBTErrorType::LongString
+        );
+    }
+}

--- a/crates/valence_nbt/src/snbt.rs
+++ b/crates/valence_nbt/src/snbt.rs
@@ -441,10 +441,10 @@ impl<'a> SnbtReader<'a> {
 /// ```
 /// use valence_nbt::snbt::SnbtReader;
 /// use valence_nbt::Value;
-/// let value = SnbtReader::from_snbt("1f").unwrap();
+/// let value = from_snbt_str("1f").unwrap();
 /// assert_eq!(value, Value::Float(1.0));
 /// ```
-pub fn from_snbt_string(snbt: &str) -> Result<Value> {
+pub fn from_snbt_str(snbt: &str) -> Result<Value> {
     SnbtReader::new(snbt).read()
 }
 
@@ -614,7 +614,7 @@ mod tests {
 				empty: [Bibabo ],
 			}
 		"#;
-        let value = from_snbt_string(str).unwrap();
+        let value = from_snbt_str(str).unwrap();
         let cpd = value.as_compound().unwrap();
         assert_eq!(*cpd.get("foo").unwrap().as_int().unwrap(), 1);
         assert_eq!(*cpd.get("bar").unwrap().as_double().unwrap(), 1.0);
@@ -642,53 +642,51 @@ mod tests {
         let List::String(list) = cpd.get("empty").unwrap().as_list().unwrap() else { panic!() };
         assert_eq!(list[0], "Bibabo");
         assert_eq!(
-            from_snbt_string("\"\\n\"").unwrap_err().error_type,
+            from_snbt_str("\"\\n\"").unwrap_err().error_type,
             SnbtErrorKind::InvalidEscapeSequence
         );
         assert_eq!(
-            from_snbt_string("[L; 1]").unwrap_err().error_type,
+            from_snbt_str("[L; 1]").unwrap_err().error_type,
             SnbtErrorKind::WrongTypeInArray
         );
         assert_eq!(
-            from_snbt_string("[L; 1L, 2L, 3L").unwrap_err().error_type,
+            from_snbt_str("[L; 1L, 2L, 3L").unwrap_err().error_type,
             SnbtErrorKind::ReachEndOfStream
         );
         assert_eq!(
-            from_snbt_string("[L; 1L, 2L, 3L,]dewdwe")
+            from_snbt_str("[L; 1L, 2L, 3L,]dewdwe")
                 .unwrap_err()
                 .error_type,
             SnbtErrorKind::TrailingData
         );
         assert_eq!(
-            from_snbt_string("{ foo: }").unwrap_err().error_type,
+            from_snbt_str("{ foo: }").unwrap_err().error_type,
             SnbtErrorKind::ExpectValue
         );
         assert_eq!(
-            from_snbt_string("{ {}, }").unwrap_err().error_type,
+            from_snbt_str("{ {}, }").unwrap_err().error_type,
             SnbtErrorKind::EmptyKeyInCompound
         );
         assert_eq!(
-            from_snbt_string("{ foo 1 }").unwrap_err().error_type,
+            from_snbt_str("{ foo 1 }").unwrap_err().error_type,
             SnbtErrorKind::ExpectColon
         );
         assert_eq!(
-            from_snbt_string("{ foo: 1 bar: 2 }")
-                .unwrap_err()
-                .error_type,
+            from_snbt_str("{ foo: 1 bar: 2 }").unwrap_err().error_type,
             SnbtErrorKind::ExpectComma
         );
         assert_eq!(
-            from_snbt_string("[{}, []]").unwrap_err().error_type,
+            from_snbt_str("[{}, []]").unwrap_err().error_type,
             SnbtErrorKind::DifferentTypesInList
         );
         assert_eq!(
-            from_snbt_string(&String::from_utf8(vec![b'e'; 32768]).unwrap())
+            from_snbt_str(&String::from_utf8(vec![b'e'; 32768]).unwrap())
                 .unwrap_err()
                 .error_type,
             SnbtErrorKind::LongString
         );
         assert_eq!(
-            from_snbt_string(
+            from_snbt_str(
                 &String::from_utf8([[b'['; MAX_DEPTH + 1], [b']'; MAX_DEPTH + 1]].concat())
                     .unwrap()
             )

--- a/crates/valence_nbt/src/snbt.rs
+++ b/crates/valence_nbt/src/snbt.rs
@@ -1,7 +1,8 @@
 use std::{
+    error::Error,
     fmt::{Display, Formatter},
     iter::Peekable,
-    str::Chars, error::Error,
+    str::Chars,
 };
 
 use crate::{tag::Tag, Compound, List, Value};
@@ -62,15 +63,14 @@ impl Display for SNBTError {
     }
 }
 
-impl Error for SNBTError {
-}
+impl Error for SNBTError {}
 
 type Result<T> = std::result::Result<T, SNBTError>;
 
 pub struct SNBTReader<'a> {
     line: usize,
     column: usize,
-	pub index: usize,
+    pub index: usize,
     iter: Peekable<Chars<'a>>,
     pushed_back: Option<char>,
 }
@@ -80,7 +80,7 @@ impl<'a> SNBTReader<'a> {
         Self {
             line: 1,
             column: 1,
-			index: 0,
+            index: 0,
             iter: input.chars().peekable(),
             pushed_back: None,
         }
@@ -114,19 +114,19 @@ impl<'a> SNBTReader<'a> {
             } else {
                 self.column += 1;
             }
-			self.index += c.len_utf8();
+            self.index += c.len_utf8();
         }
     }
 
     /// Push back a char, only one char can be pushed back
     fn push_back(&mut self, c: char) {
-		if c == '\n' {
-			self.line -= 1;
-			self.column = 1;
-		} else {
-			self.column -= 1;
-		}
-		self.index -= c.len_utf8();
+        if c == '\n' {
+            self.line -= 1;
+            self.column = 1;
+        } else {
+            self.column -= 1;
+        }
+        self.index -= c.len_utf8();
         match self.pushed_back {
             Some(_) => panic!("Can't push back two chars"),
             None => self.pushed_back = Some(c),
@@ -387,8 +387,8 @@ impl<'a> SNBTReader<'a> {
         Ok(Value::String(target))
     }
 
-	/// Read the next element in the SNBT string.
-	/// [`SNBTErrorType::TrailingData`] is impossible to be returned since it doesnot consider it's an error.
+    /// Read the next element in the SNBT string.
+    /// [`SNBTErrorType::TrailingData`] is impossible to be returned since it doesnot consider it's an error.
     pub fn parse_element(&mut self) -> Result<Value> {
         self.skip_whitespace();
         match self.peek()? {
@@ -398,7 +398,7 @@ impl<'a> SNBTReader<'a> {
             _ => self.parse_primitive(),
         }
     }
-	
+
     pub fn read(&mut self) -> Result<Value> {
         let value = self.parse_element()?;
         self.skip_whitespace();
@@ -408,28 +408,26 @@ impl<'a> SNBTReader<'a> {
         Ok(value)
     }
 
-	/// Get the number of bytes readed.
-	/// It's useful when you want to read a SNBT string from an command argument since there may be trailing data.
-	pub fn bytes_readed(&self) -> usize {
-		self.index
-	}
+    /// Get the number of bytes readed.
+    /// It's useful when you want to read a SNBT string from an command argument since there may be trailing data.
+    pub fn bytes_readed(&self) -> usize {
+        self.index
+    }
 
-	/// Parse a string in SNBT format into a `Value`.
-	/// Assert that the string has no trailing data.
-	/// SNBT is quite similar to JSON, but with some differences.
-	/// See [the wiki](https://minecraft.gamepedia.com/NBT_format#SNBT_format) for more information.
-	/// # Example
-	/// ```
-	/// use nbt::Value;
-	/// use nbt::SNBTReader;
-	/// let value = SNBTReader::from_snbt("1f").unwrap();
-	/// assert_eq!(value, Value::Float(1.0));
-	/// ```
+    /// Parse a string in SNBT format into a `Value`.
+    /// Assert that the string has no trailing data.
+    /// SNBT is quite similar to JSON, but with some differences.
+    /// See [the wiki](https://minecraft.gamepedia.com/NBT_format#SNBT_format) for more information.
+    /// # Example
+    /// ```
+    /// use nbt::Value;
+    /// use nbt::SNBTReader;
+    /// let value = SNBTReader::from_snbt("1f").unwrap();
+    /// assert_eq!(value, Value::Float(1.0));
+    /// ```
     pub fn from_snbt(snbt: &str) -> Result<Value> {
         SNBTReader::new(snbt).read()
     }
-
-
 }
 
 #[cfg(test)]
@@ -481,9 +479,9 @@ mod tests {
             *more.get("larr").unwrap().as_long_array().unwrap(),
             vec![1, 2, 3]
         );
-		println!("{:?}", more);
-		let List::String(list) = cpd.get("empty").unwrap().as_list().unwrap() else { panic!() };
-		assert_eq!(list[0], "Bibabo");
+        println!("{:?}", more);
+        let List::String(list) = cpd.get("empty").unwrap().as_list().unwrap() else { panic!() };
+        assert_eq!(list[0], "Bibabo");
         assert_eq!(
             SNBTReader::from_snbt("\"\\n\"").unwrap_err().error_type,
             SNBTErrorType::InvalidEscapeSequence

--- a/crates/valence_nbt/src/snbt.rs
+++ b/crates/valence_nbt/src/snbt.rs
@@ -94,7 +94,7 @@ impl<'a> SnbtReader<'a> {
 
     fn check_depth<T>(&mut self, f: impl FnOnce(&mut Self) -> Result<T>) -> Result<T> {
         if self.depth >= MAX_DEPTH {
-            return Err(self.make_error(SnbtErrorKind::DepthLimitExceeded));
+            Err(self.make_error(SnbtErrorKind::DepthLimitExceeded))
         } else {
             self.depth += 1;
             let res = f(self);
@@ -113,13 +113,13 @@ impl<'a> SnbtReader<'a> {
         } else {
             self.iter
                 .peek()
-                .map(|c| *c)
+                .copied()
                 .ok_or_else(|| self.make_error(SnbtErrorKind::ReachEndOfStream))
         }
     }
 
     fn next(&mut self) {
-        if let Some(_) = self.pushed_back {
+        if self.pushed_back.is_some() {
             self.pushed_back = None;
             return;
         }
@@ -227,7 +227,7 @@ impl<'a> SnbtReader<'a> {
         while self.peek()? != '}' {
             let key = self.read_string()?;
             self.skip_whitespace();
-            if key.len() == 0 {
+            if key.is_empty() {
                 return Err(self.make_error(SnbtErrorKind::EmptyKeyInCompound));
             }
             if self.peek()? != ':' {

--- a/crates/valence_nbt/src/snbt.rs
+++ b/crates/valence_nbt/src/snbt.rs
@@ -405,7 +405,7 @@ impl<'a> SnbtReader<'a> {
     }
 
     /// Read the next element in the SNBT string.
-    /// [`SNBTErrorType::TrailingData`] cannot be returned because it is not
+    /// [`SnbtErrorKind::TrailingData`] cannot be returned because it is not
     /// considered to be an error.
     pub fn parse_element(&mut self) -> Result<Value> {
         self.skip_whitespace();

--- a/crates/valence_nbt/src/value.rs
+++ b/crates/valence_nbt/src/value.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 
-use crate::{tag::Tag, Compound};
+use crate::tag::Tag;
+use crate::Compound;
 
 /// Represents an arbitrary NBT value.
 #[derive(Clone, PartialEq, Debug)]
@@ -75,7 +76,7 @@ impl List {
     }
 
     /// Returns the element type of this list.
-    pub fn element_type(&self) -> Tag {
+    pub fn element_tag(&self) -> Tag {
         match self {
             List::End => Tag::End,
             List::Byte(_) => Tag::Byte,
@@ -144,7 +145,7 @@ impl Value {
     }
 
     /// Returns the type of this value.
-    pub fn get_type(&self) -> Tag {
+    pub fn get_tag(&self) -> Tag {
         match self {
             Self::Byte(_) => Tag::Byte,
             Self::Short(_) => Tag::Short,

--- a/crates/valence_nbt/src/value.rs
+++ b/crates/valence_nbt/src/value.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use crate::Compound;
+use crate::{Compound, tag::Tag};
 
 /// Represents an arbitrary NBT value.
 #[derive(Clone, PartialEq, Debug)]
@@ -73,6 +73,25 @@ impl List {
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    /// Returns the element type of this list.
+    pub fn element_type(&self) -> Tag {
+        match self {
+            List::End => Tag::End,
+            List::Byte(_) => Tag::Byte,
+            List::Short(_) => Tag::Short,
+            List::Int(_) => Tag::Int,
+            List::Long(_) => Tag::Long,
+            List::Float(_) => Tag::Float,
+            List::Double(_) => Tag::Double,
+            List::ByteArray(_) => Tag::ByteArray,
+            List::String(_) => Tag::String,
+            List::List(_) => Tag::List,
+            List::Compound(_) => Tag::Compound,
+            List::IntArray(_) => Tag::IntArray,
+            List::LongArray(_) => Tag::LongArray,
+        }
+    }
 }
 
 /// We can not create new identities in stable Rust using macros, so we provide
@@ -122,6 +141,24 @@ impl Value {
         Compound = Compound => is_compound as_compound as_compound_mut into_compound
         IntArray = Vec<i32> => is_int_array as_int_array as_int_array_mut into_int_array
         LongArray = Vec<i64> => is_long_array as_long_array as_long_array_mut into_long_array
+    }
+
+    /// Returns the type of this value.
+    pub fn get_type(&self) -> Tag {
+        match self {
+            Self::Byte(_) => Tag::Byte,
+            Self::Short(_) => Tag::Short,
+            Self::Int(_) => Tag::Int,
+            Self::Long(_) => Tag::Long,
+            Self::Float(_) => Tag::Float,
+            Self::Double(_) => Tag::Double,
+            Self::ByteArray(_) => Tag::ByteArray,
+            Self::String(_) => Tag::String,
+            Self::List(_) => Tag::List,
+            Self::Compound(_) => Tag::Compound,
+            Self::IntArray(_) => Tag::IntArray,
+            Self::LongArray(_) => Tag::LongArray,
+        }
     }
 }
 

--- a/crates/valence_nbt/src/value.rs
+++ b/crates/valence_nbt/src/value.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use crate::{Compound, tag::Tag};
+use crate::{tag::Tag, Compound};
 
 /// Represents an arbitrary NBT value.
 #[derive(Clone, PartialEq, Debug)]


### PR DESCRIPTION
To implement the hoverEvent show_item, we need an SNBT parser and a SNBT serializer.
An SNBT parser is implemented in this commit.