### PR TITLE
tiny one line change to fix writing packets not working

### DIFF
--- a/crates/valence/src/packet.rs
+++ b/crates/valence/src/packet.rs
@@ -5,7 +5,7 @@ use valence_protocol::codec::{encode_packet, encode_packet_compressed, PacketEnc
 use valence_protocol::Packet;
 
 /// Types that can have packets written to them.
-pub(crate) trait WritePacket {
+pub trait WritePacket {
     /// Writes a packet to this object. Encoding errors are typically logged and
     /// discarded.
     fn write_packet<'a>(&mut self, packet: &impl Packet<'a>);


### PR DESCRIPTION
## Description

With component division, the WritePacket trait was pub(crate), which disallowed writing packets outside of valence. This 1 line PR fixes that.

## Test Plan

It might be a good idea to include examples/tests that use packet writing to catch this, but it's most likely not strictly necessary.
