### PR TITLE
make dropping an item in creative not crash the server

### DIFF
--- a/crates/valence/src/inventory.rs
+++ b/crates/valence/src/inventory.rs
@@ -542,6 +542,10 @@ pub(crate) fn handle_set_slot_creative(
                 // the client is not in creative mode, ignore
                 continue;
             }
+            if event.slot < 0 || event.slot >= inventory.slot_count() as i16 {
+                // the client is trying to interact with a slot that does not exist, ignore
+                continue;
+            }
             inventory.replace_slot(event.slot as u16, event.clicked_item.clone());
             inventory.modified &= !(1 << event.slot); // clear the modified bit, since we are about to send the update
             client.inventory_state_id += 1;


### PR DESCRIPTION
<!-- Please make sure that your PR is aligned with the guidelines in CONTRIBUTING.md to the best of your ability. -->
<!-- Good PRs have tests! Make sure you have sufficient test coverage. -->

## Description

<!-- Describe the changes you've made. You may include any justification you want here. -->
Added a quick and dirty bounds check because we haven't created drop item/itemstack event(s) yet.

## Test Plan

<!-- Explain how you tested your changes, and include any code that you used to test this. -->
<!-- If there is an example that is sufficient to use in place of a playground, replace the playground section with a note that indicates this.  -->

use the `building` example

<!-- You need to include steps regardless of whether or not you are using a playground. -->
Steps:
1. `cargo run --example building`
2. open inventory
3. pick an item
4. drop the item outside of the inventory window
5. see that the server does not panic

#### Related

<!-- Link to any issues that have context for this or that this PR fixes. -->
fixes #233
