### PR TITLE
Add caching layer to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,10 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: ${{ runner.os }}-cargo-
+        key: ${{ runner.os }}-cargo-target-${{ hashFiles('**/Cargo.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-target-${{ hashFiles('**/Cargo.toml') }}
+          ${{ runner.os }}-cargo-target
     - name: Validate formatting
       run: cargo fmt --all -- --check
     - name: Validate documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,18 @@ jobs:
       with:
         components: clippy, rustfmt
     - run: cp crates/playground/src/playground.template.rs crates/playground/src/playground.rs
+    - name: Set up cargo cache
+      uses: actions/cache@v3
+      continue-on-error: false
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: ${{ runner.os }}-cargo-
     - name: Validate formatting
       run: cargo fmt --all -- --check
     - name: Validate documentation

--- a/crates/packet_inspector/src/main.rs
+++ b/crates/packet_inspector/src/main.rs
@@ -50,11 +50,6 @@ struct Cli {
     /// there is no limit.
     #[clap(short, long)]
     max_connections: Option<usize>,
-
-    /// This does absolutely nothing. Added here to force a recompile on the action to compare times.
-    /// It will be removed again once the action is done.
-    #[clap(long)]
-    nogui: bool,
 }
 
 struct State {

--- a/crates/packet_inspector/src/main.rs
+++ b/crates/packet_inspector/src/main.rs
@@ -50,6 +50,11 @@ struct Cli {
     /// there is no limit.
     #[clap(short, long)]
     max_connections: Option<usize>,
+
+    /// This does absolutely nothing. Added here to force a recompile on the action to compare times.
+    /// It will be removed again once the action is done.
+    #[clap(long)]
+    nogui: bool,
 }
 
 struct State {


### PR DESCRIPTION
Added a caching layer to the CI

This creates a cache on first run (should exist because of this pr now)
The hash is calculated from the Cargo.toml files (recursively if i've done it correctly)
So whenever a Cargo.toml file changes, it invalidates the cache.

Local crates are _not_ cached, so they get recompiled regardless, but it already shaves off like half the total time from the action runners.