### PR TITLE
Fix player bugs

### DIFF
--- a/crates/valence/src/client/misc.rs
+++ b/crates/valence/src/client/misc.rs
@@ -9,6 +9,7 @@ use valence_protocol::packet::c2s::play::{
 use valence_protocol::types::{Direction, Hand};
 
 use super::action::ActionSequence;
+use crate::entity::{EntityAnimation, EntityAnimations};
 use crate::event_loop::{EventLoopSchedule, EventLoopSet, PacketEvent};
 
 pub(super) fn build(app: &mut App) {
@@ -86,7 +87,7 @@ pub struct ResourcePackStatusChange {
 #[allow(clippy::too_many_arguments)]
 fn handle_misc_packets(
     mut packets: EventReader<PacketEvent>,
-    mut clients: Query<&mut ActionSequence>,
+    mut clients: Query<(&mut ActionSequence, &mut EntityAnimations)>,
     mut hand_swing_events: EventWriter<HandSwing>,
     mut interact_block_events: EventWriter<InteractBlock>,
     mut chat_message_events: EventWriter<ChatMessage>,
@@ -96,12 +97,19 @@ fn handle_misc_packets(
 ) {
     for packet in packets.iter() {
         if let Some(pkt) = packet.decode::<HandSwingC2s>() {
+            if let Ok((_, mut animations)) = clients.get_mut(packet.client) {
+                animations.trigger(match pkt.hand {
+                    Hand::Main => EntityAnimation::SwingMainHand,
+                    Hand::Off => EntityAnimation::SwingOffHand,
+                });
+            }
+
             hand_swing_events.send(HandSwing {
                 client: packet.client,
                 hand: pkt.hand,
             });
         } else if let Some(pkt) = packet.decode::<PlayerInteractBlockC2s>() {
-            if let Ok(mut action_seq) = clients.get_mut(packet.client) {
+            if let Ok((mut action_seq, _)) = clients.get_mut(packet.client) {
                 action_seq.update(pkt.sequence.0);
             }
 
@@ -115,7 +123,7 @@ fn handle_misc_packets(
                 sequence: pkt.sequence.0,
             });
         } else if let Some(pkt) = packet.decode::<PlayerInteractItemC2s>() {
-            if let Ok(mut action_seq) = clients.get_mut(packet.client) {
+            if let Ok((mut action_seq, _)) = clients.get_mut(packet.client) {
                 action_seq.update(pkt.sequence.0);
             }
 

--- a/crates/valence/src/player_list.rs
+++ b/crates/valence/src/player_list.rs
@@ -7,8 +7,9 @@ use valence_protocol::packet::s2c::play::player_list::{Actions, Entry, PlayerLis
 use valence_protocol::packet::s2c::play::{PlayerListHeaderS2c, PlayerRemoveS2c};
 use valence_protocol::text::Text;
 
-use crate::client::{Client, FlushPacketsSet};
+use crate::client::Client;
 use crate::component::{Despawned, GameMode, Ping, Properties, UniqueId, Username};
+use crate::instance::WriteUpdatePacketsToInstancesSet;
 use crate::packet::{PacketWriter, WritePacket};
 use crate::server::Server;
 
@@ -27,7 +28,7 @@ impl Plugin for PlayerListPlugin {
                 write_player_list_changes,
             )
                 .chain()
-                .before(FlushPacketsSet)
+                .before(WriteUpdatePacketsToInstancesSet)
                 .in_base_set(CoreSet::PostUpdate),
         );
     }


### PR DESCRIPTION
## Description

Fix regressions from #317 and #315 

- Make sure player list packets get sent before player entity spawn packets are sent to prevent invisible players.
- Correctly update pose and hand swing.

## Test Plan

Steps:
1. Load any example with two players.
2. See that players are visible.
3. See that crouching and hand swings are functioning.
