### PR TITLE
Add idle tick benchmark

### DIFF
--- a/crates/valence/benches/idle.rs
+++ b/crates/valence/benches/idle.rs
@@ -1,0 +1,43 @@
+use criterion::Criterion;
+use valence::prelude::*;
+
+/// Benches the performance of a single server tick while nothing much is
+/// happening.
+pub fn idle_update(c: &mut Criterion) {
+    let mut app = App::new();
+
+    app.add_plugins(DefaultPlugins);
+    app.add_startup_system(setup);
+
+    // Run startup schedule.
+    app.update();
+
+    c.bench_function("idle_update", |b| {
+        b.iter(|| {
+            app.update();
+        });
+    });
+}
+
+fn setup(
+    mut commands: Commands,
+    dimensions: Query<&DimensionType>,
+    biomes: Query<&Biome>,
+    server: Res<Server>,
+) {
+    let mut instance = Instance::new(ident!("overworld"), &dimensions, &biomes, &server);
+
+    for z in -5..5 {
+        for x in -5..5 {
+            instance.insert_chunk([x, z], Chunk::default());
+        }
+    }
+
+    for z in -50..50 {
+        for x in -50..50 {
+            instance.set_block([x, 64, z], BlockState::GRASS_BLOCK);
+        }
+    }
+
+    commands.spawn(instance);
+}

--- a/crates/valence/benches/main.rs
+++ b/crates/valence/benches/main.rs
@@ -3,6 +3,7 @@ use criterion::{criterion_group, criterion_main};
 mod anvil;
 mod block;
 mod decode_array;
+mod idle;
 mod packet;
 mod var_int;
 mod var_long;
@@ -12,6 +13,7 @@ criterion_group! {
     anvil::load,
     block::block,
     decode_array::decode_array,
+    idle::idle_update,
     packet::packet,
     var_int::var_int,
     var_long::var_long,

--- a/crates/valence/src/lib.rs
+++ b/crates/valence/src/lib.rs
@@ -55,6 +55,7 @@ pub use {
 pub mod prelude {
     pub use ::uuid::Uuid;
     pub use app::prelude::*;
+    pub use bevy_ecs; // Needed for bevy_ecs proc macros to function correctly.
     pub use biome::{Biome, BiomeId, BiomeRegistry};
     pub use block::{BlockKind, BlockState, PropName, PropValue};
     pub use block_pos::BlockPos;

--- a/crates/valence_core/src/lib.rs
+++ b/crates/valence_core/src/lib.rs
@@ -98,22 +98,6 @@ impl Plugin for CorePlugin {
         app.add_systems(
             (increment_tick_counter, despawn_marked_entities).in_base_set(CoreSet::Last),
         );
-
-        // TODO: do this in `DefaultPlugins`.
-        /*
-        // Add internal plugins.
-        app.add_plugin(EventLoopPlugin)
-            .add_plugin(RegistryCodecPlugin)
-            .add_plugin(BiomePlugin)
-            .add_plugin(DimensionPlugin)
-            .add_plugin(ComponentPlugin)
-            .add_plugin(ClientPlugin)
-            .add_plugin(EntityPlugin)
-            .add_plugin(InstancePlugin)
-            .add_plugin(InventoryPlugin)
-            .add_plugin(PlayerListPlugin)
-            .add_plugin(WeatherPlugin);
-        */
     }
 }
 


### PR DESCRIPTION
## Description

Adds a benchmark to measure the duration of a whole server tick.

Also added `bevy_ecs` to `valence::prelude`.

## Test Plan

Steps:
1. `cargo bench idle_update`
