### PR TITLE
Replace `EncodePacket` and `DecodePacket` with `Packet`

### DIFF
--- a/crates/packet_inspector/src/main.rs
+++ b/crates/packet_inspector/src/main.rs
@@ -15,6 +15,7 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::Semaphore;
 use tokio::task::JoinHandle;
 use tracing_subscriber::filter::LevelFilter;
+use valence_protocol::Packet;
 use valence_protocol::codec::{PacketDecoder, PacketEncoder};
 use valence_protocol::packet::c2s::handshake::handshake::NextState;
 use valence_protocol::packet::c2s::handshake::HandshakeC2s;
@@ -23,7 +24,6 @@ use valence_protocol::packet::c2s::status::{QueryPingC2s, QueryRequestC2s};
 use valence_protocol::packet::s2c::login::LoginSuccessS2c;
 use valence_protocol::packet::s2c::status::{QueryPongS2c, QueryResponseS2c};
 use valence_protocol::packet::{C2sPlayPacket, S2cLoginPacket, S2cPlayPacket};
-use valence_protocol::{DecodePacket, EncodePacket};
 
 #[derive(Parser, Clone, Debug)]
 #[clap(author, version, about)]
@@ -65,7 +65,7 @@ struct State {
 impl State {
     pub async fn rw_packet<'a, P>(&'a mut self) -> anyhow::Result<P>
     where
-        P: DecodePacket<'a> + EncodePacket,
+        P: Packet<'a>,
     {
         while !self.dec.has_next_packet()? {
             self.dec.reserve(4096);

--- a/crates/packet_inspector/src/main.rs
+++ b/crates/packet_inspector/src/main.rs
@@ -15,7 +15,6 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::Semaphore;
 use tokio::task::JoinHandle;
 use tracing_subscriber::filter::LevelFilter;
-use valence_protocol::Packet;
 use valence_protocol::codec::{PacketDecoder, PacketEncoder};
 use valence_protocol::packet::c2s::handshake::handshake::NextState;
 use valence_protocol::packet::c2s::handshake::HandshakeC2s;
@@ -24,6 +23,7 @@ use valence_protocol::packet::c2s::status::{QueryPingC2s, QueryRequestC2s};
 use valence_protocol::packet::s2c::login::LoginSuccessS2c;
 use valence_protocol::packet::s2c::status::{QueryPongS2c, QueryResponseS2c};
 use valence_protocol::packet::{C2sPlayPacket, S2cLoginPacket, S2cPlayPacket};
+use valence_protocol::Packet;
 
 #[derive(Parser, Clone, Debug)]
 #[clap(author, version, about)]

--- a/crates/valence/src/client.rs
+++ b/crates/valence/src/client.rs
@@ -29,7 +29,7 @@ use valence_protocol::text::Text;
 use valence_protocol::types::{GameMode, GlobalPos, Property, SoundCategory};
 use valence_protocol::username::Username;
 use valence_protocol::var_int::VarInt;
-use valence_protocol::EncodePacket;
+use valence_protocol::Packet;
 
 use crate::dimension::DimensionId;
 use crate::entity::data::Player;
@@ -173,9 +173,9 @@ impl Client {
     ///
     /// If encoding the packet fails, the client is disconnected. Has no
     /// effect if the client is already disconnected.
-    pub fn write_packet<P>(&mut self, pkt: &P)
+    pub fn write_packet<'a, P>(&mut self, pkt: &P)
     where
-        P: EncodePacket + ?Sized,
+        P: Packet<'a>,
     {
         self.enc.write_packet(pkt);
     }
@@ -606,9 +606,9 @@ impl Client {
 }
 
 impl WritePacket for Client {
-    fn write_packet<P>(&mut self, packet: &P)
+    fn write_packet<'a, P>(&mut self, packet: &P)
     where
-        P: EncodePacket + ?Sized,
+        P: Packet<'a>,
     {
         self.enc.write_packet(packet)
     }

--- a/crates/valence/src/instance.rs
+++ b/crates/valence/src/instance.rs
@@ -16,7 +16,7 @@ use valence_protocol::packet::s2c::play::{OverlayMessageS2c, ParticleS2c, PlaySo
 use valence_protocol::sound::Sound;
 use valence_protocol::text::Text;
 use valence_protocol::types::SoundCategory;
-use valence_protocol::EncodePacket;
+use valence_protocol::Packet;
 
 use crate::dimension::DimensionId;
 use crate::entity::McEntity;
@@ -313,9 +313,9 @@ impl Instance {
     ///
     /// This is more efficient than sending the packet to each client
     /// individually.
-    pub fn write_packet<P>(&mut self, pkt: &P)
+    pub fn write_packet<'a, P>(&mut self, pkt: &P)
     where
-        P: EncodePacket + ?Sized,
+        P: Packet<'a>,
     {
         PacketWriter::new(
             &mut self.packet_buf,
@@ -340,9 +340,9 @@ impl Instance {
     ///
     /// This is more efficient than sending the packet to each client
     /// individually.
-    pub fn write_packet_at<P>(&mut self, pkt: &P, pos: impl Into<ChunkPos>)
+    pub fn write_packet_at<'a, P>(&mut self, pkt: &P, pos: impl Into<ChunkPos>)
     where
-        P: EncodePacket + ?Sized,
+        P: Packet<'a>,
     {
         let pos = pos.into();
         if let Some(cell) = self.partition.get_mut(&pos) {

--- a/crates/valence/src/unit_test/util.rs
+++ b/crates/valence/src/unit_test/util.rs
@@ -135,7 +135,7 @@ impl MockClientHelper {
 
     /// Inject a packet to be treated as a packet inbound to the server. Panics
     /// if the packet cannot be sent.
-    pub fn send<'a>(&mut self, packet: &(impl Packet<'a>)) {
+    pub fn send<'a>(&mut self, packet: &impl Packet<'a>) {
         self.enc
             .append_packet(packet)
             .expect("failed to encode packet");

--- a/crates/valence/src/unit_test/util.rs
+++ b/crates/valence/src/unit_test/util.rs
@@ -6,7 +6,7 @@ use bytes::BytesMut;
 use valence_protocol::codec::{PacketDecoder, PacketEncoder};
 use valence_protocol::packet::S2cPlayPacket;
 use valence_protocol::username::Username;
-use valence_protocol::EncodePacket;
+use valence_protocol::Packet;
 
 use crate::client::{Client, ClientConnection};
 use crate::config::{ConnectionMode, ServerPlugin};
@@ -135,7 +135,7 @@ impl MockClientHelper {
 
     /// Inject a packet to be treated as a packet inbound to the server. Panics
     /// if the packet cannot be sent.
-    pub fn send(&mut self, packet: &(impl EncodePacket + ?Sized)) {
+    pub fn send<'a>(&mut self, packet: &(impl Packet<'a>)) {
         self.enc
             .append_packet(packet)
             .expect("failed to encode packet");

--- a/crates/valence_protocol/src/lib.rs
+++ b/crates/valence_protocol/src/lib.rs
@@ -75,7 +75,7 @@ use std::io::Write;
 use std::{fmt, io};
 
 pub use anyhow::{Error, Result};
-pub use valence_protocol_macros::{ident_str, Decode, DecodePacket, Encode, EncodePacket};
+pub use valence_protocol_macros::{ident_str, Decode, Encode, Packet};
 pub use {uuid, valence_nbt as nbt};
 
 /// The Minecraft protocol version this library currently targets.
@@ -111,7 +111,7 @@ pub mod __private {
     pub use anyhow::{anyhow, bail, ensure, Context, Result};
 
     pub use crate::var_int::VarInt;
-    pub use crate::{Decode, DecodePacket, Encode, EncodePacket};
+    pub use crate::{Decode, Encode, Packet};
 }
 
 /// The maximum number of bytes in a single Minecraft packet.
@@ -249,20 +249,21 @@ pub trait Decode<'a>: Sized {
     fn decode(r: &mut &'a [u8]) -> Result<Self>;
 }
 
-/// Like [`Encode`], but implementations must write a leading [`VarInt`] packet
-/// ID before any other data.
+/// Like [`Encode`] + [`Decode`], but implementations must read and write a
+/// leading [`VarInt`] packet ID before any other data.
 ///
 /// # Deriving
 ///
 /// This trait can be implemented automatically by using the
-/// [`EncodePacket`][macro] derive macro. The trait is implemented by writing
-/// the packet ID provided in the `#[packet_id = ...]` helper attribute followed
-/// by a call to [`Encode::encode`].
+/// [`Packet`][macro] derive macro. The trait is implemented by reading or
+/// writing the packet ID provided in the `#[packet_id = ...]` helper attribute
+/// followed by a call to [`Encode::encode`] or [`Decode::decode`]. The target
+/// type must implement [`Encode`], [`Decode`], and [`fmt::Debug`].
 ///
 /// ```
-/// use valence_protocol::{Encode, EncodePacket};
+/// use valence_protocol::{Encode, Packet};
 ///
-/// #[derive(Encode, EncodePacket, Debug)]
+/// #[derive(Encode, Packet, Debug)]
 /// #[packet_id = 42]
 /// struct MyStruct {
 ///     first: i32,
@@ -277,58 +278,22 @@ pub trait Decode<'a>: Sized {
 ///
 /// [macro]: valence_protocol_macros::DecodePacket
 /// [`VarInt`]: var_int::VarInt
-pub trait EncodePacket: fmt::Debug {
-    /// The packet ID that is written when [`Self::encode_packet`] is called. A
-    /// negative value indicates that the packet ID is not statically known.
+pub trait Packet<'a>: Sized + fmt::Debug {
+    /// The packet returned by [`Self::packet_id`]. If the packet ID is not
+    /// statically known, then a negative value is used instead.
     const PACKET_ID: i32 = -1;
-
     /// Like [`Encode::encode`], but a leading [`VarInt`] packet ID must be
     /// written first.
     ///
     /// [`VarInt`]: var_int::VarInt
     fn encode_packet(&self, w: impl Write) -> Result<()>;
-}
-
-/// Like [`Decode`], but implementations must read a leading [`VarInt`] packet
-/// ID before any other data.
-///
-/// # Deriving
-///
-/// This trait can be implemented automatically by using the
-/// [`DecodePacket`][macro] derive macro. The trait is implemented by reading
-/// the packet ID provided in the `#[packet_id = ...]` helper attribute followed
-/// by a call to [`Decode::decode`].
-///
-/// ```
-/// use valence_protocol::{Decode, DecodePacket};
-///
-/// #[derive(Decode, DecodePacket, Debug)]
-/// #[packet_id = 42]
-/// struct MyStruct {
-///     first: i32,
-/// }
-///
-/// let buf = [42, 0, 0, 0, 0];
-/// let mut r = buf.as_slice();
-///
-/// let value = MyStruct::decode_packet(&mut r).unwrap();
-///
-/// assert_eq!(value.first, 0);
-/// assert!(r.is_empty());
-/// ```
-///
-/// [macro]: valence_protocol::DecodePacket
-/// [`VarInt`]: var_int::VarInt
-pub trait DecodePacket<'a>: Sized + fmt::Debug {
-    /// The packet ID that is read when [`Self::decode_packet`] is called. A
-    /// negative value indicates that the packet ID is not statically known.
-    const PACKET_ID: i32 = -1;
-
     /// Like [`Decode::decode`], but a leading [`VarInt`] packet ID must be read
     /// first.
     ///
     /// [`VarInt`]: var_int::VarInt
     fn decode_packet(r: &mut &'a [u8]) -> Result<Self>;
+    /// Returns the ID of this packet.
+    fn packet_id(&self) -> i32;
 }
 
 #[allow(dead_code)]
@@ -336,7 +301,7 @@ pub trait DecodePacket<'a>: Sized + fmt::Debug {
 mod derive_tests {
     use super::*;
 
-    #[derive(Encode, EncodePacket, Decode, DecodePacket, Debug)]
+    #[derive(Encode, Decode, Packet, Debug)]
     #[packet_id = 1]
     struct RegularStruct {
         foo: i32,
@@ -344,30 +309,30 @@ mod derive_tests {
         baz: f64,
     }
 
-    #[derive(Encode, EncodePacket, Decode, DecodePacket, Debug)]
+    #[derive(Encode, Decode, Packet, Debug)]
     #[packet_id = 2]
     struct UnitStruct;
 
-    #[derive(Encode, EncodePacket, Decode, DecodePacket, Debug)]
+    #[derive(Encode, Decode, Packet, Debug)]
     #[packet_id = 3]
     struct EmptyStruct {}
 
-    #[derive(Encode, EncodePacket, Decode, DecodePacket, Debug)]
+    #[derive(Encode, Decode, Packet, Debug)]
     #[packet_id = 4]
     struct TupleStruct(i32, bool, f64);
 
-    #[derive(Encode, EncodePacket, Decode, DecodePacket, Debug)]
+    #[derive(Encode, Decode, Packet, Debug)]
     #[packet_id = 5]
-    struct StructWithGenerics<'z, T: fmt::Debug = ()> {
+    struct StructWithGenerics<'z, T = ()> {
         foo: &'z str,
         bar: T,
     }
 
-    #[derive(Encode, EncodePacket, Decode, DecodePacket, Debug)]
+    #[derive(Encode, Decode, Packet, Debug)]
     #[packet_id = 6]
-    struct TupleStructWithGenerics<'z, T: fmt::Debug = ()>(&'z str, i32, T);
+    struct TupleStructWithGenerics<'z, T = ()>(&'z str, i32, T);
 
-    #[derive(Encode, EncodePacket, Decode, DecodePacket, Debug)]
+    #[derive(Encode, Decode, Packet, Debug)]
     #[packet_id = 7]
     enum RegularEnum {
         Empty,
@@ -375,13 +340,13 @@ mod derive_tests {
         Fields { foo: i32, bar: bool, baz: f64 },
     }
 
-    #[derive(Encode, EncodePacket, Decode, DecodePacket, Debug)]
+    #[derive(Encode, Decode, Packet, Debug)]
     #[packet_id = 8]
     enum EmptyEnum {}
 
-    #[derive(Encode, EncodePacket, Decode, DecodePacket, Debug)]
+    #[derive(Encode, Decode, Packet, Debug)]
     #[packet_id = 0xbeef]
-    enum EnumWithGenericsAndTags<'z, T: fmt::Debug = ()> {
+    enum EnumWithGenericsAndTags<'z, T = ()> {
         #[tag = 5]
         First {
             foo: &'z str,
@@ -396,7 +361,7 @@ mod derive_tests {
     #[allow(unconditional_recursion)]
     fn has_impls<'a, T>()
     where
-        T: Encode + EncodePacket + Decode<'a> + DecodePacket<'a>,
+        T: Encode + Decode<'a> + Packet<'a>,
     {
         has_impls::<RegularStruct>();
         has_impls::<UnitStruct>();

--- a/crates/valence_protocol/src/lib.rs
+++ b/crates/valence_protocol/src/lib.rs
@@ -276,7 +276,7 @@ pub trait Decode<'a>: Sized {
 /// println!("{buf:?}");
 /// ```
 ///
-/// [macro]: valence_protocol_macros::DecodePacket
+/// [macro]: valence_protocol_macros::Packet
 /// [`VarInt`]: var_int::VarInt
 pub trait Packet<'a>: Sized + fmt::Debug {
     /// The packet returned by [`Self::packet_id`]. If the packet ID is not

--- a/crates/valence_protocol_macros/src/lib.rs
+++ b/crates/valence_protocol_macros/src/lib.rs
@@ -1,6 +1,6 @@
-//! This crate provides derive macros for [`Encode`], [`Decode`],
-//! [`EncodePacket`], and [`DecodePacket`].
-//! It also provides the procedural macro [`ident_str!`]
+//! This crate provides derive macros for [`Encode`], [`Decode`], and
+//! [`Packet`]. It also provides the procedural macro [`ident_str!`] for parsing
+//! identifiers at compile time.
 //!
 //! See `valence_protocol`'s documentation for more information.
 

--- a/crates/valence_protocol_macros/src/packet.rs
+++ b/crates/valence_protocol_macros/src/packet.rs
@@ -1,0 +1,87 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{parse2, parse_quote, Attribute, DeriveInput, Error, Lit, LitInt, Meta, Result};
+
+use crate::{add_trait_bounds, decode_split_for_impl};
+
+pub fn derive_packet(item: TokenStream) -> Result<TokenStream> {
+    let mut input = parse2::<DeriveInput>(item)?;
+
+    let Some(packet_id) = find_packet_id_attr(&input.attrs)? else {
+        return Err(Error::new(
+            input.ident.span(),
+            "cannot derive `Packet` without `#[packet_id = ...]` helper attribute",
+        ))
+    };
+
+    let lifetime = input
+        .generics
+        .lifetimes()
+        .next()
+        .map(|l| l.lifetime.clone())
+        .unwrap_or_else(|| parse_quote!('a));
+
+    add_trait_bounds(
+        &mut input.generics,
+        quote!(::valence_protocol::__private::Encode),
+    );
+
+    add_trait_bounds(
+        &mut input.generics,
+        quote!(::valence_protocol::__private::Decode<#lifetime>),
+    );
+
+    add_trait_bounds(&mut input.generics, quote!(::std::fmt::Debug));
+
+    let (impl_generics, ty_generics, where_clause) =
+        decode_split_for_impl(input.generics, lifetime.clone());
+
+    let name = input.ident;
+
+    Ok(quote! {
+        impl #impl_generics ::valence_protocol::__private::Packet<#lifetime> for #name #ty_generics
+        #where_clause
+        {
+            const PACKET_ID: i32 = #packet_id;
+
+            fn packet_id(&self) -> i32 {
+                #packet_id
+            }
+
+            fn encode_packet(&self, mut w: impl ::std::io::Write) -> ::valence_protocol::__private::Result<()> {
+                use ::valence_protocol::__private::{Encode, Context, VarInt};
+
+                VarInt(#packet_id)
+                    .encode(&mut w)
+                    .context("failed to encode packet ID")?;
+
+                self.encode(w)
+            }
+
+            fn decode_packet(r: &mut &#lifetime [u8]) -> ::valence_protocol::__private::Result<Self> {
+                use ::valence_protocol::__private::{Decode, Context, VarInt, ensure};
+
+                let id = VarInt::decode(r).context("failed to decode packet ID")?.0;
+                ensure!(id == #packet_id, "unexpected packet ID {} (expected {})", id, #packet_id);
+
+                Self::decode(r)
+            }
+        }
+    })
+}
+
+fn find_packet_id_attr(attrs: &[Attribute]) -> Result<Option<LitInt>> {
+    for attr in attrs {
+        if let Meta::NameValue(nv) = attr.parse_meta()? {
+            if nv.path.is_ident("packet_id") {
+                let span = nv.lit.span();
+                return match nv.lit {
+                    Lit::Int(i) => Ok(Some(i)),
+                    _ => Err(Error::new(span, "packet ID must be an integer literal")),
+                };
+            }
+        }
+    }
+
+    Ok(None)
+}


### PR DESCRIPTION
## Description

Combines the `EncodePacket` and `DecodePacket` trait into a single `Packet` trait. This makes `valence_protocol` simpler and easier to use. This can be done because all packets were made to be bidirectional in #253.

Additionally, a `packet_id` method has been added. This should help with #238.

## Test Plan

Steps:
1. Run examples, packet_inspector, etc. Behavior should be the same.
