### PR TITLE
Add ping calculation system

### DIFF
--- a/crates/valence/src/client/event.rs
+++ b/crates/valence/src/client/event.rs
@@ -924,6 +924,7 @@ fn handle_one_packet(
                 );
             } else {
                 client.got_keepalive = true;
+                client.ping = client.keepalive_sent_time.elapsed().as_millis() as i32;
             }
         }
         C2sPlayPacket::LockDifficulty(p) => {

--- a/crates/valence/src/player_list.rs
+++ b/crates/valence/src/player_list.rs
@@ -62,7 +62,7 @@ impl PlayerList {
                     .with_username(client.username())
                     .with_properties(client.properties())
                     .with_game_mode(client.game_mode())
-                    .with_ping(-1); // TODO
+                    .with_ping(client.ping());
 
                 player_list.insert(client.uuid(), entry);
             }


### PR DESCRIPTION
## Description

Add the ping computation system and capability to send ping to connecting clients.

Currently the player list will only update upon connection. Should another ticket be made for updating this since it seems out of scope for this issue?

## Test Plan

Printing ping per keepalive packet on a different computer on my network. It seems to work fine but would need extra feedback.

#### Related

#207 
