### PR TITLE
fix playground template, add build script

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,8 +26,6 @@ body:
       label: Minimal Reproducible Example
       description: Do you have a playground to reproduce this bug? Paste it here. It should be a minimal example that exhibits the behavior. If the problem can be reproduced with one of the examples, just indicate which one instead.
       render: Rust
-    validations:
-      required: true
   - type: textarea
     attributes:
       label: Steps To Reproduce

--- a/crates/playground/build.rs
+++ b/crates/playground/build.rs
@@ -1,0 +1,21 @@
+use std::path::Path;
+
+fn main() {
+    let current = std::env::current_dir().unwrap();
+    println!("current directory: {}", current.display());
+
+    let src = current.join(Path::new("src/playground.template.rs"));
+    let dst = current.join(Path::new("src/playground.rs"));
+
+    if dst.exists() {
+        println!("{dst:?} already exists, skipping");
+        return;
+    }
+
+    if !src.exists() {
+        println!("{src:?} does not exist, skipping");
+        return;
+    }
+
+    std::fs::copy(src, dst).unwrap();
+}

--- a/crates/playground/src/playground.template.rs
+++ b/crates/playground/src/playground.template.rs
@@ -7,16 +7,12 @@ use crate::extras::*;
 
 const SPAWN_Y: i32 = 64;
 
-pub fn main() {
-    tracing_subscriber::fmt().init();
-
-    App::new()
-        .add_plugin(ServerPlugin::new(()))
+pub fn build_app(app: &mut App) {
+    app.add_plugin(ServerPlugin::new(()))
         .add_system_to_stage(EventLoop, default_event_handler)
         .add_startup_system(setup)
         .add_system(init_clients)
-        .add_system(despawn_disconnected_clients)
-        .run();
+        .add_system(despawn_disconnected_clients);
 }
 
 fn setup(world: &mut World) {


### PR DESCRIPTION
<!-- Please make sure that your PR is aligned with the guidelines in CONTRIBUTING.md to the best of your ability. -->
<!-- Good PRs have tests! Make sure you have sufficient test coverage. -->

## Description

<!-- Describe the changes you've made. You may include any justification you want here. -->

- fixes the playground not building by default by adding a build script that makes sure the playgound is always there
- makes the playground optional in the bug report issue template
- fixes the template so it actually builds

## Test Plan

<!-- Explain how you tested your changes, and include any code that you used to test this. -->
<!-- If there is an example that is sufficient to use in place of a playground, replace the playground section with a note that indicates this.  -->

<details>

<summary>Playground</summary>

```rust
PASTE YOUR PLAYGROUND CODE HERE
```

</details>

<!-- You need to include steps regardless of whether or not you are using a playground. -->
Steps:
1. `cargo build -p playground`

#### Related

<!-- Link to any issues that have context for this or that this PR fixes. -->
