### PR TITLE
Version lock nightly in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         platform: [ubuntu-latest]
         style: [default]
         rust:
-          - nightly
+          - nightly-2023-06-20
         include:
           - style: default
             flags: ""
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.4.4
         with:
-          toolchain: "nightly"
+          toolchain: "nightly-2023-06-20"
           components: "rustfmt"
 
       - name: "Copy playground"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: cp tools/playground/src/playground.template.rs tools/playground/src/playground.rs
 
       - name: cargo fmt
-        run: cargo +nightly fmt --all -- --check
+        run: cargo fmt --all -- --check
 
   valence-clippy:
     strategy:


### PR DESCRIPTION
## Description

Describe the changes you've made. Link to any issues this PR fixes or addresses.

Version lock nightly to yesterday for fmt, it seems to fail right now, not sure why, testing if this fixes the fmt job again..

Okay, this seems to fix todays issue of nightly not wanting to install on the CI.