### PR TITLE
Tweak templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,26 +6,21 @@ body:
     attributes:
       label: Valence Version
       description: What version of Valence are you using? If you are targeting a specific commit or branch, put that instead.
-      placeholder: version, branch, or commit hash
+      placeholder: Version, branch, or commit hash.
     validations:
       required: true
   - type: textarea
     attributes:
       label: Current Behavior
-      description: A concise description of what you're experiencing.
+      description: A concise description of what you're experiencing. Include any screenshots or additional information here.
     validations:
       required: false
   - type: textarea
     attributes:
       label: Expected Behavior
-      description: A concise description of what you expected to happen.
+      description: A concise description of what you expected to happen. 
     validations:
       required: true
-  - type: textarea
-    attributes:
-      label: Minimal Reproducible Example
-      description: Do you have a playground to reproduce this bug? Paste it here. It should be a minimal example that exhibits the behavior. If the problem can be reproduced with one of the examples, just indicate which one instead.
-      render: Rust
   - type: textarea
     attributes:
       label: Steps To Reproduce
@@ -37,19 +32,10 @@ body:
         4. See error
     validations:
       required: true
-  - type: checkboxes
-    attributes:
-      label: Checklist
-      options:
-        - label: I have searched the issues of this repo and believe that this is not a duplicate.
-          required: true
-        - label: This used to work before.
   - type: textarea
     attributes:
-      label: Anything else?
-      description: |
-        Links? References? Version Numbers? Anything that will give us more context about the issue you are encountering!
-
-        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+      label: Minimal Reproducible Example
+      description: A minimal example that exhibits the behavior. If you have a playground, paste it here. If the problem can be reproduced with one of the examples, just indicate which one instead.
+      render: Rust
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -4,16 +4,14 @@ labels: [enhancement]
 body:
   - type: textarea
     attributes:
-      label: Is your feature request related to a problem? Please describe.
-      description: A clear and concise description of what the problem is.
-      placeholder: I'm always frustrated when...
+      label: Describe the problem related to your feature request.
+      description: A clear description of what the problem is.
     validations:
       required: true
   - type: textarea
     attributes:
-      label: Describe the solution you'd like
-      description: A clear and concise description of what you want to happen.
-      placeholder: I would like to be able to...
+      label: Describe the solution you would like.
+      description: The solution you propose for the problem presented.
     validations:
       required: true
   - type: textarea

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,13 @@
-<!-- Please make sure that your PR is aligned with the guidelines in CONTRIBUTING.md to the best of your ability. -->
-<!-- Good PRs have tests! Make sure you have sufficient test coverage. -->
-
 ## Description
 
-<!-- Describe the changes you've made. You may include any justification you want here. -->
+Describe the changes you've made. Link to any issues that this PR fixes or addresses.
 
 ## Test Plan
 
-<!-- Explain how you tested your changes, and include any code that you used to test this. -->
-<!-- If there is an example that is sufficient to use in place of a playground, replace the playground section with a note that indicates this.  -->
+Explain the steps necessary to test your changes. If you used a playground, include the code in the details below.
+
+Steps:
+1.
 
 <details>
 
@@ -19,11 +18,3 @@ PASTE YOUR PLAYGROUND CODE HERE
 ```
 
 </details>
-
-<!-- You need to include steps regardless of whether or not you are using a playground. -->
-Steps:
-1.
-
-#### Related
-
-<!-- Link to any issues that have context for this or that this PR fixes. -->


### PR DESCRIPTION
## Description

Change the issue and pull request templates.

- Remove HTML comments from the markdown because it's often not deleted and takes up space in the final commit description.
- Remove the "related" section in the PR template because links to other issues will naturally end up in the "description" section.
- Remove some placeholder text in the feature request template.
- Remove the check boxes from the bug report template to avoid creating "tasks".
- The number of sections in the bug report template was a bit daunting IMO so I trimmed it down a bit.
