### PR TITLE
Valence tick

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ bevy_app = { version = "0.10.1", default-features = false }
 bevy_ecs = { version = "0.10.1", default-features = false, features = [
     "trace",
 ] }
+bevy_reflect = "0.10.1"
 bevy_hierarchy = { version = "0.10.1", default-features = false }
 bevy_mod_debugdump = "0.7.0"
 bitfield-struct = "0.3.1"
@@ -96,6 +97,7 @@ valence_network.path = "crates/valence_network"
 valence_player_list.path = "crates/valence_player_list"
 valence_registry.path = "crates/valence_registry"
 valence_world_border.path = "crates/valence_world_border"
+valence_tick.path = "crates/valence_tick"
 valence.path = "crates/valence"
 
 zip = "0.6.3"

--- a/crates/valence/Cargo.toml
+++ b/crates/valence/Cargo.toml
@@ -11,13 +11,22 @@ keywords = ["minecraft", "gamedev", "server", "ecs"]
 categories = ["game-engines"]
 
 [features]
-default = ["network", "player_list", "inventory", "anvil", "advancement", "world_border"]
+default = [
+    "network",
+    "player_list",
+    "inventory",
+    "anvil",
+    "advancement",
+    "world_border",
+    "tick",
+]
 network = ["dep:valence_network"]
 player_list = ["dep:valence_player_list"]
 inventory = ["dep:valence_inventory"]
 anvil = ["dep:valence_anvil"]
 advancement = ["dep:valence_advancement"]
 world_border = ["dep:valence_world_border"]
+tick = ["dep:valence_tick"]
 
 [dependencies]
 bevy_app.workspace = true
@@ -39,7 +48,7 @@ valence_inventory = { workspace = true, optional = true }
 valence_anvil = { workspace = true, optional = true }
 valence_advancement = { workspace = true, optional = true }
 valence_world_border = { workspace = true, optional = true }
-
+valence_tick = { workspace = true, optional = true }
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/crates/valence/examples/fixed_tick.rs
+++ b/crates/valence/examples/fixed_tick.rs
@@ -1,0 +1,74 @@
+#![allow(clippy::type_complexity)]
+
+use valence::prelude::*;
+use valence_client::message::SendMessage;
+
+const SPAWN_Y: i32 = 64;
+
+pub fn main() {
+    tracing_subscriber::fmt().init();
+
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(TickSystem)
+        .add_startup_system(setup)
+        .add_system(init_clients)
+        .add_system(despawn_disconnected_clients)
+        .add_system(run_every_20_ticks.in_schedule(CoreSchedule::FixedUpdate))
+        .add_system(manual_tick_interval)
+        .insert_resource(FixedTick::new(20))
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    server: Res<Server>,
+    dimensions: Res<DimensionTypeRegistry>,
+    biomes: Res<BiomeRegistry>,
+) {
+    let mut instance = Instance::new(ident!("overworld"), &dimensions, &biomes, &server);
+
+    for z in -5..5 {
+        for x in -5..5 {
+            instance.insert_chunk([x, z], Chunk::default());
+        }
+    }
+
+    for z in -25..25 {
+        for x in -25..25 {
+            instance.set_block([x, SPAWN_Y, z], BlockState::GRASS_BLOCK);
+        }
+    }
+
+    commands.spawn(instance);
+}
+
+fn init_clients(
+    mut clients: Query<(&mut Position, &mut Location, &mut GameMode), Added<Client>>,
+    instances: Query<Entity, With<Instance>>,
+) {
+    for (mut pos, mut loc, mut game_mode) in &mut clients {
+        pos.0 = [0.0, SPAWN_Y as f64 + 1.0, 0.0].into();
+        loc.0 = instances.single();
+        *game_mode = GameMode::Creative;
+    }
+}
+
+fn run_every_20_ticks(mut clients: Query<&mut Client>, tick: Res<Tick>) {
+    for mut client in &mut clients {
+        client.send_chat_message(format!("20 ticks have passed, tick: {}", tick.elapsed()));
+    }
+}
+
+fn manual_tick_interval(
+    mut clients: Query<&mut Client>,
+    mut last_time: Local<usize>,
+    tick: Res<Tick>,
+) {
+    if tick.elapsed() - *last_time >= 40 {
+        *last_time = tick.elapsed();
+        for mut client in &mut clients {
+            client.send_chat_message(format!("40 ticks have passed, tick: {}", tick.elapsed()));
+        }
+    }
+}

--- a/crates/valence/src/lib.rs
+++ b/crates/valence/src/lib.rs
@@ -37,6 +37,8 @@ pub use valence_inventory as inventory;
 pub use valence_network as network;
 #[cfg(feature = "player_list")]
 pub use valence_player_list as player_list;
+#[cfg(feature = "tick")]
+pub use valence_tick as tick;
 #[cfg(feature = "world_border")]
 pub use valence_world_border as world_border;
 pub use {
@@ -113,7 +115,7 @@ pub mod prelude {
     pub use valence_entity::hitbox::{Hitbox, HitboxShape};
 
     #[cfg(feature = "tick")]
-    pub use valence_tick::prelude::*;
+    pub use valence_tick::{fixed_tickstep::FixedTick, Tick, TickSystem};
 
     pub use super::DefaultPlugins;
     use super::*;

--- a/crates/valence/src/lib.rs
+++ b/crates/valence/src/lib.rs
@@ -112,6 +112,9 @@ pub mod prelude {
     pub use valence_core::{translation_key, CoreSettings, Server};
     pub use valence_entity::hitbox::{Hitbox, HitboxShape};
 
+    #[cfg(feature = "tick")]
+    pub use valence_tick::prelude::*;
+
     pub use super::DefaultPlugins;
     use super::*;
 }

--- a/crates/valence_tick/Cargo.toml
+++ b/crates/valence_tick/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "valence_tick"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+bevy_app.workspace = true
+bevy_ecs.workspace = true
+bevy_reflect.workspace = true
+tokio.workspace = true
+valence_core.workspace = true
+thiserror.workspace = true
+flume.workspace = true

--- a/crates/valence_tick/README.md
+++ b/crates/valence_tick/README.md
@@ -1,0 +1,3 @@
+# valence_tick
+
+Everything related to Minecraft ticks.

--- a/crates/valence_tick/src/fixed_tickstep.rs
+++ b/crates/valence_tick/src/fixed_tickstep.rs
@@ -1,26 +1,3 @@
-//! Tools to run systems at a regular interval.
-//! This can be extremely useful for steady, frame-rate independent gameplay logic and physics.
-//!
-//! To run a system on a fixed tickstep, add it to the [`CoreSchedule::FixedUpdate`] [`Schedule`](bevy_ecs::schedule::Schedule).
-//! This schedules is run in the [`CoreSet::FixedUpdate`](bevy_app::CoreSet::FixedUpdate) near the start of each frame,
-//! via the [`run_fixed_update_schedule`] exclusive system.
-//!
-//! This schedule will be run a number of ticks each frame,
-//! equal to the accumulated divided by the period resource, rounded down,
-//! as tracked in the [`FixedTick`] resource.
-//! Unused tick will be carried over.
-//!
-//! This does not guarantee that the tick elapsed between executions is exact,
-//! and systems in this schedule can run 0, 1 or more ticks on any given frame.
-//!
-//! For example, a system with a fixed tickstep run criteria of 120 ticks per second will run
-//! two ticks during a ~16.667ms frame, once during a ~8.333ms frame, and once every two frames
-//! with ~4.167ms frames. However, the same criteria may not result in exactly 8.333ms passing
-//! between each execution.
-//!
-//! When using fixed tick steps, it is advised not to rely on [`Tick::delta`] or any of it's
-//! variants for game simulation, but rather use the value of [`FixedTick`] instead.
-
 use bevy_app::CoreSchedule;
 use bevy_ecs::{system::Resource, world::World};
 use thiserror::Error;

--- a/crates/valence_tick/src/fixed_tickstep.rs
+++ b/crates/valence_tick/src/fixed_tickstep.rs
@@ -1,0 +1,146 @@
+//! Tools to run systems at a regular interval.
+//! This can be extremely useful for steady, frame-rate independent gameplay logic and physics.
+//!
+//! To run a system on a fixed tickstep, add it to the [`CoreSchedule::FixedUpdate`] [`Schedule`](bevy_ecs::schedule::Schedule).
+//! This schedules is run in the [`CoreSet::FixedUpdate`](bevy_app::CoreSet::FixedUpdate) near the start of each frame,
+//! via the [`run_fixed_update_schedule`] exclusive system.
+//!
+//! This schedule will be run a number of ticks each frame,
+//! equal to the accumulated divided by the period resource, rounded down,
+//! as tracked in the [`FixedTick`] resource.
+//! Unused tick will be carried over.
+//!
+//! This does not guarantee that the tick elapsed between executions is exact,
+//! and systems in this schedule can run 0, 1 or more ticks on any given frame.
+//!
+//! For example, a system with a fixed tickstep run criteria of 120 ticks per second will run
+//! two ticks during a ~16.667ms frame, once during a ~8.333ms frame, and once every two frames
+//! with ~4.167ms frames. However, the same criteria may not result in exactly 8.333ms passing
+//! between each execution.
+//!
+//! When using fixed tick steps, it is advised not to rely on [`Tick::delta`] or any of it's
+//! variants for game simulation, but rather use the value of [`FixedTick`] instead.
+
+use bevy_app::CoreSchedule;
+use bevy_ecs::{system::Resource, world::World};
+use thiserror::Error;
+
+/// The amount of tick that must pass before the fixed tickstep schedule is run again.
+#[derive(Resource, Debug)]
+pub struct FixedTick {
+    accumulated: usize,
+    period: usize,
+}
+
+impl FixedTick {
+    /// Creates a new [`FixedTick`] struct
+    pub fn new(period: usize) -> Self {
+        FixedTick {
+            accumulated: 0,
+            period,
+        }
+    }
+
+    /// Adds 1 to the accumulated tick so far.
+    pub fn tick(&mut self) {
+        self.accumulated += 1;
+    }
+
+    /// Returns the current amount of accumulated tick
+    pub fn accumulated(&self) -> usize {
+        self.accumulated
+    }
+
+    /// Expends one `period` of accumulated tick.
+    ///
+    /// [`Err(FixedUpdateError`)] will be returned
+    pub fn expend(&mut self) -> Result<(), FixedUpdateError> {
+        if let Some(new_value) = self.accumulated.checked_sub(self.period) {
+            self.accumulated = new_value;
+            Ok(())
+        } else {
+            Err(FixedUpdateError::NotEnoughTick {
+                accumulated: self.accumulated,
+                period: self.period,
+            })
+        }
+    }
+}
+
+impl Default for FixedTick {
+    fn default() -> Self {
+        FixedTick {
+            accumulated: 0,
+            period: 1,
+        }
+    }
+}
+
+/// An error returned when working with [`FixedTick`].
+#[derive(Debug, Error)]
+pub enum FixedUpdateError {
+    #[error("At least one period worth of ticks must be accumulated.")]
+    NotEnoughTick { accumulated: usize, period: usize },
+}
+
+/// Ticks the [`FixedTick`] resource then runs the [`CoreSchedule::FixedUpdate`].
+pub fn run_fixed_update_schedule(world: &mut World) {
+    // Tick the time
+    let mut fixed_time = world.resource_mut::<FixedTick>();
+    fixed_time.tick();
+
+    // Run the schedule until we run out of accumulated time
+    let mut check_again = true;
+    while check_again {
+        let mut fixed_time = world.resource_mut::<FixedTick>();
+        let fixed_time_run = fixed_time.expend().is_ok();
+        if fixed_time_run {
+            world.run_schedule(CoreSchedule::FixedUpdate);
+        } else {
+            check_again = false;
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn fixed_time_starts_at_zero() {
+        let new_time = FixedTick::new(42);
+        assert_eq!(new_time.accumulated(), 0);
+
+        let default_time = FixedTick::default();
+        assert_eq!(default_time.accumulated(), 0);
+    }
+
+    #[test]
+    fn fixed_time_ticks_up() {
+        let mut fixed_time = FixedTick::default();
+        fixed_time.tick();
+        assert_eq!(fixed_time.accumulated(), 1);
+    }
+
+    #[test]
+    fn enough_accumulated_time_is_required() {
+        let mut fixed_time = FixedTick::new(2);
+        fixed_time.tick();
+        assert!(fixed_time.expend().is_err());
+        assert_eq!(fixed_time.accumulated(), 1);
+
+        fixed_time.tick();
+        assert!(fixed_time.expend().is_ok());
+        assert_eq!(fixed_time.accumulated(), 0);
+    }
+
+    #[test]
+    fn repeatedly_expending_time() {
+        let mut fixed_time = FixedTick::new(1);
+        fixed_time.tick();
+        assert!(fixed_time.expend().is_ok());
+        assert!(fixed_time.expend().is_ok());
+        assert!(fixed_time.expend().is_ok());
+        assert!(fixed_time.expend().is_err());
+    }
+}

--- a/crates/valence_tick/src/fixed_tickstep.rs
+++ b/crates/valence_tick/src/fixed_tickstep.rs
@@ -139,8 +139,6 @@ mod test {
         let mut fixed_time = FixedTick::new(1);
         fixed_time.tick();
         assert!(fixed_time.expend().is_ok());
-        assert!(fixed_time.expend().is_ok());
-        assert!(fixed_time.expend().is_ok());
         assert!(fixed_time.expend().is_err());
     }
 }

--- a/crates/valence_tick/src/lib.rs
+++ b/crates/valence_tick/src/lib.rs
@@ -8,7 +8,6 @@ use fixed_tickstep::{run_fixed_update_schedule, FixedTick};
 pub use tick::*;
 
 use bevy_ecs::system::ResMut;
-use flume::{Receiver, Sender};
 
 pub mod prelude {
     //! The Bevy Time Prelude.
@@ -37,22 +36,6 @@ impl Plugin for TickSystem {
             .add_system(tick_system.in_set(TickSystem))
             .add_system(run_fixed_update_schedule.in_base_set(CoreSet::FixedUpdate));
     }
-}
-
-/// Channel resource used to receive time from render world
-#[derive(Resource)]
-pub struct TickReceiver(pub Receiver<usize>);
-
-/// Channel resource used to send time from render world
-#[derive(Resource)]
-pub struct TickSender(pub Sender<usize>);
-
-/// Creates channels used for sending time between render world and app world
-pub fn create_time_channels() -> (TickSender, TickReceiver) {
-    // bound the channel to 2 since when pipelined the render phase can finish before
-    // the time system runs.
-    let (s, r) = flume::bounded::<usize>(2);
-    (TickSender(s), TickReceiver(r))
 }
 
 /// The system used to update the [`Time`] used by app logic. If there is a render world the time is sent from

--- a/crates/valence_tick/src/lib.rs
+++ b/crates/valence_tick/src/lib.rs
@@ -1,0 +1,62 @@
+// Adapted from https://github.com/bevyengine/bevy/blob/v0.10.1/crates/bevy_time/src/lib.rs
+
+pub mod fixed_tickstep;
+#[allow(clippy::module_inception)]
+mod tick;
+
+use fixed_tickstep::{run_fixed_update_schedule, FixedTick};
+pub use tick::*;
+
+use bevy_ecs::system::ResMut;
+use flume::{Receiver, Sender};
+
+pub mod prelude {
+    //! The Bevy Time Prelude.
+    #[doc(hidden)]
+    pub use crate::{fixed_tickstep::FixedTick, Tick}; // , Time, Timer, TimerMode
+}
+
+use bevy_app::prelude::*;
+use bevy_ecs::prelude::*;
+
+/// Adds time functionality to Apps.
+#[derive(Default)]
+pub struct TickPlugin;
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, SystemSet)]
+/// Updates the elapsed time. Any system that interacts with [Time] component should run after
+/// this.
+pub struct TickSystem;
+
+impl Plugin for TickSystem {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<Tick>()
+            .register_type::<Tick>()
+            .init_resource::<FixedTick>()
+            .configure_set(TickSystem.in_base_set(CoreSet::First))
+            .add_system(tick_system.in_set(TickSystem))
+            .add_system(run_fixed_update_schedule.in_base_set(CoreSet::FixedUpdate));
+    }
+}
+
+/// Channel resource used to receive time from render world
+#[derive(Resource)]
+pub struct TickReceiver(pub Receiver<usize>);
+
+/// Channel resource used to send time from render world
+#[derive(Resource)]
+pub struct TickSender(pub Sender<usize>);
+
+/// Creates channels used for sending time between render world and app world
+pub fn create_time_channels() -> (TickSender, TickReceiver) {
+    // bound the channel to 2 since when pipelined the render phase can finish before
+    // the time system runs.
+    let (s, r) = flume::bounded::<usize>(2);
+    (TickSender(s), TickReceiver(r))
+}
+
+/// The system used to update the [`Time`] used by app logic. If there is a render world the time is sent from
+/// there to this system through channels. Otherwise the time is updated in this system.
+fn tick_system(mut tick: ResMut<Tick>) {
+    tick.update();
+}

--- a/crates/valence_tick/src/lib.rs
+++ b/crates/valence_tick/src/lib.rs
@@ -1,3 +1,22 @@
+#![doc = include_str!("../README.md")]
+#![deny(
+    rustdoc::broken_intra_doc_links,
+    rustdoc::private_intra_doc_links,
+    rustdoc::missing_crate_level_docs,
+    rustdoc::invalid_codeblock_attributes,
+    rustdoc::invalid_rust_codeblocks,
+    rustdoc::bare_urls,
+    rustdoc::invalid_html_tags
+)]
+#![warn(
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_lifetimes,
+    unused_import_braces,
+    unreachable_pub,
+    clippy::dbg_macro
+)]
+
 pub mod fixed_tickstep;
 #[allow(clippy::module_inception)]
 mod tick;

--- a/crates/valence_tick/src/lib.rs
+++ b/crates/valence_tick/src/lib.rs
@@ -1,5 +1,3 @@
-// Adapted from https://github.com/bevyengine/bevy/blob/v0.10.1/crates/bevy_time/src/lib.rs
-
 pub mod fixed_tickstep;
 #[allow(clippy::module_inception)]
 mod tick;
@@ -10,20 +8,20 @@ pub use tick::*;
 use bevy_ecs::system::ResMut;
 
 pub mod prelude {
-    //! The Bevy Time Prelude.
+    //! The Valence Tick Prelude.
     #[doc(hidden)]
-    pub use crate::{fixed_tickstep::FixedTick, Tick}; // , Time, Timer, TimerMode
+    pub use crate::{fixed_tickstep::FixedTick, Tick, TickSystem};
 }
 
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 
-/// Adds time functionality to Apps.
+/// Adds tick functionality to Apps.
 #[derive(Default)]
 pub struct TickPlugin;
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, SystemSet)]
-/// Updates the elapsed time. Any system that interacts with [Time] component should run after
+/// Updates the elapsed ticks. Any system that interacts with [Tick] component should run after
 /// this.
 pub struct TickSystem;
 
@@ -38,8 +36,7 @@ impl Plugin for TickSystem {
     }
 }
 
-/// The system used to update the [`Time`] used by app logic. If there is a render world the time is sent from
-/// there to this system through channels. Otherwise the time is updated in this system.
+/// The system used to update the [`Tick`] used by app logic.
 fn tick_system(mut tick: ResMut<Tick>) {
     tick.update();
 }

--- a/crates/valence_tick/src/lib.rs
+++ b/crates/valence_tick/src/lib.rs
@@ -7,12 +7,6 @@ pub use tick::*;
 
 use bevy_ecs::system::ResMut;
 
-pub mod prelude {
-    //! The Valence Tick Prelude.
-    #[doc(hidden)]
-    pub use crate::{fixed_tickstep::FixedTick, Tick, TickSystem};
-}
-
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 

--- a/crates/valence_tick/src/tick.rs
+++ b/crates/valence_tick/src/tick.rs
@@ -1,0 +1,43 @@
+use bevy_ecs::{reflect::ReflectResource, system::Resource};
+use bevy_reflect::{FromReflect, Reflect};
+
+/// A clock that tracks how much it has advanced (and how much real tick has elapsed) since
+/// its previous update and since its creation.
+#[derive(Resource, Reflect, FromReflect, Debug, Clone)]
+#[reflect(Resource)]
+pub struct Tick {
+    elapsed: usize,
+}
+
+impl Default for Tick {
+    fn default() -> Self {
+        Self { elapsed: 0 }
+    }
+}
+
+impl Tick {
+    /// Constructs a new `Tick` instance with a specific startup `Tick`.
+    pub fn new() -> Self {
+        Self {
+            ..Default::default()
+        }
+    }
+
+    /// Updates the internal tick measurements.
+    ///
+    /// Calling this method as part of your app will most likely result in inaccurate tickkeeping,
+    /// as the `Tick` resource is ordinarily managed by the [`TickPlugin`](crate::TickPlugin).
+    pub fn update(&mut self) {
+        self.update_with_tick(1);
+    }
+
+    pub fn update_with_tick(&mut self, tick: usize) {
+        self.elapsed += tick;
+    }
+
+    /// Returns how much tick has advanced since [`startup`](#method.startup), as [`Duration`].
+    #[inline]
+    pub fn elapsed(&self) -> usize {
+        self.elapsed
+    }
+}

--- a/crates/valence_tick/src/tick.rs
+++ b/crates/valence_tick/src/tick.rs
@@ -2,24 +2,16 @@ use bevy_ecs::{reflect::ReflectResource, system::Resource};
 use bevy_reflect::{FromReflect, Reflect};
 
 /// A counter that tracks how many ticks has advanced
-#[derive(Resource, Reflect, FromReflect, Debug, Clone)]
+#[derive(Resource, Default, Reflect, FromReflect, Debug, Clone)]
 #[reflect(Resource)]
 pub struct Tick {
     elapsed: usize,
 }
 
-impl Default for Tick {
-    fn default() -> Self {
-        Self { elapsed: 0 }
-    }
-}
-
 impl Tick {
     /// Constructs a new `Tick` instance
     pub fn new() -> Self {
-        Self {
-            ..Default::default()
-        }
+        Self::default()
     }
 
     /// Updates the internal tick measurements.

--- a/crates/valence_tick/src/tick.rs
+++ b/crates/valence_tick/src/tick.rs
@@ -1,8 +1,7 @@
 use bevy_ecs::{reflect::ReflectResource, system::Resource};
 use bevy_reflect::{FromReflect, Reflect};
 
-/// A clock that tracks how much it has advanced (and how much real tick has elapsed) since
-/// its previous update and since its creation.
+/// A counter that tracks how many ticks has advanced
 #[derive(Resource, Reflect, FromReflect, Debug, Clone)]
 #[reflect(Resource)]
 pub struct Tick {
@@ -16,7 +15,7 @@ impl Default for Tick {
 }
 
 impl Tick {
-    /// Constructs a new `Tick` instance with a specific startup `Tick`.
+    /// Constructs a new `Tick` instance
     pub fn new() -> Self {
         Self {
             ..Default::default()
@@ -24,9 +23,6 @@ impl Tick {
     }
 
     /// Updates the internal tick measurements.
-    ///
-    /// Calling this method as part of your app will most likely result in inaccurate tickkeeping,
-    /// as the `Tick` resource is ordinarily managed by the [`TickPlugin`](crate::TickPlugin).
     pub fn update(&mut self) {
         self.update_with_tick(1);
     }
@@ -35,7 +31,7 @@ impl Tick {
         self.elapsed += tick;
     }
 
-    /// Returns how much tick has advanced since [`startup`](#method.startup), as [`Duration`].
+    /// Returns how many tick have advanced since [`startup`](#method.startup), as [`usize`].
     #[inline]
     pub fn elapsed(&self) -> usize {
         self.elapsed

--- a/tools/playground/Cargo.toml
+++ b/tools/playground/Cargo.toml
@@ -10,7 +10,5 @@ glam.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
 valence_core.workspace = true
-
 valence_tick.workspace = true
-
 valence.workspace = true

--- a/tools/playground/Cargo.toml
+++ b/tools/playground/Cargo.toml
@@ -10,4 +10,7 @@ glam.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
 valence_core.workspace = true
+
+valence_tick.workspace = true
+
 valence.workspace = true


### PR DESCRIPTION
## Description

Describe the changes you've made. Link to any issues this PR fixes or addresses.

Adapted the bevy_time implementation to be used with Ticks as usize instead of Time as Instant/Duration, allows you to run systems with a fixed tick interval.

Quick note: This does (still) use `CoreSchedule::FixedUpdate` and I am not sure that it should, I looked briefly in how to add a custom Schedule thing, but that went way over my head.
What I am missing, (also from bevy itself) is how to make multiple FixedTick to run separate systems, I don't think it's possible, I would prefer to assign a system to a schedule, where you can have systems run at different intervals without needing to resort to something like https://github.com/valence-rs/valence/pull/377/files#diff-50197256120b6495759f6a7d5ff7276b9716bc0deddc48b62e174c0762e4ac00R68
But that might just be a bevy generic limitation from what I can tell.