### PR TITLE
[ECS] Inventory module unit tests

### DIFF
--- a/crates/valence_new/src/client/event.rs
+++ b/crates/valence_new/src/client/event.rs
@@ -871,7 +871,7 @@ fn handle_one_packet(
                 button: p.button,
                 mode: p.mode,
                 slot_changes: p.slots,
-                carried_item: None,
+                carried_item: p.carried_item,
             });
         }
         C2sPlayPacket::CloseContainerC2s(p) => {

--- a/crates/valence_new/src/inventory.rs
+++ b/crates/valence_new/src/inventory.rs
@@ -141,7 +141,7 @@ pub(crate) fn update_player_inventories(
                     client.inventory_state_id += 1;
                     let state_id = client.inventory_state_id.0;
                     for (i, slot) in inventory.slots.iter().enumerate() {
-                        if (modified_filtered >> 1) & 1 == 1 {
+                        if ((modified_filtered >> i) & 1) == 1 {
                             client.write_packet(&SetContainerSlotEncode {
                                 window_id: 0,
                                 state_id: VarInt(state_id),

--- a/crates/valence_new/src/inventory.rs
+++ b/crates/valence_new/src/inventory.rs
@@ -706,9 +706,10 @@ mod test {
 
         // Process a tick to get past the "on join" logic.
         app.update();
+        app.update();
         client_helper.clear_sent();
 
-        // Modify the inventory.
+        // Make the client click the slot and pick up the item.
         let state_id = app
             .world
             .get::<Client>(client_ent)
@@ -721,7 +722,7 @@ mod test {
             state_id: VarInt(state_id.0),
             slot_idx: 20,
             slots: vec![(20, None)],
-            carried_item: Some(ItemStack::new(ItemKind::Diamond, 1, None)),
+            carried_item: Some(ItemStack::new(ItemKind::Diamond, 2, None)),
         });
 
         app.update();
@@ -738,6 +739,19 @@ mod test {
             0,
             S2cPlayPacket::SetContainerContent(_) | S2cPlayPacket::SetContainerSlot(_)
         );
+        let inventory = app
+            .world
+            .get::<Inventory>(client_ent)
+            .expect("could not find inventory for client");
+        assert_eq!(inventory.slot(20), None);
+        let client = app
+            .world
+            .get::<Client>(client_ent)
+            .expect("could not find client");
+        assert_eq!(
+            client.cursor_item,
+            Some(ItemStack::new(ItemKind::Diamond, 2, None))
+        );
 
         Ok(())
     }
@@ -753,6 +767,7 @@ mod test {
         inventory.replace_slot(20, ItemStack::new(ItemKind::Diamond, 2, None));
 
         // Process a tick to get past the "on join" logic.
+        app.update();
         app.update();
         client_helper.clear_sent();
 

--- a/crates/valence_new/src/inventory.rs
+++ b/crates/valence_new/src/inventory.rs
@@ -606,7 +606,6 @@ mod test {
             .insert(open_inventory);
 
         app.update();
-        app.update();
 
         // Make assertions
         let sent_packets = client_helper.collect_sent()?;
@@ -642,7 +641,6 @@ mod test {
             .insert(open_inventory);
 
         app.update();
-        app.update();
         client_helper.clear_sent();
 
         // Close the inventory.
@@ -651,7 +649,6 @@ mod test {
             .expect("could not find client")
             .remove::<OpenInventory>();
 
-        app.update();
         app.update();
 
         // Make assertions
@@ -682,7 +679,6 @@ mod test {
             .insert(open_inventory);
 
         app.update();
-        app.update();
         client_helper.clear_sent();
 
         // Remove the inventory.
@@ -710,7 +706,6 @@ mod test {
 
         // Process a tick to get past the "on join" logic.
         app.update();
-        app.update();
         client_helper.clear_sent();
 
         // Make the client click the slot and pick up the item.
@@ -729,7 +724,6 @@ mod test {
             carried_item: Some(ItemStack::new(ItemKind::Diamond, 2, None)),
         });
 
-        app.update();
         app.update();
 
         // Make assertions
@@ -772,7 +766,6 @@ mod test {
 
         // Process a tick to get past the "on join" logic.
         app.update();
-        app.update();
         client_helper.clear_sent();
 
         // Modify the inventory.
@@ -782,7 +775,6 @@ mod test {
             .expect("could not find inventory for client");
         inventory.replace_slot(21, ItemStack::new(ItemKind::IronIngot, 1, None));
 
-        app.update();
         app.update();
 
         // Make assertions
@@ -809,7 +801,6 @@ mod test {
             .expect("could not find inventory for client");
         inventory.modified = u64::MAX;
 
-        app.update();
         app.update();
 
         // Make assertions
@@ -861,7 +852,6 @@ mod test {
         });
 
         app.update();
-        app.update();
 
         // Make assertions
         let sent_packets = client_helper.collect_sent()?;
@@ -909,7 +899,6 @@ mod test {
         inventory.replace_slot(5, ItemStack::new(ItemKind::IronIngot, 1, None));
 
         app.update();
-        app.update();
 
         // Make assertions
         let sent_packets = client_helper.collect_sent()?;
@@ -945,7 +934,6 @@ mod test {
             .expect("could not find inventory");
         inventory.modified = u64::MAX;
 
-        app.update();
         app.update();
 
         // Make assertions

--- a/crates/valence_new/src/inventory.rs
+++ b/crates/valence_new/src/inventory.rs
@@ -341,6 +341,10 @@ pub(crate) fn update_open_inventories(
         let Ok(inventory) = inventories.get_component::<Inventory>(open_inventory.entity) else {
             // the inventory no longer exists, so close the inventory
             commands.entity(client_entity).remove::<OpenInventory>();
+            let window_id = client.window_id;
+            client.write_packet(&CloseContainerS2c {
+                window_id,
+            });
             continue;
         };
 

--- a/crates/valence_new/src/inventory.rs
+++ b/crates/valence_new/src/inventory.rs
@@ -819,11 +819,7 @@ mod test {
         Ok(())
     }
 
-    #[test]
-    fn test_should_modify_open_inventory_click_container() -> anyhow::Result<()> {
-        let mut app = App::new();
-        let (client_ent, mut client_helper) = scenario_single_client(&mut app);
-
+    fn set_up_open_inventory(app: &mut App, client_ent: Entity) -> Entity {
         let inventory = Inventory::new(InventoryKind::Generic9x3);
         let inventory_ent = app.world.spawn(inventory).id();
 
@@ -833,6 +829,15 @@ mod test {
             .get_entity_mut(client_ent)
             .expect("could not find client")
             .insert(open_inventory);
+
+        inventory_ent
+    }
+
+    #[test]
+    fn test_should_modify_open_inventory_click_container() -> anyhow::Result<()> {
+        let mut app = App::new();
+        let (client_ent, mut client_helper) = scenario_single_client(&mut app);
+        let inventory_ent = set_up_open_inventory(&mut app, client_ent);
 
         // Process a tick to get past the "on join" logic.
         app.update();
@@ -890,16 +895,7 @@ mod test {
     fn test_should_modify_open_inventory_server_side() -> anyhow::Result<()> {
         let mut app = App::new();
         let (client_ent, mut client_helper) = scenario_single_client(&mut app);
-
-        let inventory = Inventory::new(InventoryKind::Generic9x3);
-        let inventory_ent = app.world.spawn(inventory).id();
-
-        // Open the inventory.
-        let open_inventory = OpenInventory::new(inventory_ent);
-        app.world
-            .get_entity_mut(client_ent)
-            .expect("could not find client")
-            .insert(open_inventory);
+        let inventory_ent = set_up_open_inventory(&mut app, client_ent);
 
         // Process a tick to get past the "on join" logic.
         app.update();
@@ -910,7 +906,7 @@ mod test {
             .world
             .get_mut::<Inventory>(inventory_ent)
             .expect("could not find inventory for client");
-        inventory.replace_slot(21, ItemStack::new(ItemKind::IronIngot, 1, None));
+        inventory.replace_slot(5, ItemStack::new(ItemKind::IronIngot, 1, None));
 
         app.update();
         app.update();
@@ -926,7 +922,7 @@ mod test {
             .get::<Inventory>(inventory_ent)
             .expect("could not find inventory for client");
         assert_eq!(
-            inventory.slot(21),
+            inventory.slot(5),
             Some(&ItemStack::new(ItemKind::IronIngot, 1, None))
         );
 
@@ -937,13 +933,7 @@ mod test {
     fn test_should_sync_entire_open_inventory() -> anyhow::Result<()> {
         let mut app = App::new();
         let (client_ent, mut client_helper) = scenario_single_client(&mut app);
-        let inventory = Inventory::new(InventoryKind::Generic9x3);
-        let inventory_ent = app.world.spawn(inventory).id();
-        let open_inventory = OpenInventory::new(inventory_ent);
-        app.world
-            .get_entity_mut(client_ent)
-            .expect("could not find client")
-            .insert(open_inventory);
+        let inventory_ent = set_up_open_inventory(&mut app, client_ent);
 
         // Process a tick to get past the "on join" logic.
         app.update();

--- a/crates/valence_new/src/inventory.rs
+++ b/crates/valence_new/src/inventory.rs
@@ -968,4 +968,40 @@ mod test {
             .expect("could not find inventory for client");
         assert_eq!(inventory.slot(36), None);
     }
+
+    #[test]
+    fn test_window_id_increments() {
+        let mut app = App::new();
+        let (client_ent, mut client_helper) = scenario_single_client(&mut app);
+        let inventory = Inventory::new(InventoryKind::Generic9x3);
+        let inventory_ent = app.world.spawn(inventory).id();
+
+        // Process a tick to get past the "on join" logic.
+        app.update();
+        client_helper.clear_sent();
+
+        for _ in 0..3 {
+            let open_inventory = OpenInventory::new(inventory_ent);
+            app.world
+                .get_entity_mut(client_ent)
+                .expect("could not find client")
+                .insert(open_inventory);
+
+            app.update();
+
+            app.world
+                .get_entity_mut(client_ent)
+                .expect("could not find client")
+                .remove::<OpenInventory>();
+
+            app.update();
+        }
+
+        // Make assertions
+        let client = app
+            .world
+            .get::<Client>(client_ent)
+            .expect("could not find client");
+        assert_eq!(client.window_id, 3);
+    }
 }

--- a/crates/valence_new/src/server.rs
+++ b/crates/valence_new/src/server.rs
@@ -354,6 +354,7 @@ pub fn build_plugin(
         .add_system_set_to_stage(
             CoreStage::PostUpdate,
             SystemSet::new()
+                .label("valence_core")
                 .with_system(init_entities)
                 .with_system(check_entity_invariants)
                 .with_system(check_instance_invariants.after(check_entity_invariants))
@@ -363,7 +364,13 @@ pub fn build_plugin(
                 .with_system(update_instances_post_client.after(update_clients))
                 .with_system(deinit_despawned_entities.after(update_instances_post_client))
                 .with_system(despawn_marked_entities.after(deinit_despawned_entities))
-                .with_system(update_entities.after(despawn_marked_entities))
+                .with_system(update_entities.after(despawn_marked_entities)),
+        )
+        .add_system_set_to_stage(
+            CoreStage::PostUpdate,
+            SystemSet::new()
+                .label("inventory")
+                .before("valence_core")
                 .with_system(update_open_inventories)
                 .with_system(handle_close_container)
                 .with_system(update_client_on_close_inventory.after(update_open_inventories))


### PR DESCRIPTION
Adds unit tests for all the inventory functionality that is currently implemented. It also fixes all the bugs that were found when creating these tests.

While I was working on this, I found that some of my tests were flakey because `update_client` was being scheduled before inventory systems that sent packets, resulting in packets being actually sent 1-3 updates later (depending on how things were scheduled).

### Test Plan

```bash
cargo test -p valence_new --tests
```
