### PR TITLE
Remove "test plan" from pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,20 +1,3 @@
 ## Description
 
 Describe the changes you've made. Link to any issues this PR fixes or addresses.
-
-## Test Plan
-
-Explain the steps necessary to test your changes. If you used a playground, include the code in the details below.
-
-Steps:
-1.
-
-<details>
-
-<summary>Playground</summary>
-
-```rust
-PASTE YOUR PLAYGROUND CODE HERE
-```
-
-</details>


### PR DESCRIPTION
## Description

Remove the "test plan" section from the pull request template. My justification is:
- The steps needed to test a pull request is usually obvious.
- Often the test plan is just "run `cargo test` lol"
- For small changes and tweaks, a "test plan" is overkill and amounts to frustrating busywork.
- Adds too much additional friction for new contributors.
- Large projects like Bevy are fine without it.
- Often not applicable to pull requests (like this one).
