### PR TITLE
[ECS] port even more examples

### DIFF
--- a/crates/valence_new/examples/conway.rs
+++ b/crates/valence_new/examples/conway.rs
@@ -10,7 +10,10 @@ pub fn main() {
     tracing_subscriber::fmt().init();
 
     App::new()
-        .add_plugin(ServerPlugin::new(()))
+        .add_plugin(ServerPlugin::new(()).with_biomes(vec![Biome {
+            grass_color: Some(0x00ff00),
+            ..Default::default()
+        }]))
         .add_system_to_stage(EventLoop, default_event_handler)
         .add_startup_system(setup)
         .add_system(init_clients)

--- a/crates/valence_new/examples/conway.rs
+++ b/crates/valence_new/examples/conway.rs
@@ -1,0 +1,185 @@
+use valence_new::client::despawn_disconnected_clients;
+use valence_new::client::event::{default_event_handler, StartDigging, StartSneaking};
+use valence_new::prelude::*;
+
+const SIZE_X: i32 = 100;
+const SIZE_Z: i32 = 100;
+const BOARD_Y: i32 = 64;
+
+pub fn main() {
+    tracing_subscriber::fmt().init();
+
+    App::new()
+        .add_plugin(ServerPlugin::new(()))
+        .add_system_to_stage(EventLoop, default_event_handler)
+        .add_startup_system(setup)
+        .add_system(init_clients)
+        .add_system(despawn_disconnected_clients)
+        .add_system_to_stage(EventLoop, alive_on_dig)
+        .add_system(update_board)
+        .add_system(pause_on_crouch)
+        .run();
+}
+
+fn setup(world: &mut World) {
+    let mut instance = world
+        .resource::<Server>()
+        .new_instance(DimensionId::default());
+
+    for z in -5..5 {
+        for x in -5..5 {
+            instance.insert_chunk([x, z], Chunk::default());
+        }
+    }
+
+    for z in 0..SIZE_Z {
+        for x in 0..SIZE_X {
+            instance.set_block_state([x, BOARD_Y, z], BlockState::GRASS_BLOCK);
+        }
+    }
+
+    world.spawn(instance);
+
+    let board = LifeBoard {
+        paused: false,
+        board: vec![false; (SIZE_X * SIZE_Z) as usize].into_boxed_slice(),
+        board_buf: vec![false; (SIZE_X * SIZE_Z) as usize].into_boxed_slice(),
+    };
+    world.insert_resource(board);
+}
+
+fn init_clients(
+    mut clients: Query<&mut Client, Added<Client>>,
+    instances: Query<Entity, With<Instance>>,
+) {
+    let instance = instances.get_single().unwrap();
+
+    for mut client in &mut clients {
+        client.set_position([
+            SIZE_X as f64 / 2.0,
+            BOARD_Y as f64 + 1.0,
+            SIZE_Z as f64 / 2.0,
+        ]);
+        client.set_instance(instance);
+        client.set_game_mode(GameMode::Survival);
+
+        client.send_message("Welcome to Conway's game of life in Minecraft!".italic());
+        client.send_message(
+            "Sneak to toggle running the simulation and the left mouse button to bring blocks to \
+             life."
+                .italic(),
+        );
+    }
+}
+
+#[derive(Resource)]
+struct LifeBoard {
+    pub paused: bool,
+    board: Box<[bool]>,
+    board_buf: Box<[bool]>,
+}
+
+impl LifeBoard {
+    pub fn set(&mut self, x: i32, z: i32, value: bool) {
+        self.board[Self::index(x, z).unwrap()] = value;
+    }
+
+    pub fn get(&self, x: i32, z: i32) -> bool {
+        self.board[Self::index(x, z).unwrap()]
+    }
+
+    #[inline]
+    fn index(x: i32, z: i32) -> Option<usize> {
+        let x = x as usize;
+        let z = z as usize;
+        if x > SIZE_X as usize || z > SIZE_Z as usize {
+            return None;
+        }
+        Some((x + z * SIZE_X as usize) % (SIZE_X * SIZE_Z) as usize)
+    }
+
+    fn count_live_neighbors(board: &Box<[bool]>, x: i32, z: i32) -> u8 {
+        let mut count = 0;
+
+        for dx in -1..=1 {
+            for dz in -1..=1 {
+                if dx == 0 && dz == 0 {
+                    continue;
+                }
+
+                let Some(index) = Self::index(x + dx, z + dz) else {
+                    continue;
+                };
+
+                if board[index] {
+                    count += 1;
+                }
+            }
+        }
+
+        count
+    }
+
+    pub fn update(&mut self) {
+        self.board_buf.iter_mut().enumerate().for_each(|(i, cell)| {
+            let x = i as i32 % SIZE_X;
+            let z = i as i32 / SIZE_Z;
+            let neighbors = Self::count_live_neighbors(&self.board, x, z);
+            let alive = &self.board[Self::index(x, z).unwrap()];
+
+            let new_alive = match (alive, neighbors) {
+                (true, n) if (2..=3).contains(&n) => true,
+                (false, 3) => true,
+                _ => false,
+            };
+
+            *cell = new_alive;
+        });
+        std::mem::swap(&mut self.board, &mut self.board_buf);
+    }
+}
+
+fn alive_on_dig(mut events: EventReader<StartDigging>, mut board: ResMut<LifeBoard>) {
+    for event in events.iter() {
+        let (x, z) = (event.position.x, event.position.z);
+        board.set(x, z, true);
+    }
+}
+
+fn update_board(mut board: ResMut<LifeBoard>, mut instances: Query<&mut Instance>) {
+    if !board.paused {
+        board.update();
+    }
+
+    let mut instance = instances.get_single_mut().unwrap();
+
+    for z in 0..SIZE_Z {
+        for x in 0..SIZE_X {
+            let alive = board.get(x, z);
+            let block = if alive {
+                BlockState::GRASS_BLOCK
+            } else {
+                BlockState::DIRT
+            };
+            instance.set_block_state([x, BOARD_Y, z], block);
+        }
+    }
+}
+
+fn pause_on_crouch(
+    mut events: EventReader<StartSneaking>,
+    mut board: ResMut<LifeBoard>,
+    mut clients: Query<&mut Client>,
+) {
+    for _ in events.iter() {
+        board.paused = !board.paused;
+
+        for mut client in clients.iter_mut() {
+            if board.paused {
+                client.set_action_bar("Paused.".italic());
+            } else {
+                client.set_action_bar("Playing.".italic());
+            }
+        }
+    }
+}

--- a/crates/valence_new/examples/entity_raycast.rs
+++ b/crates/valence_new/examples/entity_raycast.rs
@@ -1,0 +1,369 @@
+use glam::Vec3;
+use valence_new::client::despawn_disconnected_clients;
+use valence_new::client::event::default_event_handler;
+use valence_new::math::from_yaw_and_pitch;
+use valence_new::prelude::*;
+use valence_protocol::entity_meta::{Facing, PaintingKind, Pose};
+use valence_spatial_index::bvh::Bvh;
+use valence_spatial_index::{RaycastHit, SpatialIndex, WithAabb};
+
+const SPAWN_POS: BlockPos = BlockPos::new(0, 100, -5);
+const PLAYER_EYE_HEIGHT: f64 = 1.62;
+
+pub fn main() {
+    tracing_subscriber::fmt().init();
+
+    App::new()
+        .add_plugin(ServerPlugin::new(()))
+        .add_system_to_stage(EventLoop, default_event_handler)
+        .add_startup_system(setup)
+        .add_system(init_clients)
+        .add_system(despawn_disconnected_clients)
+        .add_system(rebuild_bvh)
+        .add_system(raycast)
+        .add_system(manage_cursors)
+        .run();
+}
+
+fn setup(world: &mut World) {
+    let mut instance = world
+        .resource::<Server>()
+        .new_instance(DimensionId::default());
+
+    for z in -5..5 {
+        for x in -5..5 {
+            instance.insert_chunk([x, z], Chunk::default());
+        }
+    }
+
+    instance.set_block_state(SPAWN_POS, BlockState::BEDROCK);
+
+    let raycaster = Raycaster::new();
+    let instance_ent = world.spawn((instance, raycaster)).id();
+
+    // ==== Item Frames ==== //
+    let mut e = McEntity::new(EntityKind::ItemFrame, instance_ent);
+    if let TrackedData::ItemFrame(i) = e.data_mut() {
+        i.set_rotation(Facing::North as i32);
+    }
+    e.set_position([2.0, 102.0, 0.0]);
+    world.spawn(e);
+
+    let mut e = McEntity::new(EntityKind::ItemFrame, instance_ent);
+    if let TrackedData::ItemFrame(i) = e.data_mut() {
+        i.set_rotation(Facing::East as i32);
+    }
+    e.set_position([3.0, 102.0, 0.0]);
+    world.spawn(e);
+
+    let mut e = McEntity::new(EntityKind::GlowItemFrame, instance_ent);
+    if let TrackedData::GlowItemFrame(i) = e.data_mut() {
+        i.set_rotation(Facing::South as i32);
+    }
+    e.set_position([4.0, 102.0, 0.0]);
+    world.spawn(e);
+
+    let mut e = McEntity::new(EntityKind::GlowItemFrame, instance_ent);
+    if let TrackedData::GlowItemFrame(i) = e.data_mut() {
+        i.set_rotation(Facing::West as i32);
+    }
+    e.set_position([5.0, 102.0, 0.0]);
+    world.spawn(e);
+
+    // ==== Paintings ==== //
+    let mut e = McEntity::new(EntityKind::Painting, instance_ent);
+    if let TrackedData::Painting(p) = e.data_mut() {
+        p.set_variant(PaintingKind::Pigscene);
+    }
+    e.set_yaw(180.0);
+    e.set_position([0.0, 102.0, 0.0]);
+    world.spawn(e);
+
+    let mut e = McEntity::new(EntityKind::Painting, instance_ent);
+    if let TrackedData::Painting(p) = e.data_mut() {
+        p.set_variant(PaintingKind::DonkeyKong);
+    }
+    e.set_yaw(90.0);
+    e.set_position([-4.0, 102.0, 0.0]);
+    world.spawn(e);
+
+    let mut e = McEntity::new(EntityKind::Painting, instance_ent);
+    if let TrackedData::Painting(p) = e.data_mut() {
+        p.set_variant(PaintingKind::Void);
+    }
+    e.set_position([-6.0, 102.0, 0.0]);
+    world.spawn(e);
+
+    let mut e = McEntity::new(EntityKind::Painting, instance_ent);
+    if let TrackedData::Painting(p) = e.data_mut() {
+        p.set_variant(PaintingKind::Aztec);
+    }
+    e.set_yaw(270.0);
+    e.set_position([-7.0, 102.0, 0.0]);
+    world.spawn(e);
+
+    // ==== Shulkers ==== //
+    let mut e = McEntity::new(EntityKind::Shulker, instance_ent);
+    if let TrackedData::Shulker(s) = e.data_mut() {
+        s.set_peek_amount(100);
+        s.set_attached_face(Facing::West);
+    }
+    e.set_position([-4.0, 102.0, -8.0]);
+    world.spawn(e);
+
+    let mut e = McEntity::new(EntityKind::Shulker, instance_ent);
+    if let TrackedData::Shulker(s) = e.data_mut() {
+        s.set_peek_amount(75);
+        s.set_attached_face(Facing::Up);
+    }
+    e.set_position([-1.0, 102.0, -8.0]);
+    world.spawn(e);
+
+    let mut e = McEntity::new(EntityKind::Shulker, instance_ent);
+    if let TrackedData::Shulker(s) = e.data_mut() {
+        s.set_peek_amount(50);
+        s.set_attached_face(Facing::Down);
+    }
+    e.set_position([2.0, 102.0, -8.0]);
+    world.spawn(e);
+
+    let mut e = McEntity::new(EntityKind::Shulker, instance_ent);
+    if let TrackedData::Shulker(s) = e.data_mut() {
+        s.set_peek_amount(25);
+        s.set_attached_face(Facing::East);
+    }
+    e.set_position([5.0, 102.0, -8.0]);
+    world.spawn(e);
+
+    let mut e = McEntity::new(EntityKind::Shulker, instance_ent);
+    if let TrackedData::Shulker(s) = e.data_mut() {
+        s.set_peek_amount(0);
+        s.set_attached_face(Facing::North);
+    }
+    e.set_position([8.0, 102.0, -8.0]);
+    world.spawn(e);
+
+    // ==== Slimes ==== //
+    let mut e = McEntity::new(EntityKind::Slime, instance_ent);
+    if let TrackedData::Slime(s) = e.data_mut() {
+        s.set_slime_size(30);
+    }
+    e.set_yaw(180.0);
+    e.set_head_yaw(180.0);
+    e.set_position([12.0, 102.0, 10.0]);
+    world.spawn(e);
+
+    let mut e = McEntity::new(EntityKind::MagmaCube, instance_ent);
+    if let TrackedData::MagmaCube(m) = e.data_mut() {
+        m.set_slime_size(30);
+    }
+    e.set_yaw(180.0);
+    e.set_head_yaw(180.0);
+    e.set_position([-12.0, 102.0, 10.0]);
+    world.spawn(e);
+
+    // ==== Sheep ==== //
+    let mut e = McEntity::new(EntityKind::Sheep, instance_ent);
+    if let TrackedData::Sheep(s) = e.data_mut() {
+        s.set_color(6);
+        s.set_child(true);
+    }
+    e.set_position([-5.0, 101.0, -4.5]);
+    e.set_yaw(270.0);
+    e.set_head_yaw(270.0);
+    world.spawn(e);
+
+    let mut e = McEntity::new(EntityKind::Sheep, instance_ent);
+    if let TrackedData::Sheep(s) = e.data_mut() {
+        s.set_color(6);
+    }
+    e.set_position([5.0, 101.0, -4.5]);
+    e.set_yaw(90.0);
+    e.set_head_yaw(90.0);
+    world.spawn(e);
+
+    // ==== Players ==== //
+    let player_poses = [
+        Pose::Standing,
+        Pose::Sneaking,
+        Pose::FallFlying,
+        Pose::Sleeping,
+        Pose::Swimming,
+        Pose::SpinAttack,
+        Pose::Dying,
+    ];
+
+    for (i, pose) in player_poses.into_iter().enumerate() {
+        let mut e = McEntity::new(EntityKind::Player, instance_ent);
+        if let TrackedData::Player(p) = e.data_mut() {
+            p.set_pose(pose);
+        }
+        e.set_position([-3.0 + i as f64 * 2.0, 104.0, -9.0]);
+        world.spawn(e);
+    }
+
+    // ==== Warden ==== //
+    let mut e = McEntity::new(EntityKind::Warden, instance_ent);
+    e.set_position([-7.0, 102.0, -4.5]);
+    e.set_yaw(270.0);
+    e.set_head_yaw(270.0);
+    world.spawn(e);
+
+    let mut e = McEntity::new(EntityKind::Warden, instance_ent);
+    if let TrackedData::Warden(w) = e.data_mut() {
+        w.set_pose(Pose::Emerging);
+    }
+    e.set_position([-7.0, 102.0, -6.5]);
+    e.set_yaw(270.0);
+    e.set_head_yaw(270.0);
+    world.spawn(e);
+
+    // ==== Goat ==== //
+    let mut e = McEntity::new(EntityKind::Goat, instance_ent);
+    e.set_position([5.0, 103.0, -4.5]);
+    e.set_yaw(270.0);
+    e.set_head_yaw(90.0);
+    world.spawn(e);
+
+    let mut e = McEntity::new(EntityKind::Goat, instance_ent);
+    if let TrackedData::Goat(g) = e.data_mut() {
+        g.set_pose(Pose::LongJumping);
+    }
+    e.set_position([5.0, 103.0, -3.5]);
+    e.set_yaw(270.0);
+    e.set_head_yaw(90.0);
+    world.spawn(e);
+
+    // ==== Giant ==== //
+    let mut e = McEntity::new(EntityKind::Giant, instance_ent);
+    e.set_position([20.0, 101.0, -5.0]);
+    e.set_yaw(270.0);
+    e.set_head_yaw(90.0);
+    world.spawn(e);
+}
+
+fn init_clients(
+    mut commands: Commands,
+    mut clients: Query<(Entity, &mut Client), Added<Client>>,
+    instances: Query<Entity, With<Instance>>,
+) {
+    let instance = instances.get_single().unwrap();
+
+    for (ent, mut client) in &mut clients {
+        client.set_position([
+            SPAWN_POS.x as f64 + 0.5,
+            SPAWN_POS.y as f64 + 1.0,
+            SPAWN_POS.z as f64 + 0.5,
+        ]);
+        client.set_instance(instance);
+        client.set_game_mode(GameMode::Creative);
+
+        let cursor = RaycastCursor {
+            bullet: None,
+            show: false,
+            target_pos: DVec3::ZERO,
+        };
+        commands.entity(ent).insert(cursor);
+
+        client.send_message(
+            "Press ".italic()
+                + "F3 + B".italic().color(Color::AQUA)
+                + " to show hitboxes.".italic(),
+        );
+    }
+}
+
+#[derive(Component)]
+struct Raycaster {
+    bvh: Bvh<WithAabb<Entity>>,
+}
+
+#[derive(Component)]
+struct RaycastCursor {
+    bullet: Option<Entity>,
+    show: bool,
+    target_pos: DVec3,
+}
+
+fn rebuild_bvh(
+    mut instances: Query<(Entity, &Instance, &mut Raycaster)>,
+    entities: Query<(Entity, &McEntity)>,
+) {
+    for (instance_ent, instance, mut raycaster) in &mut instances.iter_mut() {
+        raycaster.bvh.rebuild(
+            entities
+                .iter()
+                .filter(|(ent, mc_ent)| mc_ent.instance() == instance_ent)
+                .map(|(ent, mc_ent)| WithAabb::new(ent, mc_ent.hitbox())),
+        );
+    }
+}
+
+fn raycast(
+    mut instances: Query<(Entity, &Instance, &mut Raycaster)>,
+    mut clients: Query<(&mut Client, &mut RaycastCursor)>,
+    mut mc_entities: Query<&mut McEntity, Without<Client>>,
+) {
+    for (instance_ent, instance, mut raycaster) in &mut instances.iter_mut() {
+        for (mut client, cursor) in clients
+            .iter_mut()
+            .filter(|(c, _)| c.instance() == instance_ent)
+        {
+            let client_pos = client.position();
+
+            let origin = DVec3::new(client_pos.x, client_pos.y + PLAYER_EYE_HEIGHT, client_pos.z);
+            let direction = from_yaw_and_pitch(client.yaw(), client.pitch());
+            let direction = DVec3::new(direction.x as f64, direction.y as f64, direction.z as f64);
+            let not_self_or_bullet = |hit: RaycastHit<WithAabb<Entity>>| {
+                let Ok(ent) = mc_entities.get_component::<McEntity>(hit.object.object) else {
+                    return false;
+                };
+                if ent.kind() == EntityKind::ShulkerBullet {
+                    return false;
+                }
+                return true;
+            };
+
+            if let Some(hit) =
+                raycaster
+                    .bvh
+                    .raycast::<Entity>(origin, direction, not_self_or_bullet)
+            {
+                let hit_pos = origin + direction * hit.near;
+
+                cursor.show = true;
+                cursor.target_pos = hit_pos;
+
+                client.set_action_bar("Intersection".color(Color::GREEN));
+            } else {
+                cursor.show = false;
+                client.set_action_bar("No Intersection".color(Color::RED));
+            }
+        }
+    }
+}
+
+fn manage_cursors(
+    mut commands: Commands,
+    mut clients: Query<(&mut Client, &mut RaycastCursor)>,
+    mut mc_entities: Query<&mut McEntity, Without<Client>>,
+) {
+    for (mut client, cursor) in clients.iter_mut() {
+        if cursor.show && cursor.bullet.is_none() {
+            let bullet = McEntity::new(EntityKind::ShulkerBullet, client.instance());
+            cursor.bullet = Some(commands.spawn(bullet).id());
+        } else if !cursor.show && cursor.bullet.is_some() {
+            commands.entity(cursor.bullet.unwrap()).despawn();
+            cursor.bullet = None;
+        }
+
+        if let Some(bullet) = cursor.bullet {
+            if let Ok(mut bullet) = mc_entities.get_component_mut::<McEntity>(bullet) {
+                let mut target = cursor.target_pos;
+                let hitbox = bullet.hitbox();
+                target.y -= (hitbox.max.y - hitbox.min.y) / 2.0;
+                bullet.set_position(target);
+            }
+        }
+    }
+}

--- a/crates/valence_new/examples/particles.rs
+++ b/crates/valence_new/examples/particles.rs
@@ -1,0 +1,221 @@
+use valence_new::client::despawn_disconnected_clients;
+use valence_new::client::event::default_event_handler;
+use valence_new::prelude::*;
+use valence_protocol::packets::s2c::particle::Particle;
+
+const SPAWN_Y: i32 = 64;
+
+pub fn main() {
+    tracing_subscriber::fmt().init();
+
+    App::new()
+        .add_plugin(ServerPlugin::new(()))
+        .add_system_to_stage(EventLoop, default_event_handler)
+        .add_startup_system(setup)
+        .add_system(init_clients)
+        .add_system(despawn_disconnected_clients)
+        .add_system(manage_particles)
+        .run();
+}
+
+#[derive(Resource)]
+struct ParticleSpawner {
+    particles: Vec<Particle>,
+    index: usize,
+}
+
+impl ParticleSpawner {
+    pub fn new() -> Self {
+        Self {
+            particles: create_particle_vec(),
+            index: 0,
+        }
+    }
+
+    pub fn next(&mut self) {
+        self.index = (self.index + 1) % self.particles.len();
+    }
+}
+
+fn setup(world: &mut World) {
+    let mut instance = world
+        .resource::<Server>()
+        .new_instance(DimensionId::default());
+
+    for z in -5..5 {
+        for x in -5..5 {
+            instance.insert_chunk([x, z], Chunk::default());
+        }
+    }
+
+    for z in -25..25 {
+        for x in -25..25 {
+            instance.set_block_state([x, SPAWN_Y, z], BlockState::GRASS_BLOCK);
+        }
+    }
+
+    world.spawn(instance);
+
+    let spawner = ParticleSpawner::new();
+    world.insert_resource(spawner)
+}
+
+fn init_clients(
+    mut clients: Query<&mut Client, Added<Client>>,
+    instances: Query<Entity, With<Instance>>,
+) {
+    let instance = instances.get_single().unwrap();
+
+    for mut client in &mut clients {
+        client.set_position([0.0, SPAWN_Y as f64 + 1.0, 0.0]);
+        client.set_instance(instance);
+        client.set_game_mode(GameMode::Creative);
+    }
+}
+
+fn manage_particles(
+    mut spawner: ResMut<ParticleSpawner>,
+    server: Res<Server>,
+    mut clients: Query<&mut Client>,
+) {
+    if server.current_tick() % 20 == 0 {
+        spawner.next();
+    }
+
+    if server.current_tick() % 5 != 0 {
+        return;
+    }
+
+    let particle = &spawner.particles[spawner.index];
+    let name = dbg_name(particle);
+
+    let pos = [0.5, SPAWN_Y as f32 + 2.0, 2.5];
+    let offset = [0.5, 0.5, 0.5];
+
+    for mut client in clients.iter_mut() {
+        client.set_action_bar(name.clone().bold());
+        client.play_particle(particle, true, pos, offset, 0.1, 100);
+    }
+}
+
+fn dbg_name(dbg: &impl std::fmt::Debug) -> String {
+    let string = format!("{dbg:?}");
+
+    string
+        .split_once(|ch: char| !ch.is_ascii_alphabetic())
+        .map(|(fst, _)| fst.to_owned())
+        .unwrap_or(string)
+}
+
+fn create_particle_vec() -> Vec<Particle> {
+    vec![
+        Particle::AmbientEntityEffect,
+        Particle::AngryVillager,
+        Particle::Block(BlockState::OAK_PLANKS),
+        Particle::BlockMarker(BlockState::GOLD_BLOCK),
+        Particle::Bubble,
+        Particle::Cloud,
+        Particle::Crit,
+        Particle::DamageIndicator,
+        Particle::DragonBreath,
+        Particle::DrippingLava,
+        Particle::FallingLava,
+        Particle::LandingLava,
+        Particle::DrippingWater,
+        Particle::FallingWater,
+        Particle::Dust {
+            rgb: [1.0, 1.0, 0.0],
+            scale: 2.0,
+        },
+        Particle::DustColorTransition {
+            from_rgb: [1.0, 0.0, 0.0],
+            scale: 2.0,
+            to_rgb: [0.0, 1.0, 0.0],
+        },
+        Particle::Effect,
+        Particle::ElderGuardian,
+        Particle::EnchantedHit,
+        Particle::Enchant,
+        Particle::EndRod,
+        Particle::EntityEffect,
+        Particle::ExplosionEmitter,
+        Particle::Explosion,
+        Particle::SonicBoom,
+        Particle::FallingDust(BlockState::RED_SAND),
+        Particle::Firework,
+        Particle::Fishing,
+        Particle::Flame,
+        Particle::SculkSoul,
+        Particle::SculkCharge { roll: 1.0 },
+        Particle::SculkChargePop,
+        Particle::SoulFireFlame,
+        Particle::Soul,
+        Particle::Flash,
+        Particle::HappyVillager,
+        Particle::Composter,
+        Particle::Heart,
+        Particle::InstantEffect,
+        Particle::Item(None),
+        Particle::Item(Some(ItemStack::new(ItemKind::IronPickaxe, 1, None))),
+        Particle::VibrationBlock {
+            block_pos: [0, SPAWN_Y, 0].into(),
+            ticks: 50,
+        },
+        Particle::VibrationEntity {
+            entity_id: 0,
+            entity_eye_height: 1.0,
+            ticks: 50,
+        },
+        Particle::ItemSlime,
+        Particle::ItemSnowball,
+        Particle::LargeSmoke,
+        Particle::Lava,
+        Particle::Mycelium,
+        Particle::Note,
+        Particle::Poof,
+        Particle::Portal,
+        Particle::Rain,
+        Particle::Smoke,
+        Particle::Sneeze,
+        Particle::Spit,
+        Particle::SquidInk,
+        Particle::SweepAttack,
+        Particle::TotemOfUndying,
+        Particle::Underwater,
+        Particle::Splash,
+        Particle::Witch,
+        Particle::BubblePop,
+        Particle::CurrentDown,
+        Particle::BubbleColumnUp,
+        Particle::Nautilus,
+        Particle::Dolphin,
+        Particle::CampfireCosySmoke,
+        Particle::CampfireSignalSmoke,
+        Particle::DrippingHoney,
+        Particle::FallingHoney,
+        Particle::LandingHoney,
+        Particle::FallingNectar,
+        Particle::FallingSporeBlossom,
+        Particle::Ash,
+        Particle::CrimsonSpore,
+        Particle::WarpedSpore,
+        Particle::SporeBlossomAir,
+        Particle::DrippingObsidianTear,
+        Particle::FallingObsidianTear,
+        Particle::LandingObsidianTear,
+        Particle::ReversePortal,
+        Particle::WhiteAsh,
+        Particle::SmallFlame,
+        Particle::Snowflake,
+        Particle::DrippingDripstoneLava,
+        Particle::FallingDripstoneLava,
+        Particle::DrippingDripstoneWater,
+        Particle::FallingDripstoneWater,
+        Particle::GlowSquidInk,
+        Particle::Glow,
+        Particle::WaxOn,
+        Particle::WaxOff,
+        Particle::ElectricSpark,
+        Particle::Scrape,
+    ]
+}

--- a/crates/valence_new/examples/particles.rs
+++ b/crates/valence_new/examples/particles.rs
@@ -48,11 +48,7 @@ fn setup(world: &mut World) {
         }
     }
 
-    for z in -25..25 {
-        for x in -25..25 {
-            instance.set_block_state([x, SPAWN_Y, z], BlockState::GRASS_BLOCK);
-        }
-    }
+    instance.set_block_state([0, SPAWN_Y, 0], BlockState::BEDROCK);
 
     world.spawn(instance);
 
@@ -67,7 +63,7 @@ fn init_clients(
     let instance = instances.get_single().unwrap();
 
     for mut client in &mut clients {
-        client.set_position([0.0, SPAWN_Y as f64 + 1.0, 0.0]);
+        client.set_position([0.5, SPAWN_Y as f64 + 1.0, 0.5]);
         client.set_instance(instance);
         client.set_game_mode(GameMode::Creative);
     }
@@ -89,7 +85,7 @@ fn manage_particles(
     let particle = &spawner.particles[spawner.index];
     let name = dbg_name(particle);
 
-    let pos = [0.5, SPAWN_Y as f32 + 2.0, 2.5];
+    let pos = [0.5, SPAWN_Y as f64 + 2.0, 5.0];
     let offset = [0.5, 0.5, 0.5];
 
     for mut client in clients.iter_mut() {

--- a/crates/valence_new/examples/resource_pack.rs
+++ b/crates/valence_new/examples/resource_pack.rs
@@ -1,0 +1,102 @@
+use valence_new::client::despawn_disconnected_clients;
+use valence_new::client::event::{
+    default_event_handler, InteractWithEntity, ResourcePackStatus, ResourcePackStatusChange,
+};
+use valence_new::prelude::*;
+use valence_protocol::types::EntityInteraction;
+
+const SPAWN_Y: i32 = 64;
+
+pub fn main() {
+    tracing_subscriber::fmt().init();
+
+    App::new()
+        .add_plugin(ServerPlugin::new(()))
+        .add_system_to_stage(EventLoop, default_event_handler)
+        .add_system_to_stage(EventLoop, prompt_on_punch)
+        .add_system_to_stage(EventLoop, on_resource_pack_status)
+        .add_startup_system(setup)
+        .add_system(init_clients)
+        .add_system(despawn_disconnected_clients)
+        .run();
+}
+
+fn setup(world: &mut World) {
+    let mut instance = world
+        .resource::<Server>()
+        .new_instance(DimensionId::default());
+
+    for z in -5..5 {
+        for x in -5..5 {
+            instance.insert_chunk([x, z], Chunk::default());
+        }
+    }
+
+    for z in -25..25 {
+        for x in -25..25 {
+            instance.set_block_state([x, SPAWN_Y, z], BlockState::GRASS_BLOCK);
+        }
+    }
+
+    let instance_ent = world.spawn(instance).id();
+
+    let mut sheep = McEntity::new(EntityKind::Sheep, instance_ent);
+    sheep.set_position([0.0, SPAWN_Y as f64 + 1.0, 2.0]);
+    world.spawn(sheep);
+}
+
+fn init_clients(
+    mut clients: Query<&mut Client, Added<Client>>,
+    instances: Query<Entity, With<Instance>>,
+) {
+    let instance = instances.get_single().unwrap();
+
+    for mut client in &mut clients {
+        client.set_position([0.0, SPAWN_Y as f64 + 1.0, 0.0]);
+        client.set_instance(instance);
+        client.set_game_mode(GameMode::Creative);
+
+        client.send_message("Hit the sheep to prompt for the resource pack.".italic());
+    }
+}
+
+fn prompt_on_punch(mut clients: Query<&mut Client>, mut events: EventReader<InteractWithEntity>) {
+    for event in events.iter() {
+        let Ok(mut client) = clients.get_mut(event.client) else {
+            continue;
+        };
+        if event.interact == EntityInteraction::Attack {
+            client.set_resource_pack(
+                "https://github.com/valence-rs/valence/raw/main/assets/example_pack.zip",
+                "d7c6108849fb190ec2a49f2d38b7f1f897d9ce9f",
+                false,
+                None,
+            );
+        }
+    }
+}
+
+fn on_resource_pack_status(
+    mut clients: Query<&mut Client>,
+    mut events: EventReader<ResourcePackStatusChange>,
+) {
+    for event in events.iter() {
+        let Ok(mut client) = clients.get_mut(event.client) else {
+            continue;
+        };
+        match event.status {
+            ResourcePackStatus::Accepted => {
+                client.send_message("Resource pack accepted.".color(Color::GREEN));
+            }
+            ResourcePackStatus::Declined => {
+                client.send_message("Resource pack declined.".color(Color::RED));
+            }
+            ResourcePackStatus::FailedDownload => {
+                client.send_message("Resource pack failed to download.".color(Color::RED));
+            }
+            ResourcePackStatus::Loaded => {
+                client.send_message("Resource pack successfully downloaded.".color(Color::BLUE));
+            }
+        }
+    }
+}

--- a/crates/valence_new/src/client.rs
+++ b/crates/valence_new/src/client.rs
@@ -9,9 +9,9 @@ use tracing::warn;
 use uuid::Uuid;
 use valence_protocol::packets::s2c::play::{
     AcknowledgeBlockChange, CombatDeath, DisconnectPlay, EntityEvent, GameEvent, KeepAliveS2c,
-    LoginPlayOwned, PluginMessageS2c, RemoveEntitiesEncode, RespawnOwned, SetCenterChunk,
-    SetDefaultSpawnPosition, SetEntityMetadata, SetEntityVelocity, SetRenderDistance,
-    SynchronizePlayerPosition, SystemChatMessage, UnloadChunk,
+    LoginPlayOwned, PluginMessageS2c, RemoveEntitiesEncode, ResourcePackS2c, RespawnOwned,
+    SetCenterChunk, SetDefaultSpawnPosition, SetEntityMetadata, SetEntityVelocity,
+    SetRenderDistance, SynchronizePlayerPosition, SystemChatMessage, UnloadChunk,
 };
 use valence_protocol::types::{GameEventKind, GameMode, Property, SyncPlayerPosLookFlags};
 use valence_protocol::{
@@ -390,7 +390,7 @@ impl Client {
     pub fn send_message(&mut self, msg: impl Into<Text>) {
         self.write_packet(&SystemChatMessage {
             chat: msg.into(),
-            overlay: false
+            overlay: false,
         });
     }
 
@@ -410,6 +410,31 @@ impl Client {
             reason: reason.into(),
         });
         self.is_disconnected = true;
+    }
+
+    /// Requests that the client download and enable a resource pack.
+    ///
+    /// # Arguments
+    /// * `url` - The URL of the resource pack file.
+    /// * `hash` - The SHA-1 hash of the resource pack file. Any value other
+    ///   than a 40-character hexadecimal string is ignored by the client.
+    /// * `forced` - Whether a client should be kicked from the server upon
+    ///   declining the pack (this is enforced client-side)
+    /// * `prompt_message` - A message to be displayed with the resource pack
+    ///   dialog.
+    pub fn set_resource_pack(
+        &mut self,
+        url: &str,
+        hash: &str,
+        forced: bool,
+        prompt_message: Option<Text>,
+    ) {
+        self.write_packet(&ResourcePackS2c {
+            url,
+            hash,
+            forced,
+            prompt_message,
+        });
     }
 }
 

--- a/crates/valence_new/src/client.rs
+++ b/crates/valence_new/src/client.rs
@@ -481,17 +481,15 @@ impl Client {
         &mut self,
         particle: &Particle,
         long_distance: bool,
-        position: impl Into<Vec3>,
+        position: impl Into<DVec3>,
         offset: impl Into<Vec3>,
         max_speed: f32,
         count: i32,
     ) {
-        let p = position.into();
-        let position = [p.x as f64, p.y as f64, p.y as f64];
         self.write_packet(&ParticleS2c {
             particle: particle.clone(),
             long_distance,
-            position,
+            position: position.into().into(),
             offset: offset.into().into(),
             max_speed,
             count,

--- a/crates/valence_new/src/client.rs
+++ b/crates/valence_new/src/client.rs
@@ -10,8 +10,9 @@ use uuid::Uuid;
 use valence_protocol::packets::s2c::play::{
     AcknowledgeBlockChange, CombatDeath, DisconnectPlay, EntityEvent, GameEvent, KeepAliveS2c,
     LoginPlayOwned, PluginMessageS2c, RemoveEntitiesEncode, ResourcePackS2c, RespawnOwned,
-    SetCenterChunk, SetDefaultSpawnPosition, SetEntityMetadata, SetEntityVelocity,
-    SetRenderDistance, SynchronizePlayerPosition, SystemChatMessage, UnloadChunk,
+    SetActionBarText, SetCenterChunk, SetDefaultSpawnPosition, SetEntityMetadata,
+    SetEntityVelocity, SetRenderDistance, SetSubtitleText, SetTitleAnimationTimes, SetTitleText,
+    SynchronizePlayerPosition, SystemChatMessage, UnloadChunk,
 };
 use valence_protocol::types::{GameEventKind, GameMode, Property, SyncPlayerPosLookFlags};
 use valence_protocol::{
@@ -434,6 +435,44 @@ impl Client {
             hash,
             forced,
             prompt_message,
+        });
+    }
+
+    /// Sets the title this client sees.
+    ///
+    /// A title is a large piece of text displayed in the center of the screen
+    /// which may also include a subtitle underneath it. The title can be
+    /// configured to fade in and out using the [`SetTitleAnimationTimes`]
+    /// struct.
+    pub fn set_title(
+        &mut self,
+        title: impl Into<Text>,
+        subtitle: impl Into<Text>,
+        animation: impl Into<Option<SetTitleAnimationTimes>>,
+    ) {
+        let title = title.into();
+        let subtitle = subtitle.into();
+
+        self.write_packet(&SetTitleText { title_text: title });
+
+        if !subtitle.is_empty() {
+            self.write_packet(&SetSubtitleText {
+                subtitle_text: subtitle,
+            });
+        }
+
+        if let Some(anim) = animation.into() {
+            self.write_packet(&anim);
+        }
+    }
+
+    /// Sets the action bar for this client.
+    ///
+    /// The action bar is a small piece of text displayed at the bottom of the
+    /// screen, above the hotbar.
+    pub fn set_action_bar(&mut self, text: impl Into<Text>) {
+        self.write_packet(&SetActionBarText {
+            action_bar_text: text.into(),
         });
     }
 }

--- a/crates/valence_new/src/client.rs
+++ b/crates/valence_new/src/client.rs
@@ -7,10 +7,11 @@ use bytes::BytesMut;
 use glam::{DVec3, Vec3};
 use tracing::warn;
 use uuid::Uuid;
+use valence_protocol::packets::s2c::particle::Particle;
 use valence_protocol::packets::s2c::play::{
     AcknowledgeBlockChange, CombatDeath, DisconnectPlay, EntityEvent, GameEvent, KeepAliveS2c,
-    LoginPlayOwned, PluginMessageS2c, RemoveEntitiesEncode, ResourcePackS2c, RespawnOwned,
-    SetActionBarText, SetCenterChunk, SetDefaultSpawnPosition, SetEntityMetadata,
+    LoginPlayOwned, ParticleS2c, PluginMessageS2c, RemoveEntitiesEncode, ResourcePackS2c,
+    RespawnOwned, SetActionBarText, SetCenterChunk, SetDefaultSpawnPosition, SetEntityMetadata,
     SetEntityVelocity, SetRenderDistance, SetSubtitleText, SetTitleAnimationTimes, SetTitleText,
     SynchronizePlayerPosition, SystemChatMessage, UnloadChunk,
 };
@@ -474,6 +475,27 @@ impl Client {
         self.write_packet(&SetActionBarText {
             action_bar_text: text.into(),
         });
+    }
+
+    pub fn play_particle(
+        &mut self,
+        particle: &Particle,
+        long_distance: bool,
+        position: impl Into<Vec3>,
+        offset: impl Into<Vec3>,
+        max_speed: f32,
+        count: i32,
+    ) {
+        let p = position.into();
+        let position = [p.x as f64, p.y as f64, p.y as f64];
+        self.write_packet(&ParticleS2c {
+            particle: particle.clone(),
+            long_distance,
+            position,
+            offset: offset.into().into(),
+            max_speed,
+            count,
+        })
     }
 }
 


### PR DESCRIPTION
- add client.set_resource_pack
- refactor resource pack events to unsplit them
- port resource pack example
- add set_title and set_action_bar to client
- add play_particle to client
- port particles example
- port conway example
- partially port entity_raycast example

I was unable to finish the entity_raycast example because I don't really know how the spatial index package works, but if you fix the type errors it should just work.
