### PR TITLE
Replaced `valence_protocol` and `valence_nbt` imports with `valence` ones

### DIFF
--- a/crates/valence/examples/block_entities.rs
+++ b/crates/valence/examples/block_entities.rs
@@ -1,8 +1,8 @@
 use valence::client::despawn_disconnected_clients;
 use valence::client::event::{default_event_handler, ChatMessage, PlayerInteractBlock};
+use valence::nbt::{compound, List};
 use valence::prelude::*;
-use valence_nbt::{compound, List};
-use valence_protocol::types::Hand;
+use valence::protocol::types::Hand;
 
 const FLOOR_Y: i32 = 64;
 const SIGN_POS: [i32; 3] = [3, FLOOR_Y + 1, 2];

--- a/crates/valence/examples/building.rs
+++ b/crates/valence/examples/building.rs
@@ -3,7 +3,7 @@ use valence::client::event::{
     default_event_handler, PlayerInteractBlock, StartDigging, StartSneaking, StopDestroyBlock,
 };
 use valence::prelude::*;
-use valence_protocol::types::Hand;
+use valence::protocol::types::Hand;
 
 const SPAWN_Y: i32 = 64;
 


### PR DESCRIPTION
## Description

This PR replace `valence_protocol` and `valence_nbt` imports in `crates/valence/examples` with `valence` ones so you don't have to change imports or import the crates when you copy the examples and have only `valence` as a dependency.