### PR TITLE
Colorise the inspector output based on S2C or C2S

### DIFF
--- a/crates/packet_inspector/Cargo.toml
+++ b/crates/packet_inspector/Cargo.toml
@@ -7,6 +7,7 @@ description = "A simple Minecraft proxy for inspecting packets."
 [dependencies]
 anyhow = "1"
 clap = { version = "4.0.30", features = ["derive"] }
+owo-colors = "3.5.0"
 regex = "1.6.0"
 tokio = { version = "1", features = ["full"] }
 tracing-subscriber = "0.3.16"

--- a/crates/packet_inspector/src/main.rs
+++ b/crates/packet_inspector/src/main.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use anyhow::bail;
 use clap::Parser;
+use owo_colors::OwoColorize;
 use regex::Regex;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
@@ -58,6 +59,7 @@ struct State {
     read: OwnedReadHalf,
     write: OwnedWriteHalf,
     buf: String,
+    style: owo_colors::Style,
 }
 
 impl State {
@@ -75,7 +77,7 @@ impl State {
 
             self.dec.queue_bytes(buf);
         }
-
+        
         let pkt: P = self.dec.try_next_packet()?.unwrap();
 
         self.enc.append_packet(&pkt)?;
@@ -104,7 +106,7 @@ impl State {
             }
         }
 
-        println!("{}", self.buf);
+        println!("{}", self.buf.style(self.style));
 
         Ok(pkt)
     }
@@ -164,6 +166,7 @@ async fn handle_connection(client: TcpStream, cli: Arc<Cli>) -> anyhow::Result<(
         read: server_read,
         write: client_write,
         buf: String::new(),
+        style: owo_colors::Style::new().purple()
     };
 
     let mut c2s = State {
@@ -173,6 +176,7 @@ async fn handle_connection(client: TcpStream, cli: Arc<Cli>) -> anyhow::Result<(
         read: client_read,
         write: server_write,
         buf: String::new(),
+        style: owo_colors::Style::new().green()
     };
 
     let handshake: Handshake = c2s.rw_packet().await?;

--- a/crates/packet_inspector/src/main.rs
+++ b/crates/packet_inspector/src/main.rs
@@ -77,7 +77,7 @@ impl State {
 
             self.dec.queue_bytes(buf);
         }
-        
+
         let pkt: P = self.dec.try_next_packet()?.unwrap();
 
         self.enc.append_packet(&pkt)?;
@@ -166,7 +166,7 @@ async fn handle_connection(client: TcpStream, cli: Arc<Cli>) -> anyhow::Result<(
         read: server_read,
         write: client_write,
         buf: String::new(),
-        style: owo_colors::Style::new().purple()
+        style: owo_colors::Style::new().purple(),
     };
 
     let mut c2s = State {
@@ -176,7 +176,7 @@ async fn handle_connection(client: TcpStream, cli: Arc<Cli>) -> anyhow::Result<(
         read: client_read,
         write: server_write,
         buf: String::new(),
-        style: owo_colors::Style::new().green()
+        style: owo_colors::Style::new().green(),
     };
 
     let handshake: Handshake = c2s.rw_packet().await?;


### PR DESCRIPTION
<!-- Please make sure that your PR is aligned with the guidelines in CONTRIBUTING.md to the best of your ability. -->
<!-- Good PRs have tests! Make sure you have sufficient test coverage. -->

## Description

<!-- Describe the changes you've made. You may include any justification you want here. -->
I've used the popular `owo-colors` library to colourise the output of the `packet_inspector`.
This makes it a lot easier to see who's sending what for debugging purposes.

In future, I'd like to be able to filter out common, low-information packets like `SetPlayerPosition` and `KeepAlive` as well, but that's not in this PR. 

![image](https://user-images.githubusercontent.com/28905212/218880818-69c0461c-bd23-45c4-9fd4-7c5868be4b67.png)

## Test Plan

No tests - just eyeball :smile:. 
