### PR TITLE
Inventory module docs and more helper functions

### DIFF
--- a/crates/valence/examples/building.rs
+++ b/crates/valence/examples/building.rs
@@ -140,14 +140,12 @@ fn place_blocks(
         if client.game_mode() == GameMode::Survival {
             // check if the player has the item in their inventory and remove
             // it.
-            let slot = if stack.count() > 1 {
-                let mut stack = stack.clone();
-                stack.set_count(stack.count() - 1);
-                Some(stack)
+            if stack.count() > 1 {
+                let count = stack.count();
+                inventory.set_slot_amount(slot_id, count - 1);
             } else {
-                None
-            };
-            inventory.set_slot(slot_id, slot);
+                inventory.set_slot(slot_id, None);
+            }
         }
         let real_pos = event.position.get_in_direction(event.direction);
         instance.set_block(real_pos, block_kind.to_state());

--- a/crates/valence/examples/building.rs
+++ b/crates/valence/examples/building.rs
@@ -147,7 +147,7 @@ fn place_blocks(
             } else {
                 None
             };
-            inventory.replace_slot(slot_id, slot);
+            inventory.set_slot(slot_id, slot);
         }
         let real_pos = event.position.get_in_direction(event.direction);
         instance.set_block(real_pos, block_kind.to_state());

--- a/crates/valence/src/inventory.rs
+++ b/crates/valence/src/inventory.rs
@@ -833,7 +833,7 @@ mod test {
             .world
             .get_mut::<Inventory>(client_ent)
             .expect("could not find inventory for client");
-        inventory.replace_slot(20, ItemStack::new(ItemKind::Diamond, 2, None));
+        inventory.set_slot(20, ItemStack::new(ItemKind::Diamond, 2, None));
 
         // Process a tick to get past the "on join" logic.
         app.update();
@@ -896,7 +896,7 @@ mod test {
             .world
             .get_mut::<Inventory>(client_ent)
             .expect("could not find inventory for client");
-        inventory.replace_slot(20, ItemStack::new(ItemKind::Diamond, 2, None));
+        inventory.set_slot(20, ItemStack::new(ItemKind::Diamond, 2, None));
 
         // Process a tick to get past the "on join" logic.
         app.update();
@@ -907,7 +907,7 @@ mod test {
             .world
             .get_mut::<Inventory>(client_ent)
             .expect("could not find inventory for client");
-        inventory.replace_slot(21, ItemStack::new(ItemKind::IronIngot, 1, None));
+        inventory.set_slot(21, ItemStack::new(ItemKind::IronIngot, 1, None));
 
         app.update();
 
@@ -1037,7 +1037,7 @@ mod test {
             .world
             .get_mut::<Inventory>(inventory_ent)
             .expect("could not find inventory for client");
-        inventory.replace_slot(5, ItemStack::new(ItemKind::IronIngot, 1, None));
+        inventory.set_slot(5, ItemStack::new(ItemKind::IronIngot, 1, None));
 
         app.update();
 
@@ -1229,7 +1229,7 @@ mod test {
                 .world
                 .get_mut::<Inventory>(client_ent)
                 .expect("could not find inventory");
-            inventory.replace_slot(36, ItemStack::new(ItemKind::IronIngot, 3, None));
+            inventory.set_slot(36, ItemStack::new(ItemKind::IronIngot, 3, None));
 
             // Process a tick to get past the "on join" logic.
             app.update();
@@ -1284,7 +1284,7 @@ mod test {
                 .world
                 .get_mut::<Inventory>(client_ent)
                 .expect("could not find inventory");
-            inventory.replace_slot(36, ItemStack::new(ItemKind::IronIngot, 32, None));
+            inventory.set_slot(36, ItemStack::new(ItemKind::IronIngot, 32, None));
 
             // Process a tick to get past the "on join" logic.
             app.update();
@@ -1423,7 +1423,7 @@ mod test {
                 .world
                 .get_mut::<Inventory>(client_ent)
                 .expect("could not find inventory");
-            inventory.replace_slot(40, ItemStack::new(ItemKind::IronIngot, 32, None));
+            inventory.set_slot(40, ItemStack::new(ItemKind::IronIngot, 32, None));
 
             // Process a tick to get past the "on join" logic.
             app.update();
@@ -1471,7 +1471,7 @@ mod test {
                 .world
                 .get_mut::<Inventory>(client_ent)
                 .expect("could not find inventory");
-            inventory.replace_slot(40, ItemStack::new(ItemKind::IronIngot, 32, None));
+            inventory.set_slot(40, ItemStack::new(ItemKind::IronIngot, 32, None));
 
             // Process a tick to get past the "on join" logic.
             app.update();

--- a/crates/valence/src/inventory.rs
+++ b/crates/valence/src/inventory.rs
@@ -69,6 +69,7 @@ impl Inventory {
 
     #[track_caller]
     #[allow(unused_must_use)]
+    #[inline]
     pub fn set_slot(&mut self, idx: u16, item: impl Into<Option<ItemStack>>) {
         self.replace_slot(idx, item);
     }
@@ -417,12 +418,12 @@ fn handle_click_container(
             for slot in event.slot_changes.clone() {
                 if (0i16..target_inventory.slot_count() as i16).contains(&slot.idx) {
                     // the client is interacting with a slot in the target inventory
-                    target_inventory.replace_slot(slot.idx as u16, slot.item);
+                    target_inventory.set_slot(slot.idx as u16, slot.item);
                     open_inventory.client_modified |= 1 << slot.idx;
                 } else {
                     // the client is interacting with a slot in their own inventory
                     let slot_id = convert_to_player_slot_id(target_inventory.kind, slot.idx as u16);
-                    client_inventory.replace_slot(slot_id, slot.item);
+                    client_inventory.set_slot(slot_id, slot.item);
                     client.inventory_slots_modified |= 1 << slot_id;
                 }
             }
@@ -448,7 +449,7 @@ fn handle_click_container(
             client.cursor_item = event.carried_item.clone();
             for slot in event.slot_changes.clone() {
                 if (0i16..client_inventory.slot_count() as i16).contains(&slot.idx) {
-                    client_inventory.replace_slot(slot.idx as u16, slot.item);
+                    client_inventory.set_slot(slot.idx as u16, slot.item);
                     client.inventory_slots_modified |= 1 << slot.idx;
                 } else {
                     // the client is trying to interact with a slot that does not exist,
@@ -477,7 +478,7 @@ fn handle_set_slot_creative(
                 // the client is trying to interact with a slot that does not exist, ignore
                 continue;
             }
-            inventory.replace_slot(event.slot as u16, event.clicked_item.clone());
+            inventory.set_slot(event.slot as u16, event.clicked_item.clone());
             inventory.modified &= !(1 << event.slot); // clear the modified bit, since we are about to send the update
             client.inventory_state_id += 1;
             let state_id = client.inventory_state_id.0;

--- a/crates/valence/src/inventory.rs
+++ b/crates/valence/src/inventory.rs
@@ -126,10 +126,36 @@ impl Inventory {
         self.kind
     }
 
+    /// The text displayed on the inventory's title bar.
+    ///
+    /// ```
+    /// # use valence::inventory::{Inventory, InventoryKind};
+    /// # use valence_protocol::text::Text;
+    /// let inv = Inventory::with_title(InventoryKind::Generic9x3, "Box of Holding");
+    /// assert_eq!(inv.title(), &Text::from("Box of Holding"));
+    /// ```
     pub fn title(&self) -> &Text {
         &self.title
     }
 
+    /// Set the text displayed on the inventory's title bar.
+    ///
+    /// To get the old title, use [`replace_title`].
+    ///
+    /// ```
+    /// # use valence::inventory::{Inventory, InventoryKind};
+    /// let mut inv = Inventory::new(InventoryKind::Generic9x3);
+    /// inv.set_title("Box of Holding");
+    /// ```
+    #[allow(unused_must_use)]
+    #[inline]
+    pub fn set_title(&mut self, title: impl Into<Text>) {
+        self.replace_title(title);
+    }
+
+    /// Replace the text displayed on the inventory's title bar, and returns the
+    /// old text.
+    #[must_use]
     pub fn replace_title(&mut self, title: impl Into<Text>) -> Text {
         // TODO: set title modified flag
         std::mem::replace(&mut self.title, title.into())

--- a/crates/valence/src/inventory.rs
+++ b/crates/valence/src/inventory.rs
@@ -107,10 +107,9 @@ impl Inventory {
     /// assert_eq!(inv.slot(0).unwrap().item, ItemKind::Diamond);
     /// ```
     #[track_caller]
-    #[allow(unused_must_use)]
     #[inline]
     pub fn set_slot(&mut self, idx: u16, item: impl Into<Option<ItemStack>>) {
-        self.replace_slot(idx, item);
+        let _ = self.replace_slot(idx, item);
     }
 
     /// Replaces the slot at the given index with the given item stack, and
@@ -234,10 +233,9 @@ impl Inventory {
     /// let mut inv = Inventory::new(InventoryKind::Generic9x3);
     /// inv.set_title("Box of Holding");
     /// ```
-    #[allow(unused_must_use)]
     #[inline]
     pub fn set_title(&mut self, title: impl Into<Text>) {
-        self.replace_title(title);
+        let _ = self.replace_title(title);
     }
 
     /// Replace the text displayed on the inventory's title bar, and returns the

--- a/crates/valence/src/inventory.rs
+++ b/crates/valence/src/inventory.rs
@@ -1,3 +1,31 @@
+//! The inventory system.
+//!
+//! This module contains the systems and components needed to handle
+//! inventories. By default, clients will have a player inventory attached to
+//! them.
+//!
+//! # Components
+//!
+//! - [`Inventory`]: The inventory component. This is the thing that holds
+//!   items.
+//! - [`OpenInventory`]: The component that is attached to clients when they
+//!   have an inventory open.
+//!
+//! # Examples
+//!
+//! An example system that will let you access all player's inventories:
+//!
+//! ```rust
+//! # use valence::prelude::*;
+//! fn system(mut clients: Query<(&Client, &Inventory)>) {}
+//! ```
+//!
+//! ### See also
+//!
+//! Examples related to inventories in the `examples/` directory:
+//! - `building`
+//! - `chest`
+
 use std::borrow::Cow;
 use std::iter::FusedIterator;
 

--- a/crates/valence/src/inventory.rs
+++ b/crates/valence/src/inventory.rs
@@ -264,20 +264,14 @@ impl Inventory {
     /// ```
     #[track_caller]
     #[must_use]
-    pub fn first_empty_slot_in(&self, range: Range<u16>) -> Option<u16> {
+    pub fn first_empty_slot_in(&self, mut range: Range<u16>) -> Option<u16> {
         assert!(
             (0..=self.slot_count()).contains(&range.start)
                 && (0..=self.slot_count()).contains(&range.end),
             "slot range out of range"
         );
 
-        for idx in range {
-            if self.slots[idx as usize].is_none() {
-                return Some(idx);
-            }
-        }
-
-        None
+        range.find(|&idx| self.slots[idx as usize].is_none())
     }
 
     /// Returns the first empty slot in the inventory, or `None` if there are no

--- a/crates/valence/src/inventory.rs
+++ b/crates/valence/src/inventory.rs
@@ -68,12 +68,14 @@ impl Inventory {
     }
 
     /// Sets the slot at the given index to the given item stack.
+    ///
+    /// See also [`Inventory::replace_slot`].
+    ///
     /// ```
     /// # use valence::prelude::*;
     /// let mut inv = Inventory::new(InventoryKind::Generic9x1);
     /// inv.set_slot(0, ItemStack::new(ItemKind::Diamond, 1, None));
-    /// let old = inv.replace_slot(0, ItemStack::new(ItemKind::IronIngot, 1, None));
-    /// assert_eq!(old.unwrap().item, ItemKind::Diamond);
+    /// assert_eq!(inv.slot(0).unwrap().item, ItemKind::Diamond);
     /// ```
     #[track_caller]
     #[allow(unused_must_use)]
@@ -84,6 +86,16 @@ impl Inventory {
 
     /// Replaces the slot at the given index with the given item stack, and
     /// returns the old stack in that slot.
+    ///
+    /// See also [`Inventory::set_slot`].
+    ///
+    /// ```
+    /// # use valence::prelude::*;
+    /// let mut inv = Inventory::new(InventoryKind::Generic9x1);
+    /// inv.set_slot(0, ItemStack::new(ItemKind::Diamond, 1, None));
+    /// let old = inv.replace_slot(0, ItemStack::new(ItemKind::IronIngot, 1, None));
+    /// assert_eq!(old.unwrap().item, ItemKind::Diamond);
+    /// ```
     #[track_caller]
     #[must_use]
     pub fn replace_slot(

--- a/crates/valence/src/inventory.rs
+++ b/crates/valence/src/inventory.rs
@@ -68,6 +68,13 @@ impl Inventory {
     }
 
     #[track_caller]
+    #[allow(unused_must_use)]
+    pub fn set_slot(&mut self, idx: u16, item: impl Into<Option<ItemStack>>) {
+        self.replace_slot(idx, item);
+    }
+
+    #[track_caller]
+    #[must_use]
     pub fn replace_slot(
         &mut self,
         idx: u16,

--- a/crates/valence/src/inventory.rs
+++ b/crates/valence/src/inventory.rs
@@ -198,7 +198,7 @@ impl Inventory {
 
     /// Set the text displayed on the inventory's title bar.
     ///
-    /// To get the old title, use [`replace_title`].
+    /// To get the old title, use [`Inventory::replace_title`].
     ///
     /// ```
     /// # use valence::inventory::{Inventory, InventoryKind};


### PR DESCRIPTION
<!-- Please make sure that your PR is aligned with the guidelines in CONTRIBUTING.md to the best of your ability. -->
<!-- Good PRs have tests! Make sure you have sufficient test coverage. -->

## Description

<!-- Describe the changes you've made. You may include any justification you want here. -->

This mostly adds docs, but it also adds (and documents) some new helper functions:

- `set_title()` - Allows us to put `must_use` on `replace_title`
- `set_slot()` - Allows us to put `must_use` on `replace_slot`
- `set_slot_amount()` - Allows users to modify stack counts without cloning the entire stack and replacing it. Useful if the stack has a lot of NBT data.
- `first_empty_slot()`
- `first_empty_slot_in()` - Useful, trivial to provide

## Test Plan

<!-- Explain how you tested your changes, and include any code that you used to test this. -->
<!-- If there is an example that is sufficient to use in place of a playground, replace the playground section with a note that indicates this.  -->

<details>

<summary>Playground</summary>

```rust
N/A
```

</details>

<!-- You need to include steps regardless of whether or not you are using a playground. -->
Steps:
1. `cargo test -p valence --doc`

#### Related

<!-- Link to any issues that have context for this or that this PR fixes. -->
