### PR TITLE
Changed `setup()` to not be an exclusive system

### DIFF
--- a/crates/playground/src/playground.template.rs
+++ b/crates/playground/src/playground.template.rs
@@ -30,7 +30,7 @@ fn setup(mut commands: Commands, server: Res<Server>) {
         }
     }
 
-    world.spawn(instance);
+    commands.spawn(instance);
 }
 
 fn init_clients(

--- a/crates/playground/src/playground.template.rs
+++ b/crates/playground/src/playground.template.rs
@@ -15,10 +15,8 @@ pub fn build_app(app: &mut App) {
         .add_system(despawn_disconnected_clients);
 }
 
-fn setup(world: &mut World) {
-    let mut instance = world
-        .resource::<Server>()
-        .new_instance(DimensionId::default());
+fn setup(mut commands: Commands, server: Res<Server>) {
+    let mut instance = server.new_instance(DimensionId::default());
 
     for z in -5..5 {
         for x in -5..5 {

--- a/crates/valence/examples/bench_players.rs
+++ b/crates/valence/examples/bench_players.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use bevy_app::{App, CoreStage};
+use bevy::app::{App, CoreStage};
 use valence::client::despawn_disconnected_clients;
 use valence::client::event::default_event_handler;
 use valence::instance::{Chunk, Instance};
@@ -31,10 +31,8 @@ fn main() {
         .run();
 }
 
-fn record_tick_start_time(world: &mut World) {
-    world
-        .get_resource_or_insert_with(|| TickStart(Instant::now()))
-        .0 = Instant::now();
+fn record_tick_start_time(mut commands: Commands) {
+    commands.insert_resource(TickStart(Instant::now()));
 }
 
 fn print_tick_time(server: Res<Server>, time: Res<TickStart>, clients: Query<(), With<Client>>) {
@@ -47,10 +45,8 @@ fn print_tick_time(server: Res<Server>, time: Res<TickStart>, clients: Query<(),
     }
 }
 
-fn setup(world: &mut World) {
-    let mut instance = world
-        .resource::<Server>()
-        .new_instance(DimensionId::default());
+fn setup(mut commands: Commands, server: Res<Server>) {
+    let mut instance = server.new_instance(DimensionId::default());
 
     for z in -5..5 {
         for x in -5..5 {
@@ -64,7 +60,7 @@ fn setup(world: &mut World) {
         }
     }
 
-    world.spawn(instance);
+    commands.spawn(instance);
 }
 
 fn init_clients(
@@ -72,7 +68,7 @@ fn init_clients(
     instances: Query<Entity, With<Instance>>,
     mut commands: Commands,
 ) {
-    let instance = instances.get_single().unwrap();
+    let instance = instances.single();
 
     for (client_entity, mut client) in &mut clients {
         client.set_position([0.0, SPAWN_Y as f64 + 1.0, 0.0]);

--- a/crates/valence/examples/bench_players.rs
+++ b/crates/valence/examples/bench_players.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use bevy::app::{App, CoreStage};
+use bevy_app::{App, CoreStage};
 use valence::client::despawn_disconnected_clients;
 use valence::client::event::default_event_handler;
 use valence::instance::{Chunk, Instance};

--- a/crates/valence/examples/biomes.rs
+++ b/crates/valence/examples/biomes.rs
@@ -40,8 +40,7 @@ pub fn main() {
         .run();
 }
 
-fn setup(world: &mut World) {
-    let server = world.resource::<Server>();
+fn setup(mut commands: Commands, server: Res<Server>) {
     let mut instance = server.new_instance(DimensionId::default());
 
     for z in -5..5 {
@@ -72,7 +71,7 @@ fn setup(world: &mut World) {
         }
     }
 
-    world.spawn(instance);
+    commands.spawn(instance);
 }
 
 fn init_clients(

--- a/crates/valence/examples/block_entities.rs
+++ b/crates/valence/examples/block_entities.rs
@@ -22,10 +22,8 @@ pub fn main() {
         .run();
 }
 
-fn setup(world: &mut World) {
-    let mut instance = world
-        .resource::<Server>()
-        .new_instance(DimensionId::default());
+fn setup(mut commands: Commands, server: Res<Server>) {
+    let mut instance = server.new_instance(DimensionId::default());
 
     for z in -5..5 {
         for x in -5..5 {
@@ -57,7 +55,7 @@ fn setup(world: &mut World) {
         BlockState::PLAYER_HEAD.set(PropName::Rotation, PropValue::_12),
     );
 
-    world.spawn(instance);
+    commands.spawn(instance);
 }
 
 fn init_clients(

--- a/crates/valence/examples/building.rs
+++ b/crates/valence/examples/building.rs
@@ -24,10 +24,8 @@ pub fn main() {
         .run();
 }
 
-fn setup(world: &mut World) {
-    let mut instance = world
-        .resource::<Server>()
-        .new_instance(DimensionId::default());
+fn setup(mut commands: Commands, server: Res<Server>) {
+    let mut instance = server.new_instance(DimensionId::default());
 
     for z in -5..5 {
         for x in -5..5 {
@@ -41,7 +39,7 @@ fn setup(world: &mut World) {
         }
     }
 
-    world.spawn(instance);
+    commands.spawn(instance);
 }
 
 fn init_clients(

--- a/crates/valence/examples/chat.rs
+++ b/crates/valence/examples/chat.rs
@@ -21,10 +21,8 @@ pub fn main() {
         .run();
 }
 
-fn setup(world: &mut World) {
-    let mut instance = world
-        .resource::<Server>()
-        .new_instance(DimensionId::default());
+fn setup(mut commands: Commands, server: Res<Server>) {
+    let mut instance = server.new_instance(DimensionId::default());
 
     for z in -5..5 {
         for x in -5..5 {
@@ -38,7 +36,7 @@ fn setup(world: &mut World) {
         }
     }
 
-    world.spawn(instance);
+    commands.spawn(instance);
 }
 
 fn init_clients(

--- a/crates/valence/examples/chest.rs
+++ b/crates/valence/examples/chest.rs
@@ -21,10 +21,8 @@ pub fn main() {
         .run();
 }
 
-fn setup(world: &mut World) {
-    let mut instance = world
-        .resource::<Server>()
-        .new_instance(DimensionId::default());
+fn setup(mut commands: Commands, server: Res<Server>) {
+    let mut instance = server.new_instance(DimensionId::default());
 
     for z in -5..5 {
         for x in -5..5 {
@@ -39,13 +37,13 @@ fn setup(world: &mut World) {
     }
     instance.set_block(CHEST_POS, BlockState::CHEST);
 
-    world.spawn(instance);
+    commands.spawn(instance);
 
     let inventory = Inventory::with_title(
         InventoryKind::Generic9x3,
         "Extra".italic() + " Chesty".not_italic().bold().color(Color::RED) + " Chest".not_italic(),
     );
-    world.spawn(inventory);
+    commands.spawn(inventory);
 }
 
 fn init_clients(

--- a/crates/valence/examples/combat.rs
+++ b/crates/valence/examples/combat.rs
@@ -31,10 +31,8 @@ pub fn main() {
         .run();
 }
 
-fn setup(world: &mut World) {
-    let mut instance = world
-        .resource::<Server>()
-        .new_instance(DimensionId::default());
+fn setup(mut commands: Commands, server: Res<Server>) {
+    let mut instance = server.new_instance(DimensionId::default());
 
     for z in -5..5 {
         for x in -5..5 {
@@ -63,7 +61,7 @@ fn setup(world: &mut World) {
         }
     }
 
-    world.spawn(instance);
+    commands.spawn(instance);
 }
 
 fn init_clients(

--- a/crates/valence/examples/conway.rs
+++ b/crates/valence/examples/conway.rs
@@ -39,10 +39,8 @@ pub fn main() {
         .run();
 }
 
-fn setup(world: &mut World) {
-    let mut instance = world
-        .resource::<Server>()
-        .new_instance(DimensionId::default());
+fn setup(mut commands: Commands, server: Res<Server>) {
+    let mut instance = server.new_instance(DimensionId::default());
 
     for z in -10..10 {
         for x in -10..10 {
@@ -56,9 +54,9 @@ fn setup(world: &mut World) {
         }
     }
 
-    world.spawn(instance);
+    commands.spawn(instance);
 
-    world.insert_resource(LifeBoard {
+    commands.insert_resource(LifeBoard {
         paused: true,
         board: vec![false; BOARD_SIZE_X * BOARD_SIZE_Z].into(),
         board_buf: vec![false; BOARD_SIZE_X * BOARD_SIZE_Z].into(),

--- a/crates/valence/examples/cow_sphere.rs
+++ b/crates/valence/examples/cow_sphere.rs
@@ -33,10 +33,8 @@ fn main() {
         .run();
 }
 
-fn setup(world: &mut World) {
-    let mut instance = world
-        .resource::<Server>()
-        .new_instance(DimensionId::default());
+fn setup(mut commands: Commands, server: Res<Server>) {
+    let mut instance = server.new_instance(DimensionId::default());
 
     for z in -5..5 {
         for x in -5..5 {
@@ -46,9 +44,9 @@ fn setup(world: &mut World) {
 
     instance.set_block(SPAWN_POS, BlockState::BEDROCK);
 
-    let instance_id = world.spawn(instance).id();
+    let instance_id = commands.spawn(instance).id();
 
-    world.spawn_batch(
+    commands.spawn_batch(
         [0; SPHERE_AMOUNT].map(|_| (McEntity::new(SPHERE_KIND, instance_id), SpherePart)),
     );
 }

--- a/crates/valence/examples/death.rs
+++ b/crates/valence/examples/death.rs
@@ -20,11 +20,9 @@ pub fn main() {
         .run();
 }
 
-fn setup(world: &mut World) {
+fn setup(mut commands: Commands, server: Res<Server>) {
     for block in [BlockState::GRASS_BLOCK, BlockState::DEEPSLATE] {
-        let mut instance = world
-            .resource::<Server>()
-            .new_instance(DimensionId::default());
+        let mut instance = server.new_instance(DimensionId::default());
 
         for z in -5..5 {
             for x in -5..5 {
@@ -38,7 +36,7 @@ fn setup(world: &mut World) {
             }
         }
 
-        world.spawn(instance);
+        commands.spawn(instance);
     }
 }
 

--- a/crates/valence/examples/gamemode_switcher.rs
+++ b/crates/valence/examples/gamemode_switcher.rs
@@ -18,10 +18,8 @@ pub fn main() {
         .run();
 }
 
-fn setup(world: &mut World) {
-    let mut instance = world
-        .resource::<Server>()
-        .new_instance(DimensionId::default());
+fn setup(mut commands: Commands, server: Res<Server>) {
+    let mut instance = server.new_instance(DimensionId::default());
 
     for z in -5..5 {
         for x in -5..5 {
@@ -35,7 +33,7 @@ fn setup(world: &mut World) {
         }
     }
 
-    world.spawn(instance);
+    commands.spawn(instance);
 }
 
 fn init_clients(

--- a/crates/valence/examples/particles.rs
+++ b/crates/valence/examples/particles.rs
@@ -37,10 +37,8 @@ impl ParticleSpawner {
     }
 }
 
-fn setup(world: &mut World) {
-    let mut instance = world
-        .resource::<Server>()
-        .new_instance(DimensionId::default());
+fn setup(mut commands: Commands, server: Res<Server>) {
+    let mut instance = server.new_instance(DimensionId::default());
 
     for z in -5..5 {
         for x in -5..5 {
@@ -50,10 +48,10 @@ fn setup(world: &mut World) {
 
     instance.set_block([0, SPAWN_Y, 0], BlockState::BEDROCK);
 
-    world.spawn(instance);
+    commands.spawn(instance);
 
     let spawner = ParticleSpawner::new();
-    world.insert_resource(spawner)
+    commands.insert_resource(spawner)
 }
 
 fn init_clients(

--- a/crates/valence/examples/player_list.rs
+++ b/crates/valence/examples/player_list.rs
@@ -22,7 +22,7 @@ fn main() {
         .run();
 }
 
-fn setup(mut commands: Commands, server: Res<Server>) {
+fn setup(mut commands: Commands, server: Res<Server>, mut player_list: ResMut<PlayerList>) {
     let mut instance = server.new_instance(DimensionId::default());
 
     for z in -5..5 {
@@ -38,8 +38,6 @@ fn setup(mut commands: Commands, server: Res<Server>) {
     }
 
     commands.spawn(instance);
-
-    let mut player_list = world.resource_mut::<PlayerList>();
 
     player_list.insert(
         PLAYER_UUID_1,

--- a/crates/valence/examples/player_list.rs
+++ b/crates/valence/examples/player_list.rs
@@ -22,10 +22,8 @@ fn main() {
         .run();
 }
 
-fn setup(world: &mut World) {
-    let mut instance = world
-        .resource::<Server>()
-        .new_instance(DimensionId::default());
+fn setup(mut commands: Commands, server: Res<Server>) {
+    let mut instance = server.new_instance(DimensionId::default());
 
     for z in -5..5 {
         for x in -5..5 {
@@ -39,7 +37,7 @@ fn setup(world: &mut World) {
         }
     }
 
-    world.spawn(instance);
+    commands.spawn(instance);
 
     let mut player_list = world.resource_mut::<PlayerList>();
 

--- a/crates/valence/examples/resource_pack.rs
+++ b/crates/valence/examples/resource_pack.rs
@@ -22,10 +22,8 @@ pub fn main() {
         .run();
 }
 
-fn setup(world: &mut World) {
-    let mut instance = world
-        .resource::<Server>()
-        .new_instance(DimensionId::default());
+fn setup(mut commands: Commands, server: Res<Server>) {
+    let mut instance = server.new_instance(DimensionId::default());
 
     for z in -5..5 {
         for x in -5..5 {
@@ -39,11 +37,11 @@ fn setup(world: &mut World) {
         }
     }
 
-    let instance_ent = world.spawn(instance).id();
+    let instance_ent = commands.spawn(instance).id();
 
     let mut sheep = McEntity::new(EntityKind::Sheep, instance_ent);
     sheep.set_position([0.0, SPAWN_Y as f64 + 1.0, 2.0]);
-    world.spawn(sheep);
+    commands.spawn(sheep);
 }
 
 fn init_clients(

--- a/crates/valence/examples/terrain.rs
+++ b/crates/valence/examples/terrain.rs
@@ -95,7 +95,7 @@ fn setup(mut commands: Commands, server: Res<Server>) {
         receiver: finished_receiver,
     });
 
-    let mut instance = server.new_instance(DimensionId::default());
+    let instance = server.new_instance(DimensionId::default());
 
     commands.spawn(instance);
 }

--- a/crates/valence/examples/terrain.rs
+++ b/crates/valence/examples/terrain.rs
@@ -54,9 +54,8 @@ pub fn main() {
         .run();
 }
 
-fn setup(world: &mut World) {
+fn setup(mut commands: Commands, server: Res<Server>) {
     let seconds_per_day = 86_400;
-
     let seed = (SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap()
@@ -90,17 +89,15 @@ fn setup(world: &mut World) {
         thread::spawn(move || chunk_worker(state));
     }
 
-    world.insert_resource(GameState {
+    commands.insert_resource(GameState {
         pending: HashMap::new(),
         sender: pending_sender,
         receiver: finished_receiver,
     });
 
-    let instance = world
-        .resource::<Server>()
-        .new_instance(DimensionId::default());
+    let mut instance = server.new_instance(DimensionId::default());
 
-    world.spawn(instance);
+    commands.spawn(instance);
 }
 
 fn init_clients(


### PR DESCRIPTION
<!-- Please make sure that your PR is aligned with the guidelines in CONTRIBUTING.md to the best of your ability. -->
<!-- Good PRs have tests! Make sure you have sufficient test coverage. -->

## Description

In the [examples of the `valence` crate](https://github.com/valence-rs/valence/tree/main/crates/valence/examples), the `setup()` functions are currently [exclusive systems](https://bevy-cheatbook.github.io/programming/exclusive.html). My reasoning for making these a standard system is twofold:
- Exclusive systems can be considered an advanced Bevy topic. I don't think you should be using advanced concepts in examples meant to be an introduction to the way this project/framework is used.
- In instances where developers try to use these examples, adding another startup system would result is running the systems sequentially. That leaves performance on the table (albeit only during startup).

## Test Plan (or lack thereof)

I've chosen to _not_ include any tests besides the ones already present, because I feel that it's unnecessary. My justification is as follows: Since `setup()` was the only _startup_ system in these examples (that I'm aware of), the changes are functionally equivalent to anything before. This is because startup systems run _before_ all non-startup systems. See [this docs.rs section](https://docs.rs/bevy/0.9.1/bevy/app/struct.App.html#the-stages) for some information on startup system scheduling.
