### PR TITLE
Fix data type of acknowledgement attribute

### DIFF
--- a/crates/valence_protocol/src/packets/c2s.rs
+++ b/crates/valence_protocol/src/packets/c2s.rs
@@ -134,7 +134,10 @@ pub mod play {
         pub salt: u64,
         pub argument_signatures: Vec<CommandArgumentSignature<'a>>,
         pub signed_preview: bool,
-        pub acknowledgement: MessageAcknowledgment<'a>,
+        // This is a bitset of 20; each bit represents one
+        // of the last 20 messages received and whether or not
+        // the message was acknowledged by the client
+        pub acknowledgement: &'a [u8; 3],
     }
 
     #[derive(Clone, Debug, Encode, EncodePacket, Decode, DecodePacket)]


### PR DESCRIPTION
I change the data type of `acknowledgement` attribute of the ChatCommand packet to a bitset of 20 length (see https://wiki.vg/Protocol#Chat_Command). It's an extent of #190 PR who edit the ChatMessage packet.


