### PR TITLE
Add `RawPacket`

### DIFF
--- a/crates/valence/src/server/connect.rs
+++ b/crates/valence/src/server/connect.rs
@@ -31,7 +31,7 @@ use valence_protocol::packet::s2c::login::{
     LoginCompressionS2c, LoginDisconnectS2c, LoginHelloS2c, LoginQueryRequestS2c, LoginSuccessS2c,
 };
 use valence_protocol::packet::s2c::status::{QueryPongS2c, QueryResponseS2c};
-use valence_protocol::raw_bytes::RawBytes;
+use valence_protocol::raw::RawBytes;
 use valence_protocol::text::Text;
 use valence_protocol::types::Property;
 use valence_protocol::username::Username;

--- a/crates/valence_protocol/src/lib.rs
+++ b/crates/valence_protocol/src/lib.rs
@@ -95,7 +95,7 @@ pub mod ident;
 mod impls;
 pub mod item;
 pub mod packet;
-pub mod raw_bytes;
+pub mod raw;
 pub mod sound;
 pub mod text;
 pub mod tracked_data;

--- a/crates/valence_protocol/src/packet/c2s/login/login_query_response.rs
+++ b/crates/valence_protocol/src/packet/c2s/login/login_query_response.rs
@@ -1,4 +1,4 @@
-use crate::raw_bytes::RawBytes;
+use crate::raw::RawBytes;
 use crate::var_int::VarInt;
 use crate::{Decode, Encode};
 

--- a/crates/valence_protocol/src/packet/c2s/play/custom_payload.rs
+++ b/crates/valence_protocol/src/packet/c2s/play/custom_payload.rs
@@ -1,5 +1,5 @@
 use crate::ident::Ident;
-use crate::raw_bytes::RawBytes;
+use crate::raw::RawBytes;
 use crate::{Decode, Encode};
 
 #[derive(Copy, Clone, Debug, Encode, Decode)]

--- a/crates/valence_protocol/src/packet/s2c/login/login_query_request.rs
+++ b/crates/valence_protocol/src/packet/s2c/login/login_query_request.rs
@@ -1,5 +1,5 @@
 use crate::ident::Ident;
-use crate::raw_bytes::RawBytes;
+use crate::raw::RawBytes;
 use crate::var_int::VarInt;
 use crate::{Decode, Encode};
 

--- a/crates/valence_protocol/src/packet/s2c/play/custom_payload.rs
+++ b/crates/valence_protocol/src/packet/s2c/play/custom_payload.rs
@@ -1,5 +1,5 @@
 use crate::ident::Ident;
-use crate::raw_bytes::RawBytes;
+use crate::raw::RawBytes;
 use crate::{Decode, Encode};
 
 #[derive(Copy, Clone, Debug, Encode, Decode)]

--- a/crates/valence_protocol/src/packet/s2c/play/entity_tracker_update.rs
+++ b/crates/valence_protocol/src/packet/s2c/play/entity_tracker_update.rs
@@ -1,4 +1,4 @@
-use crate::raw_bytes::RawBytes;
+use crate::raw::RawBytes;
 use crate::var_int::VarInt;
 use crate::{Decode, Encode};
 

--- a/crates/valence_protocol/src/raw.rs
+++ b/crates/valence_protocol/src/raw.rs
@@ -22,7 +22,7 @@ impl Encode for RawBytes<'_> {
 
 impl<'a> Decode<'a> for RawBytes<'a> {
     fn decode(r: &mut &'a [u8]) -> Result<Self> {
-        Ok(Self(mem::replace(r, &[])))
+        Ok(Self(mem::take(r)))
     }
 }
 
@@ -57,6 +57,6 @@ impl<'a> Packet<'a> for RawPacket<'a> {
     }
 
     fn decode_packet(r: &mut &'a [u8]) -> Result<Self> {
-        Ok(Self(mem::replace(r, &[])))
+        Ok(Self(mem::take(r)))
     }
 }

--- a/crates/valence_protocol/src/raw.rs
+++ b/crates/valence_protocol/src/raw.rs
@@ -1,6 +1,7 @@
 use std::io::Write;
+use std::mem;
 
-use crate::{Decode, Encode, Result};
+use crate::{Decode, Encode, Packet, Result};
 
 /// While [encoding], the contained slice is written directly to the output
 /// without any length prefix or metadata.
@@ -10,7 +11,7 @@ use crate::{Decode, Encode, Result};
 ///
 /// [encoding]: Encode
 /// [decoding]: Decode
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Debug)]
 pub struct RawBytes<'a>(pub &'a [u8]);
 
 impl Encode for RawBytes<'_> {
@@ -21,9 +22,7 @@ impl Encode for RawBytes<'_> {
 
 impl<'a> Decode<'a> for RawBytes<'a> {
     fn decode(r: &mut &'a [u8]) -> Result<Self> {
-        let slice = *r;
-        *r = &[];
-        Ok(Self(slice))
+        Ok(Self(mem::replace(r, &[])))
     }
 }
 
@@ -36,5 +35,28 @@ impl<'a> From<&'a [u8]> for RawBytes<'a> {
 impl<'a> From<RawBytes<'a>> for &'a [u8] {
     fn from(value: RawBytes<'a>) -> Self {
         value.0
+    }
+}
+
+/// A fake [`Packet`] which simply reads all data into a slice, or writes all
+/// data from a slice. The packet ID is included in the slice.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Debug)]
+pub struct RawPacket<'a>(pub &'a [u8]);
+
+impl<'a> Packet<'a> for RawPacket<'a> {
+    fn packet_id(&self) -> i32 {
+        -1
+    }
+
+    fn packet_name(&self) -> &str {
+        "RawPacket"
+    }
+
+    fn encode_packet(&self, mut w: impl Write) -> Result<()> {
+        Ok(w.write_all(self.0)?)
+    }
+
+    fn decode_packet(r: &mut &'a [u8]) -> Result<Self> {
+        Ok(Self(mem::replace(r, &[])))
     }
 }


### PR DESCRIPTION
## Description

Adds a `RawPacket` type to `valence_protocol`. This type simply reads and writes data to a slice, analogous to the `RawBytes` type in the same module.

## Test Plan

Steps:
1. `cargo t -p valence_protocol`
