### PR TITLE
Add entity equipment support

### DIFF
--- a/crates/valence/examples/random_equipment.rs
+++ b/crates/valence/examples/random_equipment.rs
@@ -1,0 +1,124 @@
+use bevy_app::CoreStage;
+use rand::Rng;
+use valence::client::despawn_disconnected_clients;
+use valence::client::event::default_event_handler;
+use valence::equipment::{EquipmentSlot, Equipments};
+use valence::prelude::*;
+
+const BOARD_MIN_X: i32 = -30;
+const BOARD_MAX_X: i32 = 30;
+const BOARD_MIN_Z: i32 = -30;
+const BOARD_MAX_Z: i32 = 30;
+const BOARD_Y: i32 = 64;
+
+const SPAWN_POS: DVec3 = DVec3::new(
+    (BOARD_MIN_X + BOARD_MAX_X) as f64 / 2.0,
+    BOARD_Y as f64 + 1.0,
+    (BOARD_MIN_Z + BOARD_MAX_Z) as f64 / 2.0,
+);
+
+pub fn main() {
+    tracing_subscriber::fmt().init();
+
+    App::new()
+        .add_plugin(
+            ServerPlugin::new(())
+                .with_biomes(vec![Biome {
+                    grass_color: Some(0x00ff00),
+                    ..Default::default()
+                }])
+                .with_connection_mode(ConnectionMode::Offline),
+        )
+        .add_system_to_stage(EventLoop, default_event_handler)
+        .add_system_set(PlayerList::default_system_set())
+        .add_startup_system(setup)
+        .add_system(init_clients)
+        .add_system(despawn_disconnected_clients)
+        .add_system_to_stage(CoreStage::Update, randomize_equipment)
+        .run();
+}
+
+fn setup(world: &mut World) {
+    let mut instance = world
+        .resource::<Server>()
+        .new_instance(DimensionId::default());
+
+    for z in -10..10 {
+        for x in -10..10 {
+            instance.insert_chunk([x, z], Chunk::default());
+        }
+    }
+
+    for z in BOARD_MIN_Z..=BOARD_MAX_Z {
+        for x in BOARD_MIN_X..=BOARD_MAX_X {
+            instance.set_block_state([x, BOARD_Y, z], BlockState::DIRT);
+        }
+    }
+
+    let instance = world.spawn(instance);
+    let instance_entity = instance.id();
+
+    let mut equipments = Equipments::default();
+    equipments.set(
+        ItemStack::new(ItemKind::IronBoots, 1, None),
+        EquipmentSlot::Boots,
+    );
+
+    // Spawn armor stand
+    let mut armor_stand = world.spawn((
+        McEntity::new(EntityKind::ArmorStand, instance_entity),
+        equipments,
+    ));
+
+    if let Some(mut armor_stand) = armor_stand.get_mut::<McEntity>() {
+        let position = [SPAWN_POS.x, SPAWN_POS.y, SPAWN_POS.z + 3.0];
+        armor_stand.set_position(position);
+        armor_stand.set_yaw(180.0);
+    }
+}
+
+fn init_clients(
+    mut clients: Query<(&mut Client, Entity), Added<Client>>,
+    instances: Query<Entity, With<Instance>>,
+    mut commands: Commands,
+) {
+    let instance = instances.single();
+
+    for (mut client, entity) in &mut clients {
+        client.set_position(SPAWN_POS);
+        client.set_instance(instances.single());
+        client.set_game_mode(GameMode::Creative);
+
+        let equipments = Equipments::default();
+
+        commands.entity(entity).insert((
+            equipments,
+            McEntity::with_uuid(EntityKind::Player, instance, client.uuid()),
+        ));
+    }
+}
+
+fn randomize_equipment(mut query: Query<&mut Equipments>, server: Res<Server>) {
+    let ticks = server.current_tick();
+    if ticks % server.tps() != 0 {
+        return;
+    }
+
+    for mut equips in &mut query {
+        equips.clear();
+
+        let (slot, item_kind) = match rand::thread_rng().gen_range(0..=5) {
+            0 => (EquipmentSlot::MainHand, ItemKind::DiamondSword),
+            1 => (EquipmentSlot::OffHand, ItemKind::Torch),
+            2 => (EquipmentSlot::Boots, ItemKind::IronBoots),
+            3 => (EquipmentSlot::Leggings, ItemKind::DiamondLeggings),
+            4 => (EquipmentSlot::Chestplate, ItemKind::ChainmailChestplate),
+            5 => (EquipmentSlot::Helmet, ItemKind::LeatherHelmet),
+            _ => (EquipmentSlot::Boots, ItemKind::IronBoots),
+        };
+
+        let item = ItemStack::new(item_kind, 1, None);
+
+        equips.set(item, slot);
+    }
+}

--- a/crates/valence/src/client.rs
+++ b/crates/valence/src/client.rs
@@ -28,6 +28,7 @@ use valence_protocol::{
 use crate::dimension::DimensionId;
 use crate::entity::data::Player;
 use crate::entity::{velocity_to_packet_units, EntityStatus, McEntity};
+use crate::equipment::Equipments;
 use crate::instance::Instance;
 use crate::packet::WritePacket;
 use crate::server::{NewClientInfo, Server};
@@ -626,6 +627,7 @@ pub(crate) fn update_clients(
     mut clients: Query<(Entity, &mut Client, Option<&McEntity>)>,
     instances: Query<&Instance>,
     entities: Query<&McEntity>,
+    equipments: Query<&Equipments>,
 ) {
     // TODO: what batch size to use?
     clients.par_for_each_mut(16, |(entity_id, mut client, self_entity)| {
@@ -636,6 +638,7 @@ pub(crate) fn update_clients(
                 entity_id,
                 &instances,
                 &entities,
+                &equipments,
                 &server,
             ) {
                 client.write_packet(&DisconnectPlay {
@@ -662,6 +665,7 @@ fn update_one_client(
     _self_id: Entity,
     instances: &Query<&Instance>,
     entities: &Query<&McEntity>,
+    equipments: &Query<&Equipments>,
     server: &Server,
 ) -> anyhow::Result<()> {
     let Ok(instance) = instances.get(client.instance) else {
@@ -804,6 +808,7 @@ fn update_one_client(
                                 &mut client.enc,
                                 entity.old_position(),
                                 &mut client.scratch,
+                                equipments.get(id).ok(),
                             );
                         }
                     }
@@ -881,6 +886,7 @@ fn update_one_client(
                             &mut client.enc,
                             entity.position(),
                             &mut client.scratch,
+                            equipments.get(id).ok(),
                         );
                     }
                 }
@@ -934,6 +940,7 @@ fn update_one_client(
                             &mut client.enc,
                             entity.position(),
                             &mut client.scratch,
+                            equipments.get(id).ok(),
                         );
                     }
                 }

--- a/crates/valence/src/equipment.rs
+++ b/crates/valence/src/equipment.rs
@@ -1,0 +1,240 @@
+use bevy_ecs::prelude::*;
+use bevy_ecs::{query::Changed, system::Query};
+use valence_protocol::packets::s2c::set_equipment::SetEquipment;
+use valence_protocol::VarInt;
+use valence_protocol::{packets::s2c::set_equipment::EquipmentEntry, ItemStack};
+
+use crate::prelude::*;
+use crate::view::ChunkPos;
+
+/// ECS component to be added for entities with equipments.
+///
+/// Equipment updates managed by [update_equipment].
+#[derive(Component, Default, PartialEq, Debug)]
+pub struct Equipments {
+    equipments: Vec<EquipmentEntry>,
+    /// Bit set with the modified equipment slots
+    modified_slots: u8,
+}
+
+#[derive(Copy, Clone)]
+pub enum EquipmentSlot {
+    MainHand,
+    OffHand,
+    Boots,
+    Leggings,
+    Chestplate,
+    Helmet,
+}
+
+impl Equipments {
+    pub fn new() -> Equipments {
+        Equipments::default()
+    }
+
+    /// Set an equipment slot with an item stack
+    pub fn set(&mut self, item: ItemStack, slot: EquipmentSlot) {
+        if let Some(equip) = self.get_mut(slot) {
+            equip.item = Some(item);
+        } else {
+            self.equipments.push(EquipmentEntry {
+                item: Some(item),
+                slot: slot.into(),
+            });
+        }
+
+        self.set_modified_slot(slot);
+    }
+
+    /// Remove all equipments
+    pub fn clear(&mut self) {
+        for equip in self.equipments.iter() {
+            self.modified_slots |= 1 << equip.slot as u8;
+        }
+
+        self.equipments.clear();
+    }
+
+    /// Remove an equipment from a slot and return it if present
+    pub fn remove(&mut self, slot: EquipmentSlot) -> Option<EquipmentEntry> {
+        let slot: i8 = slot.into();
+
+        if let Some(idx) = self.equipments.iter().position(|equip| equip.slot == slot) {
+            Some(self.equipments.remove(idx))
+        } else {
+            None
+        }
+    }
+
+    pub fn get_mut(&mut self, slot: EquipmentSlot) -> Option<&mut EquipmentEntry> {
+        let slot: i8 = slot.into();
+        self.equipments.iter_mut().find(|equip| equip.slot == slot)
+    }
+
+    pub fn get(&self, slot: EquipmentSlot) -> Option<&EquipmentEntry> {
+        let slot: i8 = slot.into();
+        self.equipments.iter().find(|equip| equip.slot == slot)
+    }
+
+    pub fn equipments(&self) -> &Vec<EquipmentEntry> {
+        &self.equipments
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.equipments.is_empty()
+    }
+
+    fn has_modified_slots(&self) -> bool {
+        self.modified_slots != 0
+    }
+
+    fn iter_modified_equipments(&self) -> impl Iterator<Item = EquipmentEntry> + '_ {
+        self.iter_modified_slots().map(|slot| {
+            self.get(slot).cloned().unwrap_or_else(|| EquipmentEntry {
+                slot: slot.into(),
+                item: None,
+            })
+        })
+    }
+
+    fn iter_modified_slots(&self) -> impl Iterator<Item = EquipmentSlot> {
+        let modified_slots = self.modified_slots;
+
+        (0..=5).filter_map(move |slot: i8| {
+            if modified_slots & (1 << slot) != 0 {
+                Some(EquipmentSlot::try_from(slot).unwrap())
+            } else {
+                None
+            }
+        })
+    }
+
+    fn set_modified_slot(&mut self, slot: EquipmentSlot) {
+        let shifts: i8 = slot.into();
+        self.modified_slots |= 1 << (shifts as u8);
+    }
+
+    fn clear_modified_slot(&mut self) {
+        self.modified_slots = 0;
+    }
+}
+
+impl TryFrom<i8> for EquipmentSlot {
+    type Error = &'static str;
+
+    /// Convert from `id` according to https://wiki.vg/Protocol#Set_Equipment
+    fn try_from(id: i8) -> Result<Self, Self::Error> {
+        let slot = match id {
+            0 => EquipmentSlot::MainHand,
+            1 => EquipmentSlot::OffHand,
+            2 => EquipmentSlot::Boots,
+            3 => EquipmentSlot::Leggings,
+            4 => EquipmentSlot::Chestplate,
+            5 => EquipmentSlot::Helmet,
+            _ => return Err("Invalid value"),
+        };
+
+        Ok(slot)
+    }
+}
+
+impl From<EquipmentSlot> for i8 {
+    /// Convert to `id` according to https://wiki.vg/Protocol#Set_Equipment
+    fn from(slot: EquipmentSlot) -> Self {
+        match slot {
+            EquipmentSlot::MainHand => 0,
+            EquipmentSlot::OffHand => 1,
+            EquipmentSlot::Boots => 2,
+            EquipmentSlot::Leggings => 3,
+            EquipmentSlot::Chestplate => 4,
+            EquipmentSlot::Helmet => 5,
+        }
+    }
+}
+
+/// When a [Equipments] component is changed, send [SetEquipment] packet to all clients
+/// that have the updated entity in their view distance.
+///
+/// NOTE: [SetEquipment] packet only have cosmetic effect, which means it does not affect armor resistance or damage.
+pub fn update_equipment(
+    mut equiped_entities: Query<(Entity, &McEntity, &mut Equipments), Changed<Equipments>>,
+    mut clients: Query<(Entity, &mut Client)>,
+) {
+    for (equiped_entity, equiped_mc_entity, mut equips) in &mut equiped_entities {
+        if !equips.has_modified_slots() {
+            continue;
+        }
+
+        let equiped_instance = equiped_mc_entity.instance();
+        let equiped_chunk_pos = ChunkPos::from_dvec3(equiped_mc_entity.position());
+
+        // Send packets to all clients which have the equiped entity in view
+        for (client_entity, mut client) in &mut clients {
+            if client.instance() != equiped_instance {
+                continue;
+            }
+
+            // It is not necessary to `SetEquipment` packets for the associate client's player entity,
+            // because its equipments are already tracked on the client side.
+            if client_entity != equiped_entity && client.view().contains(equiped_chunk_pos) {
+                client.write_packet(&SetEquipment {
+                    entity_id: VarInt(equiped_mc_entity.protocol_id()),
+                    equipment: equips.iter_modified_equipments().collect(),
+                });
+            }
+        }
+
+        equips.clear_modified_slot();
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn modify_equipments() {
+        let mut equipments = Equipments::default();
+        assert_eq!(
+            equipments,
+            Equipments {
+                equipments: vec![],
+                modified_slots: 0
+            }
+        );
+
+        let item = ItemStack::new(ItemKind::GreenWool, 1, None);
+        let slot = EquipmentSlot::Boots;
+        equipments.set(item.clone(), slot);
+
+        assert_eq!(
+            equipments,
+            Equipments {
+                equipments: vec![EquipmentEntry {
+                    slot: slot.into(),
+                    item: Some(item)
+                }],
+                modified_slots: 0b100
+            }
+        );
+
+        equipments.clear_modified_slot();
+        equipments.clear();
+        assert_eq!(
+            equipments,
+            Equipments {
+                equipments: vec![],
+                modified_slots: 0b100
+            }
+        );
+        assert_eq!(
+            equipments
+                .iter_modified_equipments()
+                .collect::<Vec<EquipmentEntry>>(),
+            vec![EquipmentEntry {
+                slot: slot.into(),
+                item: None
+            }]
+        );
+    }
+}

--- a/crates/valence/src/lib.rs
+++ b/crates/valence/src/lib.rs
@@ -36,6 +36,7 @@ pub mod client;
 pub mod config;
 pub mod dimension;
 pub mod entity;
+pub mod equipment;
 pub mod instance;
 pub mod inventory;
 pub mod math;

--- a/crates/valence/src/server.rs
+++ b/crates/valence/src/server.rs
@@ -29,6 +29,7 @@ use crate::entity::{
     check_entity_invariants, deinit_despawned_entities, init_entities, update_entities,
     McEntityManager,
 };
+use crate::equipment::update_equipment;
 use crate::instance::{
     check_instance_invariants, update_instances_post_client, update_instances_pre_client, Instance,
 };
@@ -361,6 +362,7 @@ pub fn build_plugin(
                 .with_system(handle_close_container)
                 .with_system(update_client_on_close_inventory.after(update_open_inventories))
                 .with_system(update_player_inventories)
+                .with_system(update_equipment)
                 .with_system(
                     handle_click_container
                         .before(update_open_inventories)


### PR DESCRIPTION
## Description

Main additions:
- Add a  Bevy `Component` called `Equipments` which tracks entity's current equipments and if they have been modified.
- Add a Bevy system called `update_equipment` which sends [`SetEquipment`](https://wiki.vg/Protocol#Set_Equipment) packets to all clients in view, when an entity with a `Equipments` component is modified.
- Modify [McEntity::write_init_packets] to also send `SetEquipment` packets.
- Add `random_equipment.rs`

These change only have cosmetic effect for now, but the `Equipments` component can be also used when dealing with game logic when equipments data is required.

## Test Plan

Steps:
1. `cargo test -p valence --tests` (there is a unit test in `equipment.rs`)
2. Run the `random_equipment` example with: `cargo run --example random_equipment`
3. Join the server on `localhost`
4. An armor stand is spawned near the spawn point
5. Every `McEntity` will be assigned a random set of equipments every second

### Video of the `random_equipment` example
https://user-images.githubusercontent.com/49251043/220204501-9cfa5e61-d486-4ecc-93d8-34e965c63dfd.mp4

**PROBLEM**: As we can see from the video, our client only display equipment changes from other players, but not from our own player entity. This happens because the equipments of our player entity are tracked client-side, thus the `SetEquipment` packet does have effect when the `entity_id` is equal to the your player entity id. There might me another packet type which can be used for such case, but I'm not sure don't know which one 😞 

#### Related

Issue related: #223 
