### PR TITLE
fix key input with filters, also removed regex from gui and make text…

### DIFF
--- a/crates/packet_inspector/src/context.rs
+++ b/crates/packet_inspector/src/context.rs
@@ -380,14 +380,13 @@ impl Context {
 
         let filter = self.filter.read().expect("Poisoned RwLock");
         let filter = filter.as_str();
-        if !filter.is_empty() {
-            if packet
+        if !filter.is_empty()
+            && packet
                 .packet_name
                 .to_lowercase()
                 .contains(&filter.to_lowercase())
-            {
-                return true;
-            }
+        {
+            return true;
         }
 
         false

--- a/crates/packet_inspector/src/main.rs
+++ b/crates/packet_inspector/src/main.rs
@@ -329,6 +329,17 @@ impl From<(Stage, i32, PacketDirection, String)> for MetaPacket {
     }
 }
 
+impl From<Packet> for MetaPacket {
+    fn from(packet: Packet) -> Self {
+        Self {
+            stage: packet.stage,
+            id: packet.packet_type,
+            direction: packet.direction,
+            name: packet.packet_name,
+        }
+    }
+}
+
 // to string and from string to be used in toml
 impl ToString for MetaPacket {
     fn to_string(&self) -> String {
@@ -485,6 +496,8 @@ impl GuiApp {
             None => BTreeMap::new(),
         };
 
+        context.set_selected_packets(selected_packets.clone());
+
         Self {
             config,
             context,
@@ -572,6 +585,8 @@ impl GuiApp {
 
         if changed {
             self.config
+                .set_selected_packets(self.selected_packets.clone());
+            self.context
                 .set_selected_packets(self.selected_packets.clone());
         }
     }
@@ -839,6 +854,8 @@ impl eframe::App for GuiApp {
                                     self.selected_packets.insert(m_packet.clone(), true);
                                     self.config
                                         .set_selected_packets(self.selected_packets.clone());
+                                    self.context
+                                        .set_selected_packets(self.selected_packets.clone());
                                 } else {
                                     // if it does exist, check if the names are the same, if not
                                     // update the key
@@ -849,6 +866,8 @@ impl eframe::App for GuiApp {
                                         self.selected_packets.remove(&m_packet);
                                         self.selected_packets.insert(m_packet.clone(), value);
                                         self.config
+                                            .set_selected_packets(self.selected_packets.clone());
+                                        self.context
                                             .set_selected_packets(self.selected_packets.clone());
                                     }
                                 }
@@ -863,8 +882,11 @@ impl eframe::App for GuiApp {
                                     return true;
                                 }
 
-                                if let Ok(re) = regex::Regex::new(&self.filter) {
-                                    return re.is_match(&p.packet_name);
+                                if p.packet_name
+                                    .to_lowercase()
+                                    .contains(&self.filter.to_lowercase())
+                                {
+                                    return true;
                                 }
 
                                 false


### PR DESCRIPTION
… filters case-insensitive

Closes #297

## Description

Up and down arrow to select previous/next packet now ignore filtered packets.

## Test Plan

1. Query the server using refresh on the server browser
2. Uncheck QueryResponseS2c in the packet-selector list
3. Click HandshakeC2s
4. Press down arrow until last packet is selected
5. It shouldn't go "blank" anymore when going from QueryRequestC2s to QueryPingC2s

As an additive request, I've removed the regex check from the main GUI filter box, such that this is now case-insensitive when filtering specific packets.
CLI still uses regex to be able to filter on multiple packets (unchanged)