### PR TITLE
`dump_schedule` utility

### DIFF
--- a/crates/dump_schedule/Cargo.toml
+++ b/crates/dump_schedule/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "dump_schedule"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+bevy_mod_debugdump = "0.7.0"
+valence = { path = "../valence", version = "0.2.0" }

--- a/crates/dump_schedule/src/main.rs
+++ b/crates/dump_schedule/src/main.rs
@@ -1,0 +1,23 @@
+use valence::bevy_app::prelude::*;
+use valence::config::ServerPlugin;
+
+fn main() -> std::io::Result<()> {
+    let mut app = App::new();
+
+    app.add_plugin(ServerPlugin::new(()));
+
+    let data = bevy_mod_debugdump::schedule_graph_dot(
+        &mut app,
+        CoreSchedule::Main,
+        &bevy_mod_debugdump::schedule_graph::Settings {
+            ambiguity_enable: false,
+            ..Default::default()
+        },
+    );
+
+    let path = "graph.gv";
+
+    println!("Writing schedule dump to file '{path}'");
+
+    std::fs::write(path, data)
+}

--- a/crates/valence/Cargo.toml
+++ b/crates/valence/Cargo.toml
@@ -12,7 +12,6 @@ build = "build/main.rs"
 authors = ["Ryan Johnson <ryanj00a@gmail.com>"]
 
 [dependencies]
-#bevy_mod_debugdump = "0.7.0"
 anyhow = "1.0.65"
 arrayvec = "0.7.2"
 async-trait = "0.1.60"

--- a/crates/valence/src/server.rs
+++ b/crates/valence/src/server.rs
@@ -339,20 +339,6 @@ pub fn build_plugin(
         .add_plugin(PlayerListPlugin)
         .add_plugin(WeatherPlugin);
 
-    /*
-    println!(
-        "{}",
-        bevy_mod_debugdump::schedule_graph_dot(
-            app,
-            CoreSchedule::Main,
-            &bevy_mod_debugdump::schedule_graph::Settings {
-                ambiguity_enable: false,
-                ..Default::default()
-            },
-        )
-    );
-    */
-
     Ok(())
 }
 


### PR DESCRIPTION
## Description

Adds the `dump_schedule` crate which is a simple tool that writes valence's schedule graph to a file named `graph.gv`.

## Test Plan

Steps:
1. `cargo r -p dump_schedule`
2. Paste the contents of `graph.gv` to https://edotor.net/
3. Look at the pretty graph.
