### PR TITLE
Use a struct to store block collision shapes

### DIFF
--- a/crates/valence_block/Cargo.toml
+++ b/crates/valence_block/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 [dependencies]
 valence_core.workspace = true
 anyhow.workspace = true
+glam.workspace = true
 
 [build-dependencies]
 anyhow.workspace = true

--- a/crates/valence_block/build.rs
+++ b/crates/valence_block/build.rs
@@ -161,14 +161,10 @@ fn build() -> anyhow::Result<TokenStream> {
         let max_y = s.max_y;
         let max_z = s.max_z;
         quote! {
-            [
-                #min_x,
-                #min_y,
-                #min_z,
-                #max_x,
-                #max_y,
-                #max_z,
-            ]
+            Aabb {
+                min: dvec3(#min_x, #min_y, #min_z),
+                max: dvec3(#max_x, #max_y, #max_z),
+            }
         }
     });
 
@@ -577,6 +573,9 @@ fn build() -> anyhow::Result<TokenStream> {
     let prop_value_count = prop_values.len();
 
     Ok(quote! {
+        use valence_core::aabb::Aabb;
+        use glam::dvec3;
+
         /// Represents the state of a block. This does not include block entity data such as
         /// the text on a sign, the design on a banner, or the content of a spawner.
         #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Hash)]
@@ -682,11 +681,11 @@ fn build() -> anyhow::Result<TokenStream> {
                 }
             }
 
-            const SHAPES: [[f64; 6]; #shape_count] = [
+            const SHAPES: [Aabb; #shape_count] = [
                 #(#shapes,)*
             ];
 
-            pub fn collision_shapes(self) -> impl ExactSizeIterator<Item = [f64; 6]> + FusedIterator + Clone {
+            pub fn collision_shapes(self) -> impl ExactSizeIterator<Item = Aabb> + FusedIterator + Clone {
                 let shape_idxs: &'static [u16] = match self.0 {
                     #state_to_collision_shapes_arms
                     _ => &[],


### PR DESCRIPTION
## Description

Created a new CollisionShape struct for blocks (was previously an [f64; 6]).

## Test Plan

Explain the steps necessary to test your changes. If you used a playground, include the code in the details below.

Steps:
1. Run the following code

<details>

<summary>Playground</summary>

```rust
use valence_block;

fn main() {
    let shapes = valence_block::BlockState::STONE.collision_shapes();
    println!("{:?}", shapes.collect::<Vec<_>>());
    // [CollisionShape { min_x: 0.0, min_y: 0.0, min_z: 0.0, max_x: 1.0, max_y: 1.0, max_z: 1.0 }]
    let shapes = valence_block::BlockState::OAK_STAIRS.collision_shapes();
    println!("{:?}", shapes.collect::<Vec<_>>());
    // [CollisionShape { min_x: 0.0, min_y: 0.0, min_z: 0.0, max_x: 1.0, max_y: 0.5, max_z: 1.0 }, CollisionShape { min_x: 0.0, min_y: 0.5, min_z: 0.0, max_x: 1.0, max_y: 1.0, max_z: 0.5 }]
}
```

</details>
