### PR TITLE
Visibility layer

### DIFF
--- a/crates/valence/src/lib.rs
+++ b/crates/valence/src/lib.rs
@@ -120,6 +120,23 @@ pub mod prelude {
 /// [`DefaultPlugins`] obeys Cargo feature flags. Users may exert control over
 /// this plugin group by disabling `default-features` in their `Cargo.toml` and
 /// enabling only those features that they wish to use.
+///
+/// Currently, the following features are available:
+/// - [`CorePlugin`]
+/// - [`valence_registry::RegistryPlugin`]
+/// - [`valence_biome::BiomePlugin`]
+/// - [`valence_dimension::DimensionPlugin`]
+/// - [`valence_entity::EntityPlugin`]
+/// - [`valence_entity::hitbox::HitboxPlugin`]
+/// - [`valence_instance::InstancePlugin`]
+/// - [`valence_client::ClientPlugin`]
+/// - [`valence_network::NetworkPlugin`] (requires the `network` feature)
+/// - [`valence_player_list::PlayerListPlugin`] (requires the `player_list`
+///   feature)
+/// - [`valence_inventory::InventoryPlugin`] (requires the `inventory` feature)
+/// - [`valence_advancement::AdvancementPlugin`] (requires the `advancement`
+///   feature)
+/// - [...] (requires the `anvil` feature)
 pub struct DefaultPlugins;
 
 impl PluginGroup for DefaultPlugins {

--- a/crates/valence_entity/src/lib.rs
+++ b/crates/valence_entity/src/lib.rs
@@ -401,6 +401,11 @@ pub struct ObjectData(pub i32);
 #[derive(Component, Default, Debug)]
 pub struct PacketByteRange(pub Range<usize>);
 
+/// The layer the entity is on.
+/// The entity will only be show to clients on the same layer.
+#[derive(Component, Copy, Clone, PartialEq, Eq, Debug)]
+pub struct Layer(pub u8);
+
 /// Cache for all the tracked data of an entity. Used for the
 /// [`EntityTrackerUpdateS2c`][packet] packet.
 ///

--- a/crates/valence_instance/src/chunk_entry.rs
+++ b/crates/valence_instance/src/chunk_entry.rs
@@ -104,8 +104,7 @@ impl<'a> VacantChunkEntry<'a> {
             incoming: vec![],
             outgoing: vec![],
             packet_buf: vec![],
-            layers_packet_buf: vec![],
-            layers_byte_range: HashMap::new(),
+            layers_packet_buf: [0; 64].map(|_| vec![])
         });
 
         debug_assert!(cell.chunk.is_none());

--- a/crates/valence_instance/src/chunk_entry.rs
+++ b/crates/valence_instance/src/chunk_entry.rs
@@ -104,6 +104,8 @@ impl<'a> VacantChunkEntry<'a> {
             incoming: vec![],
             outgoing: vec![],
             packet_buf: vec![],
+            layers_packet_buf: vec![],
+            layers_byte_range: HashMap::new(),
         });
 
         debug_assert!(cell.chunk.is_none());


### PR DESCRIPTION
## Ref
#342 

## Description

> I use the word 'mob' to reference minecraft entities and client for the player.

Implementation of a layer system for mob, the client can have a `ClientLayerMask` component which determine for what layer he can see mobs. The mobs them can have a `Layer` component which determine on what layer they are.

## Implementation

- [x] Client see only update for mask layer
- [ ] Spawn or Sync mob status when arriving on a new layer
- [ ] Despawn mob when quitting a layer

## Potential Upgrade

- Not have one buffer per layer
- Having the possibility to have infinite numbers of layers
- Extend layers to blocks ?