### PR TITLE
Very rough Inventory Menu prototype

### DIFF
--- a/crates/valence_inventory/src/menu.rs
+++ b/crates/valence_inventory/src/menu.rs
@@ -11,7 +11,7 @@ use valence_core::protocol::encode::WritePacket;
 use valence_core::text::Text;
 
 use crate::packet::{
-    ClickSlotC2s, InventoryS2c, OpenScreenS2c, ScreenHandlerSlotUpdateS2c, WindowType,
+    ClickMode, ClickSlotC2s, InventoryS2c, OpenScreenS2c, ScreenHandlerSlotUpdateS2c, WindowType,
 };
 use crate::{
     validate, ClickSlot, ClientInventoryState, CursorItem, DropItemStack, Inventory, InventoryKind,
@@ -52,6 +52,9 @@ fn handle_click_slot(
     mut inventories: Query<&mut Inventory, (Without<Client>, With<InventoryMenu>)>,
 ) {
     for click in clicks.iter() {
+        if click.mode != ClickMode::Click {
+            continue;
+        }
         println!("menu click: {:?}", click);
         if let Ok((mut client, mut inv, mut inv_state, mut cursor_item, open_inv)) =
             clients.get_mut(click.client)

--- a/crates/valence_inventory/src/menu.rs
+++ b/crates/valence_inventory/src/menu.rs
@@ -1,0 +1,77 @@
+use std::borrow::Cow;
+
+use bevy_app::{CoreSet, IntoSystemAppConfig, Plugin};
+use bevy_ecs::prelude::*;
+use tracing::debug;
+use valence_client::event_loop::{EventLoopSchedule, PacketEvent};
+use valence_client::Client;
+use valence_core::__private::VarInt;
+use valence_core::item::ItemStack;
+use valence_core::protocol::encode::WritePacket;
+use valence_core::text::Text;
+
+use crate::packet::{
+    ClickSlotC2s, InventoryS2c, OpenScreenS2c, ScreenHandlerSlotUpdateS2c, WindowType,
+};
+use crate::{
+    validate, ClickSlot, ClientInventoryState, CursorItem, DropItemStack, Inventory, InventoryKind,
+    OpenInventory,
+};
+
+#[derive(Debug, Default)]
+pub struct InventoryMenuPlugin;
+
+impl Plugin for InventoryMenuPlugin {
+    fn build(&self, app: &mut bevy_app::App) {
+        app.add_system(
+            handle_click_slot
+                .in_schedule(EventLoopSchedule)
+                .in_base_set(CoreSet::PreUpdate),
+        );
+    }
+}
+
+#[derive(Debug, Component)]
+pub struct OpenMenu;
+
+#[derive(Debug, Component)]
+pub struct InventoryMenu;
+
+fn handle_click_slot(
+    mut clicks: EventReader<ClickSlot>,
+    mut clients: Query<
+        (
+            &mut Client,
+            &mut Inventory,
+            &mut ClientInventoryState,
+            &mut CursorItem,
+            &mut OpenInventory,
+        ),
+        With<OpenMenu>,
+    >,
+    mut inventories: Query<&mut Inventory, (Without<Client>, With<InventoryMenu>)>,
+) {
+    for click in clicks.iter() {
+        println!("menu click: {:?}", click);
+        if let Ok((mut client, mut inv, mut inv_state, mut cursor_item, open_inv)) =
+            clients.get_mut(click.client)
+        {
+            let Ok(mut target) = inventories.get_mut(open_inv.entity) else {
+                continue;
+            };
+            println!("reset clicked slot");
+            target.set_slot(click.slot_id as u16, click.carried_item.clone());
+            inv_state.slots_changed &= !(1 << click.slot_id);
+            client.write_packet(&ScreenHandlerSlotUpdateS2c {
+                window_id: inv_state.window_id as i8,
+                state_id: VarInt(inv_state.state_id.0),
+                slot_idx: click.slot_id,
+                slot_data: Cow::Borrowed(&click.carried_item),
+            });
+
+            println!("clearing cursor item");
+            cursor_item.0 = None;
+            inv_state.client_updated_cursor_item = false;
+        }
+    }
+}


### PR DESCRIPTION
## Description

- refactor handle_click_slot to primarily emit ClickSlot events, and handle those in a new system
- fix cursor item updates not being sent if an inventory is open
- very rough inventory menu behavior
- only allow ClickMode::Click
- emit MenuClickEvents for inventory menu clicks

fixes #307 

This PR makes it possible to do inventory menus. I don't particularly like the approach so far. I think I'll need to do some refactoring of how inventories work before continuing work on this.

<details>

<summary>Playground</summary>

```rust
use valence::client::despawn_disconnected_clients;
use valence::client::hand_swing::HandSwingEvent;
use valence::inventory::menu::{InventoryMenu, InventoryMenuPlugin, MenuClickEvent, OpenMenu};
use valence::network::ConnectionMode;
use valence::prelude::*;

#[allow(unused_imports)]
use crate::extras::*;

const SPAWN_Y: i32 = 64;

pub fn build_app(app: &mut App) {
    app.insert_resource(NetworkSettings {
        connection_mode: ConnectionMode::Offline,
        ..Default::default()
    })
    .add_plugins(DefaultPlugins)
    .add_startup_system(setup)
    .add_system(init_clients)
    .add_system(despawn_disconnected_clients)
    .add_system(toggle_gamemode_on_sneak.in_schedule(EventLoopSchedule))
    .add_plugin(InventoryMenuPlugin::default())
    .add_system(open_menu.in_schedule(EventLoopSchedule))
    .add_system(handle_menu.in_schedule(EventLoopSchedule));
}

fn setup(
    mut commands: Commands,
    server: Res<Server>,
    biomes: Query<&Biome>,
    dimensions: Query<&DimensionType>,
) {
    let mut instance = Instance::new(ident!("overworld"), &dimensions, &biomes, &server);

    for z in -5..5 {
        for x in -5..5 {
            instance.insert_chunk([x, z], Chunk::default());
        }
    }

    for z in -25..25 {
        for x in -25..25 {
            instance.set_block([x, SPAWN_Y, z], BlockState::GRASS_BLOCK);
        }
    }

    commands.spawn(instance);
}

fn init_clients(
    mut clients: Query<(&mut Location, &mut Position), Added<Client>>,
    instances: Query<Entity, With<Instance>>,
) {
    for (mut loc, mut pos) in &mut clients {
        loc.0 = instances.single();
        pos.set([0.5, SPAWN_Y as f64 + 1.0, 0.5]);
    }
}

// Add more systems here!

fn open_menu(mut events: EventReader<HandSwingEvent>, mut commands: Commands) {
    for event in events.iter() {
        println!("HandSwingEvent: {:?}", event);
        // let (client) = clients.get(event.client);
        if event.hand == Hand::Main {
            println!("opening menu");
            let mut inv = Inventory::new(InventoryKind::Generic3x3);
            inv.set_slot(3, Some(ItemStack::new(ItemKind::RedWool, 1, None)));
            inv.set_slot(5, Some(ItemStack::new(ItemKind::BlueWool, 1, None)));

            let menu = commands.spawn((inv, InventoryMenu {})).id();
            commands
                .entity(event.client)
                .insert((OpenInventory::new(menu), OpenMenu {}));
        }
    }
}

fn handle_menu(
    mut menu_clicks: EventReader<MenuClickEvent>,
    mut clients: Query<(&mut Client, &OpenInventory), With<OpenMenu>>,
    mut commands: Commands,
) {
    for click in menu_clicks.iter() {
        println!("MenuClickEvent: {:?}", click);

        let (mut client, open_inv) = clients.get_mut(click.client).unwrap();

        if click.slot_id == 3 {
            client.send_message("You clicked the red wool!");
        } else if click.slot_id == 5 {
            client.send_message("You clicked the blue wool!");
        } else {
            client.send_message("You clicked something else!");
        }

        commands.entity(click.client).remove::<OpenMenu>();
        commands.entity(click.client).remove::<OpenInventory>();
        commands.entity(open_inv.entity).despawn();
    }
}
```

</details>