### PR TITLE
Add `packet_name`

### DIFF
--- a/crates/valence_protocol/src/packet.rs
+++ b/crates/valence_protocol/src/packet.rs
@@ -41,6 +41,10 @@ macro_rules! packet_group {
                     $packet_id
                 }
 
+                fn packet_name(&self) -> &str {
+                    stringify!($packet)
+                }
+
                 #[allow(unused_imports)]
                 fn encode_packet(&self, mut w: impl std::io::Write) -> crate::Result<()> {
                     use ::valence_protocol::__private::{Encode, Context, VarInt};
@@ -69,6 +73,14 @@ macro_rules! packet_group {
                 match self {
                     $(
                         Self::$packet(_) => <$packet as crate::Packet>::PACKET_ID,
+                    )*
+                }
+            }
+
+            fn packet_name(&self) -> &str {
+                match self {
+                    $(
+                        Self::$packet(pkt) => pkt.packet_name(),
                     )*
                 }
             }
@@ -142,6 +154,10 @@ macro_rules! packet_group {
                     $packet_id
                 }
 
+                fn packet_name(&self) -> &str {
+                    stringify!($packet_name)
+                }
+
                 #[allow(unused_imports)]
                 fn encode_packet(&self, mut w: impl std::io::Write) -> crate::Result<()> {
                     use ::valence_protocol::__private::{Encode, Context, VarInt};
@@ -170,6 +186,14 @@ macro_rules! packet_group {
                 match self {
                     $(
                         Self::$packet(_) => <$packet as crate::Packet>::PACKET_ID,
+                    )*
+                }
+            }
+
+            fn packet_name(&self) -> &str {
+                match self {
+                    $(
+                        Self::$packet(pkt) => pkt.packet_name(),
                     )*
                 }
             }

--- a/crates/valence_protocol/src/types.rs
+++ b/crates/valence_protocol/src/types.rs
@@ -16,8 +16,9 @@ pub struct PublicKeyData<'a> {
     pub signature: &'a [u8],
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Encode, Decode)]
+#[derive(Copy, Clone, PartialEq, Eq, Default, Debug, Encode, Decode)]
 pub enum Hand {
+    #[default]
     Main,
     Off,
 }


### PR DESCRIPTION
## Description

Adds `packet_name` method to the `Packet` trait to help with #238.

## Test Plan

Steps:
1. `cargo t -p valence_protocol`
