### PR TITLE
Split fmt clippy ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,36 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  valence-fmt-clippy:
+  valence-fmt:
+    strategy:
+      fail-fast: true
+      matrix:
+        platform: [ubuntu-latest]
+        style: [default]
+        rust:
+          - nightly
+        include:
+          - style: default
+            flags: ""
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Rust toolchain and cache
+        uses: actions-rust-lang/setup-rust-toolchain@v1.4.4
+        with:
+          toolchain: "nightly"
+          components: "clippy, rustfmt"
+
+      - name: "Copy playground"
+        run: cp tools/playground/src/playground.template.rs tools/playground/src/playground.rs
+
+      - name: cargo fmt
+        run: cargo +nightly fmt --all -- --check
+
+  valence-clippy:
     strategy:
       fail-fast: true
       matrix:
@@ -31,7 +60,7 @@ jobs:
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.4.4
         with:
-          toolchain: "nightly"
+          toolchain: "stable"
           components: "clippy, rustfmt"
 
       - name: "Copy playground"
@@ -40,9 +69,6 @@ jobs:
       - name: Install Dependencies (Linux)
         run: sudo apt-get update && sudo apt-get install -y libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev libclang-dev libgtk-3-dev
         if: matrix.platform == 'ubuntu-latest'
-
-      - name: cargo fmt
-        run: cargo +nightly fmt --all -- --check
 
       - name: Clippy
         run: cargo clippy --workspace ${{ matrix.flags }}--no-deps --all-features --all-targets -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1.4.4
         with:
           toolchain: "nightly"
-          components: "clippy, rustfmt"
+          components: "rustfmt"
 
       - name: "Copy playground"
         run: cp tools/playground/src/playground.template.rs tools/playground/src/playground.rs
@@ -61,7 +61,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1.4.4
         with:
           toolchain: "stable"
-          components: "clippy, rustfmt"
+          components: "clippy"
 
       - name: "Copy playground"
         run: cp tools/playground/src/playground.template.rs tools/playground/src/playground.rs


### PR DESCRIPTION
## Description

Split fmt and clippy in ci, since fmt requires nightly, and clippy breaks on nightly
fmt only needs to run on a single platform as they _should be_ run with identical behavior across platforms