### PR TITLE
Set bevy version to 0.10

### DIFF
--- a/crates/valence/Cargo.toml
+++ b/crates/valence/Cargo.toml
@@ -16,8 +16,8 @@ anyhow = "1.0.65"
 arrayvec = "0.7.2"
 async-trait = "0.1.60"
 base64 = "0.21.0"
-bevy_app = { git = "https://github.com/bevyengine/bevy/", rev = "2ea00610188dce1eba1172a3ded8244570189230" }
-bevy_ecs = { git = "https://github.com/bevyengine/bevy/", rev = "2ea00610188dce1eba1172a3ded8244570189230" }
+bevy_app = "0.10"
+bevy_ecs = "0.10"
 bitfield-struct = "0.3.1"
 bytes = "1.2.1"
 flume = "0.10.14"

--- a/crates/valence_anvil/Cargo.toml
+++ b/crates/valence_anvil/Cargo.toml
@@ -20,7 +20,7 @@ valence_nbt = { version = "0.5.0", path = "../valence_nbt" }
 
 [dev-dependencies]
 anyhow = "1.0.68"
-bevy_ecs = { git = "https://github.com/bevyengine/bevy/", rev = "2ea00610188dce1eba1172a3ded8244570189230" }
+bevy_ecs = "0.10"
 clap = "4.1.4"
 criterion = "0.4.0"
 flume = "0.10.14"


### PR DESCRIPTION
## Description

Sets Bevy dependencies to version 0.10 instead of the previous commit hash.

