### PR TITLE
refactor held item into a new component

### DIFF
--- a/crates/valence/examples/building.rs
+++ b/crates/valence/examples/building.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::type_complexity)]
 
-use valence::inventory::ClientInventoryState;
+use valence::inventory::HeldItem;
 use valence::prelude::*;
 use valence_client::interact_block::InteractBlockEvent;
 
@@ -109,14 +109,14 @@ fn digging_survival_mode(
 }
 
 fn place_blocks(
-    mut clients: Query<(&mut Inventory, &GameMode, &ClientInventoryState)>,
+    mut clients: Query<(&mut Inventory, &GameMode, &HeldItem)>,
     mut instances: Query<&mut Instance>,
     mut events: EventReader<InteractBlockEvent>,
 ) {
     let mut instance = instances.single_mut();
 
     for event in events.iter() {
-        let Ok((mut inventory, game_mode, inv_state)) = clients.get_mut(event.client) else {
+        let Ok((mut inventory, game_mode, held)) = clients.get_mut(event.client) else {
             continue;
         };
         if event.hand != Hand::Main {
@@ -124,7 +124,7 @@ fn place_blocks(
         }
 
         // get the held item
-        let slot_id = inv_state.held_item_slot();
+        let slot_id = held.slot();
         let Some(stack) = inventory.slot(slot_id) else {
             // no item in the slot
             continue;

--- a/crates/valence/src/tests/inventory.rs
+++ b/crates/valence/src/tests/inventory.rs
@@ -6,8 +6,8 @@ use valence_inventory::packet::{
     OpenScreenS2c, ScreenHandlerSlotUpdateS2c, SlotChange, UpdateSelectedSlotC2s,
 };
 use valence_inventory::{
-    convert_to_player_slot_id, ClientInventoryState, CursorItem, DropItemStack, Inventory,
-    InventoryKind, OpenInventory,
+    convert_to_player_slot_id, ClientInventoryState, CursorItem, DropItemStack, HeldItem,
+    Inventory, InventoryKind, OpenInventory,
 };
 
 use super::*;
@@ -474,12 +474,12 @@ fn test_should_handle_set_held_item() {
     app.update();
 
     // Make assertions
-    let inv_state = app
+    let held = app
         .world
-        .get::<ClientInventoryState>(client_ent)
+        .get::<HeldItem>(client_ent)
         .expect("could not find client");
 
-    assert_eq!(inv_state.held_item_slot(), 40);
+    assert_eq!(held.slot(), 40);
 }
 
 #[test]
@@ -602,11 +602,11 @@ mod dropping_items {
         app.update();
 
         // Make assertions
-        let inv_state = app
+        let held = app
             .world
-            .get::<ClientInventoryState>(client_ent)
+            .get::<HeldItem>(client_ent)
             .expect("could not find client");
-        assert_eq!(inv_state.held_item_slot(), 36);
+        assert_eq!(held.slot(), 36);
         let inventory = app
             .world
             .get::<Inventory>(client_ent)


### PR DESCRIPTION
## Description

This moves the `held_item_slot` field in `ClientInventoryState` to a new component: `HeldItem`

related: pr #355
