### PR TITLE
Port terrain example

### DIFF
--- a/crates/valence_new/examples/terrain.rs
+++ b/crates/valence_new/examples/terrain.rs
@@ -79,7 +79,9 @@ fn setup(world: &mut World) {
     });
 
     // Chunks are generated in a thread pool for parallelism and to avoid blocking
-    // the main tick loop.
+    // the main tick loop. You can use your thread pool of choice here (rayon,
+    // bevy_tasks, etc). Only the standard library is used in the example for the
+    // sake of simplicity.
     //
     // If your chunk generation algorithm is inexpensive then there's no need to do
     // this.

--- a/crates/valence_new/examples/terrain.rs
+++ b/crates/valence_new/examples/terrain.rs
@@ -1,0 +1,344 @@
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::thread;
+use std::time::SystemTime;
+
+use flume::{Receiver, Sender};
+use noise::{NoiseFn, SuperSimplex};
+use tracing::info;
+use valence_new::client::despawn_disconnected_clients;
+use valence_new::client::event::default_event_handler;
+use valence_new::prelude::*;
+
+const SPAWN_POS: DVec3 = DVec3::new(0.0, 200.0, 0.0);
+const SECTION_COUNT: usize = 24;
+
+struct ChunkWorkerState {
+    sender: Sender<(ChunkPos, Chunk)>,
+    receiver: Receiver<ChunkPos>,
+    // Noise functions
+    density: SuperSimplex,
+    hilly: SuperSimplex,
+    stone: SuperSimplex,
+    gravel: SuperSimplex,
+    grass: SuperSimplex,
+}
+
+#[derive(Resource)]
+struct GameState {
+    /// Chunks that need to be generated. Chunks without a priority have already
+    /// been sent to the thread pool.
+    pending: HashMap<ChunkPos, Option<Priority>>,
+    sender: Sender<ChunkPos>,
+    receiver: Receiver<(ChunkPos, Chunk)>,
+}
+
+/// The order in which chunks should be processed by the thread pool. Smaller
+/// values are sent first.
+type Priority = u64;
+
+pub fn main() {
+    tracing_subscriber::fmt().init();
+
+    App::new()
+        .add_plugin(ServerPlugin::new(()))
+        .add_system_to_stage(EventLoop, default_event_handler)
+        .add_system_set(PlayerList::default_system_set())
+        .add_startup_system(setup)
+        .add_system(init_clients)
+        .add_system(remove_unviewed_chunks.after(init_clients))
+        .add_system(update_client_views.after(remove_unviewed_chunks))
+        .add_system(send_recv_chunks.after(update_client_views))
+        .add_system(despawn_disconnected_clients)
+        .run();
+}
+
+fn setup(world: &mut World) {
+    let seconds_per_day = 86_400;
+
+    let seed = (SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        / seconds_per_day) as u32;
+
+    info!("current seed: {seed}");
+
+    let (finished_sender, finished_receiver) = flume::unbounded();
+    let (pending_sender, pending_receiver) = flume::unbounded();
+
+    let state = Arc::new(ChunkWorkerState {
+        sender: finished_sender,
+        receiver: pending_receiver,
+        density: SuperSimplex::new(seed),
+        hilly: SuperSimplex::new(seed.wrapping_add(1)),
+        stone: SuperSimplex::new(seed.wrapping_add(2)),
+        gravel: SuperSimplex::new(seed.wrapping_add(3)),
+        grass: SuperSimplex::new(seed.wrapping_add(4)),
+    });
+
+    // Chunks are generated in a thread pool for parallelism and to avoid blocking
+    // the main tick loop.
+    //
+    // If your chunk generation algorithm is inexpensive then there's no need to do
+    // this.
+    for _ in 0..thread::available_parallelism().unwrap().get() {
+        let state = state.clone();
+        thread::spawn(move || chunk_worker(state));
+    }
+
+    world.insert_resource(GameState {
+        pending: HashMap::new(),
+        sender: pending_sender,
+        receiver: finished_receiver,
+    });
+
+    let instance = world
+        .resource::<Server>()
+        .new_instance(DimensionId::default());
+
+    world.spawn(instance);
+}
+
+fn init_clients(
+    mut clients: Query<&mut Client, Added<Client>>,
+    instances: Query<Entity, With<Instance>>,
+    mut commands: Commands,
+) {
+    for mut client in &mut clients {
+        let instance = instances.single();
+
+        client.set_flat(true);
+        client.set_game_mode(GameMode::Creative);
+        client.set_position(SPAWN_POS);
+        client.set_instance(instance);
+
+        commands.spawn(McEntity::with_uuid(
+            EntityKind::Player,
+            instance,
+            client.uuid(),
+        ));
+    }
+}
+
+fn remove_unviewed_chunks(mut instances: Query<&mut Instance>) {
+    instances
+        .single_mut()
+        .retain_chunks(|_, chunk| chunk.is_viewed_mut());
+}
+
+fn update_client_views(
+    mut instances: Query<&mut Instance>,
+    mut clients: Query<&mut Client>,
+    mut state: ResMut<GameState>,
+) {
+    let instance = instances.single_mut();
+
+    for client in &mut clients {
+        let view = client.view();
+        let queue_pos = |pos| {
+            if instance.chunk(pos).is_none() {
+                match state.pending.entry(pos) {
+                    Entry::Occupied(mut oe) => {
+                        if let Some(priority) = oe.get_mut() {
+                            let dist = view.pos.distance_squared(pos);
+                            *priority = (*priority).min(dist);
+                        }
+                    }
+                    Entry::Vacant(ve) => {
+                        let dist = view.pos.distance_squared(pos);
+                        ve.insert(Some(dist));
+                    }
+                }
+            }
+        };
+
+        // Queue all the new chunks in the view to be sent to the thread pool.
+        if client.is_added() {
+            view.iter().for_each(queue_pos);
+        } else {
+            let old_view = client.old_view();
+            if old_view != view {
+                view.diff(old_view).for_each(queue_pos);
+            }
+        }
+    }
+}
+
+fn send_recv_chunks(mut instances: Query<&mut Instance>, state: ResMut<GameState>) {
+    let mut instance = instances.single_mut();
+    let state = state.into_inner();
+
+    // Insert the chunks that are finished generating into the instance.
+    for (pos, chunk) in state.receiver.drain() {
+        instance.insert_chunk(pos, chunk);
+        assert!(state.pending.remove(&pos).is_some());
+    }
+
+    // Collect all the new chunks that need to be loaded this tick.
+    let mut to_send = vec![];
+
+    for (pos, priority) in &mut state.pending {
+        if let Some(pri) = priority.take() {
+            to_send.push((pri, pos));
+        }
+    }
+
+    // Sort chunks by ascending priority.
+    to_send.sort_unstable_by_key(|(pri, _)| *pri);
+
+    // Send the sorted chunks to be loaded.
+    for (_, pos) in to_send {
+        let _ = state.sender.try_send(*pos);
+    }
+}
+
+fn chunk_worker(state: Arc<ChunkWorkerState>) {
+    while let Ok(pos) = state.receiver.recv() {
+        let mut chunk = Chunk::new(SECTION_COUNT);
+
+        for offset_z in 0..16 {
+            for offset_x in 0..16 {
+                let x = offset_x as i32 + pos.x * 16;
+                let z = offset_z as i32 + pos.z * 16;
+
+                let mut in_terrain = false;
+                let mut depth = 0;
+
+                // Fill in the terrain column.
+                for y in (0..chunk.section_count() as i32 * 16).rev() {
+                    const WATER_HEIGHT: i32 = 55;
+
+                    let p = DVec3::new(x as f64, y as f64, z as f64);
+
+                    let block = if has_terrain_at(&state, p) {
+                        let gravel_height = WATER_HEIGHT
+                            - 1
+                            - (fbm(&state.gravel, p / 10.0, 3, 2.0, 0.5) * 6.0).floor() as i32;
+
+                        if in_terrain {
+                            if depth > 0 {
+                                depth -= 1;
+                                if y < gravel_height {
+                                    BlockState::GRAVEL
+                                } else {
+                                    BlockState::DIRT
+                                }
+                            } else {
+                                BlockState::STONE
+                            }
+                        } else {
+                            in_terrain = true;
+                            let n = noise01(&state.stone, p / 15.0);
+
+                            depth = (n * 5.0).round() as u32;
+
+                            if y < gravel_height {
+                                BlockState::GRAVEL
+                            } else if y < WATER_HEIGHT - 1 {
+                                BlockState::DIRT
+                            } else {
+                                BlockState::GRASS_BLOCK
+                            }
+                        }
+                    } else {
+                        in_terrain = false;
+                        depth = 0;
+                        if y < WATER_HEIGHT {
+                            BlockState::WATER
+                        } else {
+                            BlockState::AIR
+                        }
+                    };
+
+                    chunk.set_block_state(offset_x, y as usize, offset_z, block);
+                }
+
+                // Add grass on top of grass blocks.
+                for y in (0..chunk.section_count() * 16).rev() {
+                    if chunk.block_state(offset_x, y, offset_z).is_air()
+                        && chunk.block_state(offset_x, y - 1, offset_z) == BlockState::GRASS_BLOCK
+                    {
+                        let p = DVec3::new(x as f64, y as f64, z as f64);
+                        let density = fbm(&state.grass, p / 5.0, 4, 2.0, 0.7);
+
+                        if density > 0.55 {
+                            if density > 0.7
+                                && chunk.block_state(offset_x, y + 1, offset_z).is_air()
+                            {
+                                let upper =
+                                    BlockState::TALL_GRASS.set(PropName::Half, PropValue::Upper);
+                                let lower =
+                                    BlockState::TALL_GRASS.set(PropName::Half, PropValue::Lower);
+
+                                chunk.set_block_state(offset_x, y + 1, offset_z, upper);
+                                chunk.set_block_state(offset_x, y, offset_z, lower);
+                            } else {
+                                chunk.set_block_state(offset_x, y, offset_z, BlockState::GRASS);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        let _ = state.sender.try_send((pos, chunk));
+    }
+}
+
+fn has_terrain_at(state: &ChunkWorkerState, p: DVec3) -> bool {
+    let hilly = lerp(0.1, 1.0, noise01(&state.hilly, p / 400.0)).powi(2);
+
+    let lower = 15.0 + 100.0 * hilly;
+    let upper = lower + 100.0 * hilly;
+
+    if p.y <= lower {
+        return true;
+    } else if p.y >= upper {
+        return false;
+    }
+
+    let density = 1.0 - lerpstep(lower, upper, p.y);
+
+    let n = fbm(&state.density, p / 100.0, 4, 2.0, 0.5);
+
+    n < density
+}
+
+fn lerp(a: f64, b: f64, t: f64) -> f64 {
+    a * (1.0 - t) + b * t
+}
+
+fn lerpstep(edge0: f64, edge1: f64, x: f64) -> f64 {
+    if x <= edge0 {
+        0.0
+    } else if x >= edge1 {
+        1.0
+    } else {
+        (x - edge0) / (edge1 - edge0)
+    }
+}
+
+fn fbm(noise: &SuperSimplex, p: DVec3, octaves: u32, lacunarity: f64, persistence: f64) -> f64 {
+    let mut freq = 1.0;
+    let mut amp = 1.0;
+    let mut amp_sum = 0.0;
+    let mut sum = 0.0;
+
+    for _ in 0..octaves {
+        let n = noise01(noise, p * freq);
+        sum += n * amp;
+        amp_sum += amp;
+
+        freq *= lacunarity;
+        amp *= persistence;
+    }
+
+    // Scale the output to [0, 1]
+    sum / amp_sum
+}
+
+fn noise01(noise: &SuperSimplex, p: DVec3) -> f64 {
+    (noise.get(p.to_array()) + 1.0) / 2.0
+}

--- a/crates/valence_new/src/client.rs
+++ b/crates/valence_new/src/client.rs
@@ -717,6 +717,10 @@ fn update_one_client(
                     });
                 }
 
+                if let Some(chunk) = &cell.chunk {
+                    chunk.mark_viewed();
+                }
+
                 // Send entity spawn packets for entities entering the client's view.
                 for &(id, src_pos) in &cell.incoming {
                     if src_pos.map_or(true, |p| !old_view.contains(p)) {
@@ -795,6 +799,8 @@ fn update_one_client(
                         &mut client.enc,
                         &mut client.scratch,
                     );
+
+                    chunk.mark_viewed();
                 }
 
                 // Load all the entities in this cell.
@@ -812,7 +818,7 @@ fn update_one_client(
     } else if old_view != view {
         // Client changed their view without changing the instance.
 
-        // Uunload chunks and entities in the old view and load chunks and entities in
+        // Unload chunks and entities in the old view and load chunks and entities in
         // the new view. We don't need to do any work where the old and new view
         // overlap.
         old_view.diff_for_each(view, |pos| {
@@ -846,6 +852,8 @@ fn update_one_client(
                         &mut client.enc,
                         &mut client.scratch,
                     );
+
+                    chunk.mark_viewed();
                 }
 
                 // Load all the entities in this cell.

--- a/crates/valence_new/src/lib.rs
+++ b/crates/valence_new/src/lib.rs
@@ -62,7 +62,7 @@ pub mod prelude {
     pub use instance::{Chunk, Instance};
     pub use inventory::{Inventory, InventoryKind, OpenInventory};
     pub use player_list::{PlayerList, PlayerListEntry};
-    pub use protocol::block::BlockState;
+    pub use protocol::block::{BlockState, PropName, PropValue};
     pub use protocol::ident::Ident;
     pub use protocol::text::{Color, Text, TextFormat};
     pub use protocol::types::GameMode;

--- a/crates/valence_new/src/view.rs
+++ b/crates/valence_new/src/view.rs
@@ -34,6 +34,13 @@ impl ChunkPos {
     pub fn at(x: f64, z: f64) -> Self {
         Self::new((x / 16.0).floor() as i32, (z / 16.0).floor() as i32)
     }
+
+    pub fn distance_squared(self, other: Self) -> u64 {
+        let diff_x = other.x as i64 - self.x as i64;
+        let diff_z = other.z as i64 - self.z as i64;
+
+        (diff_x * diff_x + diff_z * diff_z) as u64
+    }
 }
 
 impl From<(i32, i32)> for ChunkPos {
@@ -91,12 +98,8 @@ impl ChunkView {
 
     #[inline]
     pub fn contains(self, pos: ChunkPos) -> bool {
-        let true_dist = self.dist as i64 + EXTRA_VIEW_RADIUS as i64;
-
-        let diff_x = pos.x as i64 - self.pos.x as i64;
-        let diff_z = pos.z as i64 - self.pos.z as i64;
-
-        diff_x * diff_x + diff_z * diff_z <= true_dist * true_dist
+        let true_dist = self.dist as u64 + EXTRA_VIEW_RADIUS as u64;
+        self.pos.distance_squared(pos) <= true_dist * true_dist
     }
 
     /// Returns an iterator over all the chunk positions in this view.


### PR DESCRIPTION
- Added `viewed` boolean to chunks, which is used to efficiently track chunks that can be removed from an instance because nobody is looking at it.
- Added `to_unloaded` function to loaded chunks. Used to make an unloaded clone of a loaded chunk.
- Ported terrain example to `valence_new`.
- Terrain generation is now fully asynchronous and will no longer block the main tick loop.
  - Unloaded chunks closer to players are prioritized over chunks that are further away.
# Test Plan

```bash
cargo r -p valence_new --example terrain
```