### PR TITLE
Add cli arg for log level to playground

### DIFF
--- a/tools/playground/src/main.rs
+++ b/tools/playground/src/main.rs
@@ -16,6 +16,9 @@
     clippy::dbg_macro
 )]
 
+use std::str::FromStr;
+use std::env;
+
 use tracing::Level;
 use valence::app::App;
 
@@ -24,8 +27,14 @@ mod extras;
 mod playground;
 
 fn main() {
+    let mut args = env::args().skip(1);
+    let log_level = match (args.next().as_deref(), args.next()) {
+        (Some("-l" | "--log"), Some(level)) => Level::from_str(&level).unwrap_or(Level::DEBUG),
+        _ => Level::DEBUG,
+    };
+
     tracing_subscriber::fmt()
-        .with_max_level(Level::DEBUG)
+        .with_max_level(log_level)
         .init();
 
     let mut app = App::new();


### PR DESCRIPTION
## Description
Fixes #305 

`cargo run -- --log trace`

Uses `Level`'s `FromStr` impl, which accepts numbers 1-5 or case-insensitive level names. Default level is `Level::DEBUG`

We could use a dedicated argument parsing crate (`clap`?) instead, but idk if we want those extra dependencies.