### PR TITLE
Provide API for getting the wall variant of blocks

### DIFF
--- a/crates/valence_protocol/build/block.rs
+++ b/crates/valence_protocol/build/block.rs
@@ -615,7 +615,7 @@ pub fn build() -> anyhow::Result<TokenStream> {
             /// Returns the wall variant of the block state.
             ///
             /// If the given block state doesn't have a wall variant, `None` is returned.
-            pub const fn to_wall_variant(self) -> Option<Self> {
+            pub const fn wall_block_id(self) -> Option<Self> {
                 match self {
                     #state_to_wall_variant_arms
                     _ => None

--- a/crates/valence_protocol/build/block.rs
+++ b/crates/valence_protocol/build/block.rs
@@ -18,6 +18,7 @@ struct TopLevel {
 struct Block {
     id: u16,
     item_id: u16,
+    wall_variant_id: Option<u16>,
     translation_key: String,
     name: String,
     properties: Vec<Property>,
@@ -293,6 +294,22 @@ pub fn build() -> anyhow::Result<TokenStream> {
             quote! {
                 #[doc = #doc]
                 pub const #name: BlockState = BlockState(#state);
+            }
+        })
+        .collect::<TokenStream>();
+
+    let state_to_wall_variant_arms = blocks
+        .iter()
+        .filter(|b| b.wall_variant_id.is_some())
+        .map(|b| {
+            let block_name = ident(b.name.to_shouty_snake_case());
+            let wall_block_name = ident(
+                blocks[b.wall_variant_id.unwrap() as usize]
+                    .name
+                    .to_shouty_snake_case(),
+            );
+            quote! {
+                BlockState::#block_name => Some(BlockState::#wall_block_name),
             }
         })
         .collect::<TokenStream>();
@@ -593,6 +610,16 @@ pub fn build() -> anyhow::Result<TokenStream> {
             /// Returns the maximum block state ID.
             pub const fn max_raw() -> u16 {
                 #max_state_id
+            }
+
+            /// Returns the wall variant of the block state.
+            ///
+            /// If the given block state doesn't have a wall variant, `None` is returned.
+            pub const fn to_wall_variant(self) -> Option<Self> {
+                match self {
+                    #state_to_wall_variant_arms
+                    _ => None
+                }
             }
 
             /// Gets the value of the property with the given name from this block.

--- a/crates/valence_protocol/src/block.rs
+++ b/crates/valence_protocol/src/block.rs
@@ -124,4 +124,21 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn blockstate_to_wall() {
+        assert_eq!(BlockState::STONE.to_wall_variant(), None);
+        assert_eq!(
+            BlockState::OAK_SIGN.to_wall_variant(),
+            Some(BlockState::OAK_WALL_SIGN)
+        );
+        assert_eq!(
+            BlockState::GREEN_BANNER.to_wall_variant(),
+            Some(BlockState::GREEN_WALL_BANNER)
+        );
+        assert_ne!(
+            BlockState::GREEN_BANNER.to_wall_variant(),
+            Some(BlockState::GREEN_BANNER)
+        );
+    }
 }

--- a/crates/valence_protocol/src/block.rs
+++ b/crates/valence_protocol/src/block.rs
@@ -127,17 +127,17 @@ mod tests {
 
     #[test]
     fn blockstate_to_wall() {
-        assert_eq!(BlockState::STONE.to_wall_variant(), None);
+        assert_eq!(BlockState::STONE.wall_block_id(), None);
         assert_eq!(
-            BlockState::OAK_SIGN.to_wall_variant(),
+            BlockState::OAK_SIGN.wall_block_id(),
             Some(BlockState::OAK_WALL_SIGN)
         );
         assert_eq!(
-            BlockState::GREEN_BANNER.to_wall_variant(),
+            BlockState::GREEN_BANNER.wall_block_id(),
             Some(BlockState::GREEN_WALL_BANNER)
         );
         assert_ne!(
-            BlockState::GREEN_BANNER.to_wall_variant(),
+            BlockState::GREEN_BANNER.wall_block_id(),
             Some(BlockState::GREEN_BANNER)
         );
     }

--- a/crates/valence_protocol/src/codec.rs
+++ b/crates/valence_protocol/src/codec.rs
@@ -442,6 +442,11 @@ impl PacketDecoder {
     }
 
     #[cfg(feature = "compression")]
+    pub fn compression(&self) -> bool {
+        self.compression_enabled
+    }
+
+    #[cfg(feature = "compression")]
     pub fn set_compression(&mut self, enabled: bool) {
         self.compression_enabled = enabled;
     }

--- a/crates/valence_protocol/src/lib.rs
+++ b/crates/valence_protocol/src/lib.rs
@@ -271,7 +271,7 @@ pub trait Decode<'a>: Sized {
 /// ```
 /// use valence_protocol::{Encode, EncodePacket};
 ///
-/// #[derive(Encode, EncodePacket)]
+/// #[derive(Encode, EncodePacket, Debug)]
 /// #[packet_id = 42]
 /// struct MyStruct {
 ///     first: i32,
@@ -308,7 +308,7 @@ pub trait EncodePacket: fmt::Debug {
 /// ```
 /// use valence_protocol::{Decode, DecodePacket};
 ///
-/// #[derive(Decode, DecodePacket)]
+/// #[derive(Decode, DecodePacket, Debug)]
 /// #[packet_id = 42]
 /// struct MyStruct {
 ///     first: i32,

--- a/extractor/src/main/java/rs/valence/extractor/extractors/Blocks.java
+++ b/extractor/src/main/java/rs/valence/extractor/extractors/Blocks.java
@@ -4,9 +4,11 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import net.minecraft.registry.Registries;
+import net.minecraft.item.VerticallyAttachableBlockItem;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.EmptyBlockView;
 import rs.valence.extractor.Main;
+import rs.valence.extractor.mixin.ExposeWallBlock;
 
 import java.util.LinkedHashMap;
 import java.util.Locale;
@@ -36,6 +38,13 @@ public class Blocks implements Main.Extractor {
             blockJson.addProperty("name", Registries.BLOCK.getId(block).getPath());
             blockJson.addProperty("translation_key", block.getTranslationKey());
             blockJson.addProperty("item_id", Registries.ITEM.getRawId(block.asItem()));
+
+            if (block.asItem() instanceof VerticallyAttachableBlockItem wsbItem) {
+                if (wsbItem.getBlock() == block) {
+                    var wallBlock = ((ExposeWallBlock) wsbItem).getWallBlock();
+                    blockJson.addProperty("wall_variant_id", Registries.BLOCK.getRawId(wallBlock));
+                }
+            }
 
             var propsJson = new JsonArray();
             for (var prop : block.getStateManager().getProperties()) {

--- a/extractor/src/main/java/rs/valence/extractor/mixin/ExposeWallBlock.java
+++ b/extractor/src/main/java/rs/valence/extractor/mixin/ExposeWallBlock.java
@@ -1,0 +1,12 @@
+package rs.valence.extractor.mixin;
+
+import net.minecraft.block.Block;
+import net.minecraft.item.VerticallyAttachableBlockItem;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(VerticallyAttachableBlockItem.class)
+public interface ExposeWallBlock {
+    @Accessor
+    Block getWallBlock();
+}

--- a/extractor/src/main/resources/extractor.mixins.json
+++ b/extractor/src/main/resources/extractor.mixins.json
@@ -1,0 +1,9 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "rs.valence.extractor.mixin",
+  "compatibilityLevel": "JAVA_17",
+  "mixins": [
+    "ExposeWallBlock"
+  ]
+}

--- a/extractor/src/main/resources/fabric.mod.json
+++ b/extractor/src/main/resources/fabric.mod.json
@@ -17,7 +17,9 @@
       "rs.valence.extractor.Main"
     ]
   },
-  "mixins": [],
+  "mixins": [
+    "extractor.mixins.json"
+  ],
   "depends": {
     "fabricloader": ">=0.14.6",
     "minecraft": "~1.19",


### PR DESCRIPTION
<!-- Please make sure that your PR is aligned with the guidelines in CONTRIBUTING.md to the best of your ability. -->
<!-- Good PRs have tests! Make sure you have sufficient test coverage. -->

## Description

This adds an API for getting the wall / attachable variant of a block. 
Unlike #117 it does not add convenience methods for orientation, and it does not modify the example to use this code.

## Test Plan

<!-- Explain how you tested your changes, and include any code that you used to test this. -->
<!-- If there is an example that is sufficient to use in place of a playground, replace the playground section with a note that indicates this.  -->

The extractor is not tested. 
The API has some tests in the test module.

#### Related

<!-- Link to any issues that have context for this or that this PR fixes. -->

#115 - it does not fix this, as it doesn't modify the example, but it could lead to it.