### PR TITLE
Refactor Schedule

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = ["crates/*"]
 exclude = ["rust-mc-bot"]
+resolver = "2"
 
 [profile.dev.package."*"]
 opt-level = 3

--- a/crates/valence/src/client/event.rs
+++ b/crates/valence/src/client/event.rs
@@ -1,8 +1,10 @@
 use std::cmp;
 
 use anyhow::bail;
+use bevy_app::{CoreSet, Plugin};
 use bevy_ecs::prelude::*;
 use bevy_ecs::query::WorldQuery;
+use bevy_ecs::schedule::ScheduleLabel;
 use bevy_ecs::system::{SystemParam, SystemState};
 use glam::{DVec3, Vec3};
 use paste::paste;
@@ -39,7 +41,6 @@ use crate::client::Client;
 use crate::component::{Look, OnGround, Ping, Position};
 use crate::entity::{EntityAnimation, EntityKind, McEntity, TrackedData};
 use crate::inventory::Inventory;
-use crate::server::EventLoopSchedule;
 
 #[derive(Clone, Debug)]
 pub struct QueryBlockNbt {
@@ -527,7 +528,7 @@ macro_rules! events {
         )*
     ) => {
         /// Inserts [`Events`] resources into the world for each client event.
-        pub(crate) fn register_client_events(world: &mut World) {
+        fn register_client_events(world: &mut World) {
             $(
                 $(
                     world.insert_resource(Events::<$name>::default());
@@ -641,6 +642,31 @@ events! {
     }
 }
 
+pub(crate) struct ClientEventPlugin;
+
+/// The [`ScheduleLabel`] for the event loop [`Schedule`].
+#[derive(ScheduleLabel, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Debug)]
+pub struct EventLoopSchedule;
+
+/// The default base set for [`EventLoopSchedule`].
+#[derive(SystemSet, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Debug)]
+pub struct EventLoopSet;
+
+impl Plugin for ClientEventPlugin {
+    fn build(&self, app: &mut bevy_app::App) {
+        register_client_events(&mut app.world);
+
+        app.configure_set(EventLoopSet.in_base_set(CoreSet::PreUpdate))
+            .add_system(run_event_loop.in_set(EventLoopSet));
+
+        // Add the event loop schedule.
+        let mut event_loop = Schedule::new();
+        event_loop.set_default_base_set(EventLoopSet);
+
+        app.add_schedule(EventLoopSchedule, event_loop);
+    }
+}
+
 #[derive(WorldQuery)]
 #[world_query(mutable)]
 pub(crate) struct EventLoopQuery {
@@ -659,7 +685,7 @@ pub(crate) struct EventLoopQuery {
 }
 
 /// An exclusive system for running the event loop schedule.
-pub(crate) fn run_event_loop(
+fn run_event_loop(
     world: &mut World,
     state: &mut SystemState<(Query<EventLoopQuery>, ClientEvents, Commands)>,
     mut clients_to_check: Local<Vec<Entity>>,

--- a/crates/valence/src/client/event.rs
+++ b/crates/valence/src/client/event.rs
@@ -1410,7 +1410,7 @@ fn handle_one_packet(
 /// is subject to change.
 ///
 /// This system must be scheduled to run in the
-/// [`EventLoopSchedule`](crate::server::EventLoopSchedule). Otherwise, it may
+/// [`EventLoopSchedule`]. Otherwise, it may
 /// not function correctly.
 #[allow(clippy::too_many_arguments)]
 pub fn default_event_handler(

--- a/crates/valence/src/component.rs
+++ b/crates/valence/src/component.rs
@@ -1,11 +1,13 @@
 use std::fmt;
 
+use bevy_app::{CoreSet, Plugin};
 /// Contains shared components and world queries.
 use bevy_ecs::prelude::*;
 use glam::{DVec3, Vec3};
 use uuid::Uuid;
 use valence_protocol::types::{GameMode as ProtocolGameMode, Property};
 
+use crate::prelude::FlushPacketsSet;
 use crate::util::{from_yaw_and_pitch, to_yaw_and_pitch};
 use crate::view::ChunkPos;
 use crate::NULL_ENTITY;
@@ -111,12 +113,6 @@ impl Default for Location {
 pub struct OldLocation(Entity);
 
 impl OldLocation {
-    pub(crate) fn update(mut query: Query<(&Location, &mut OldLocation), Changed<Location>>) {
-        for (loc, mut old_loc) in &mut query {
-            old_loc.0 = loc.0;
-        }
-    }
-
     pub fn new(instance: Entity) -> Self {
         Self(instance)
     }
@@ -153,12 +149,6 @@ impl Position {
 pub struct OldPosition(DVec3);
 
 impl OldPosition {
-    pub(crate) fn update(mut query: Query<(&Position, &mut OldPosition), Changed<Position>>) {
-        for (pos, mut old_pos) in &mut query {
-            old_pos.0 = pos.0;
-        }
-    }
-
     pub fn new(pos: DVec3) -> Self {
         Self(pos)
     }
@@ -201,4 +191,39 @@ impl Look {
 pub struct OnGround(pub bool);
 
 #[derive(Component, Default, Debug)]
-pub struct ScratchBuffer(pub Vec<u8>);
+pub struct ScratchBuf(pub Vec<u8>);
+
+pub(crate) struct ComponentPlugin;
+
+impl Plugin for ComponentPlugin {
+    fn build(&self, app: &mut bevy_app::App) {
+        app.add_systems(
+            (update_old_position, update_old_location)
+                .in_base_set(CoreSet::PostUpdate)
+                .after(FlushPacketsSet),
+        )
+        // This is fine because we're applying system buffers later.
+        .add_system(despawn_marked_entities.in_base_set(CoreSet::PostUpdate
+        ));
+    }
+}
+
+fn update_old_position(mut query: Query<(&Position, &mut OldPosition), Changed<Position>>) {
+    for (pos, mut old_pos) in &mut query {
+        old_pos.0 = pos.0;
+    }
+}
+
+fn update_old_location(mut query: Query<(&Location, &mut OldLocation), Changed<Location>>) {
+    for (loc, mut old_loc) in &mut query {
+        old_loc.0 = loc.0;
+    }
+}
+
+/// Despawns all the entities marked as despawned with the [`Despawned`]
+/// component.
+fn despawn_marked_entities(mut commands: Commands, entities: Query<Entity, With<Despawned>>) {
+    for entity in &entities {
+        commands.entity(entity).despawn();
+    }
+}

--- a/crates/valence/src/lib.rs
+++ b/crates/valence/src/lib.rs
@@ -49,6 +49,7 @@ pub mod prelude {
     pub use bevy_app::prelude::*;
     pub use bevy_ecs::prelude::*;
     pub use biome::{Biome, BiomeId};
+    pub use client::event::{EventLoopSchedule, EventLoopSet};
     pub use client::*;
     pub use component::*;
     pub use config::{
@@ -66,7 +67,7 @@ pub mod prelude {
     pub use protocol::ident::Ident;
     pub use protocol::item::{ItemKind, ItemStack};
     pub use protocol::text::{Color, Text, TextFormat};
-    pub use server::{EventLoopSchedule, EventLoopSet, NewClientInfo, Server, SharedServer};
+    pub use server::{NewClientInfo, Server, SharedServer};
     pub use uuid::Uuid;
     pub use valence_nbt::Compound;
     pub use valence_protocol::block::BlockKind;

--- a/crates/valence/src/player_list.rs
+++ b/crates/valence/src/player_list.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::iter::FusedIterator;
 use std::mem;
 
-use bevy_app::{Plugin, CoreSet};
+use bevy_app::{CoreSet, Plugin};
 use bevy_ecs::prelude::*;
 use bevy_ecs::schedule::SystemConfigs;
 use tracing::warn;

--- a/crates/valence_protocol/src/packet/s2c/play/scoreboard_display.rs
+++ b/crates/valence_protocol/src/packet/s2c/play/scoreboard_display.rs
@@ -1,6 +1,5 @@
-use crate::{Decode, Encode};
-
 use super::team::TeamColor;
+use crate::{Decode, Encode};
 
 #[derive(Copy, Clone, Debug, Encode, Decode)]
 pub struct ScoreboardDisplayS2c<'a> {


### PR DESCRIPTION
## Description

- Tweak the system schedule to be more parallel-friendly and explicit. Dependencies between systems is clearer.
- System and resource configuration is better encapsulated in each module by using plugins.

The schedule graph for `Main` now looks like this (using `bevy_mod_debugdump`):

![graph](https://user-images.githubusercontent.com/31678482/225321113-0ec4f4dd-86f6-45fe-8158-12a451536770.svg)

### Unresolved

- What to do about ambiguous systems? Many systems here are ambiguous because they take `&mut Client`, but the order they write packets isn't really important. Marking them as ambiguous explicitly with `.ambiguous_with*` across module boundaries seems difficult and cumbersome.

## Test Plan

Steps:
1. Run examples. Check that I didn't screw up the system order.
