### PR TITLE
Rename valence_protocol to valence::protocol

### DIFF
--- a/crates/valence/examples/parkour.rs
+++ b/crates/valence/examples/parkour.rs
@@ -6,9 +6,9 @@ use rand::Rng;
 use valence::client::despawn_disconnected_clients;
 use valence::client::event::default_event_handler;
 use valence::prelude::*;
-use valence_protocol::packet::s2c::play::TitleFadeS2c;
-use valence_protocol::sound::Sound;
-use valence_protocol::types::SoundCategory;
+use valence::protocol::packet::s2c::play::TitleFadeS2c;
+use valence::protocol::sound::Sound;
+use valence::protocol::types::SoundCategory;
 
 const START_POS: BlockPos = BlockPos::new(0, 100, 0);
 const VIEW_DIST: u8 = 10;

--- a/crates/valence/examples/resource_pack.rs
+++ b/crates/valence/examples/resource_pack.rs
@@ -3,7 +3,7 @@ use valence::client::event::{
     default_event_handler, PlayerInteract, ResourcePackStatus, ResourcePackStatusChange,
 };
 use valence::prelude::*;
-use valence_protocol::packet::c2s::play::player_interact::Interaction;
+use valence::protocol::packet::c2s::play::player_interact::Interaction;
 
 const SPAWN_Y: i32 = 64;
 

--- a/crates/valence/examples/text.rs
+++ b/crates/valence/examples/text.rs
@@ -1,7 +1,7 @@
 use valence::client::despawn_disconnected_clients;
 use valence::client::event::default_event_handler;
 use valence::prelude::*;
-use valence_protocol::translation_key;
+use valence::protocol::translation_key;
 
 const SPAWN_Y: i32 = 64;
 


### PR DESCRIPTION
## Description

Replaced the remaining `valence_protcol` with `valence::protocol` in the examples
