### PR TITLE
Refactor PacketDecoder

### DIFF
--- a/crates/valence_protocol/src/var_int.rs
+++ b/crates/valence_protocol/src/var_int.rs
@@ -18,6 +18,7 @@ impl VarInt {
 
     /// Returns the exact number of bytes this varint will write when
     /// [`Encode::encode`] is called, assuming no error occurs.
+    #[inline(always)]
     pub fn written_size(self) -> usize {
         match self.0 {
             0 => 1,
@@ -25,6 +26,7 @@ impl VarInt {
         }
     }
 
+    #[inline]
     pub fn decode_partial(mut r: impl Read) -> Result<i32, VarIntDecodeError> {
         let mut val = 0;
         for i in 0..Self::MAX_SIZE {


### PR DESCRIPTION
There was little bit of code duplication inside of the `PacketDecoder`. Because of that I did the following changes:

- Extract the packet data and length extraction logic to `DecodeBuffer(BytesMut)`
- Extract the packet decompression logic to `DecompressionBuffer(Vec<u8>)`
- Extract packet decoding logic to `fn decode_packet`
- Refactor the following methods from `PacketDecoder` using the extracted code: `try_next_packet`, `collect_into_vec` and `has_next_packet`
- Sprinkle some `#[inline]` attributes
- Add some comments

NOTE: First I tried to extract all the logic into new `PacketDecoder` methods, but the borrow checker was complaining. Because of that I had to create the wrapper structs `DecodeBuffer` and `DecompressionBuffer` to give more granular control over mutation and make the borrow checker happy.

Anyways, I'm not entirely sure these modifications are worth merging, so feel free to reject them.

