### PR TITLE
Add `write_packet_fallible`

### DIFF
--- a/crates/valence_client/src/lib.rs
+++ b/crates/valence_client/src/lib.rs
@@ -293,11 +293,11 @@ impl Drop for Client {
 /// Writes packets into this client's packet buffer. The buffer is flushed at
 /// the end of the tick.
 impl WritePacket for Client {
-    fn write_packet<P>(&mut self, packet: &P)
+    fn write_packet_fallible<P>(&mut self, packet: &P) -> anyhow::Result<()>
     where
         P: Packet + Encode,
     {
-        self.enc.write_packet(packet)
+        self.enc.write_packet_fallible(packet)
     }
 
     fn write_packet_bytes(&mut self, bytes: &[u8]) {

--- a/crates/valence_core/src/protocol/encode.rs
+++ b/crates/valence_core/src/protocol/encode.rs
@@ -185,6 +185,16 @@ pub trait WritePacket {
     /// discarded.
     fn write_packet<P>(&mut self, packet: &P)
     where
+        P: Packet + Encode,
+    {
+        if let Err(e) = self.write_packet_fallible(packet) {
+            warn!("failed to write packet '{}': {e:#}", P::NAME);
+        }
+    }
+
+    /// Writes a packet to this object. The result of encoding the packet is returned.
+    fn write_packet_fallible<P>(&mut self, packet: &P) -> anyhow::Result<()>
+    where
         P: Packet + Encode;
 
     /// Copies raw packet data directly into this object. Don't use this unless
@@ -193,11 +203,11 @@ pub trait WritePacket {
 }
 
 impl<W: WritePacket> WritePacket for &mut W {
-    fn write_packet<P>(&mut self, packet: &P)
+    fn write_packet_fallible<P>(&mut self, packet: &P) -> anyhow::Result<()>
     where
         P: Packet + Encode,
     {
-        (*self).write_packet(packet)
+        (*self).write_packet_fallible(packet)
     }
 
     fn write_packet_bytes(&mut self, bytes: &[u8]) {
@@ -206,11 +216,11 @@ impl<W: WritePacket> WritePacket for &mut W {
 }
 
 impl<T: WritePacket> WritePacket for Mut<'_, T> {
-    fn write_packet<P>(&mut self, packet: &P)
+    fn write_packet_fallible<P>(&mut self, packet: &P) -> anyhow::Result<()>
     where
         P: Packet + Encode,
     {
-        self.as_mut().write_packet(packet)
+        self.as_mut().write_packet_fallible(packet)
     }
 
     fn write_packet_bytes(&mut self, bytes: &[u8]) {
@@ -236,23 +246,19 @@ impl<'a> PacketWriter<'a> {
 }
 
 impl WritePacket for PacketWriter<'_> {
-    fn write_packet<P>(&mut self, pkt: &P)
+    fn write_packet_fallible<P>(&mut self, pkt: &P) -> anyhow::Result<()>
     where
         P: Packet + Encode,
     {
         #[cfg(feature = "compression")]
-        let res = if let Some(threshold) = self.threshold {
+        if let Some(threshold) = self.threshold {
             encode_packet_compressed(self.buf, pkt, threshold, self.scratch)
         } else {
             encode_packet(self.buf, pkt)
-        };
+        }
 
         #[cfg(not(feature = "compression"))]
-        let res = encode_packet(self.buf, pkt);
-
-        if let Err(e) = res {
-            warn!("failed to write packet: {e:#}");
-        }
+        encode_packet(self.buf, pkt)
     }
 
     fn write_packet_bytes(&mut self, bytes: &[u8]) {
@@ -263,13 +269,11 @@ impl WritePacket for PacketWriter<'_> {
 }
 
 impl WritePacket for PacketEncoder {
-    fn write_packet<P>(&mut self, packet: &P)
+    fn write_packet_fallible<P>(&mut self, packet: &P) -> anyhow::Result<()>
     where
         P: Packet + Encode,
     {
-        if let Err(e) = self.append_packet(packet) {
-            warn!("failed to write packet: {e:#}");
-        }
+        self.append_packet(packet)
     }
 
     fn write_packet_bytes(&mut self, bytes: &[u8]) {

--- a/crates/valence_core/src/protocol/encode.rs
+++ b/crates/valence_core/src/protocol/encode.rs
@@ -192,7 +192,8 @@ pub trait WritePacket {
         }
     }
 
-    /// Writes a packet to this object. The result of encoding the packet is returned.
+    /// Writes a packet to this object. The result of encoding the packet is
+    /// returned.
     fn write_packet_fallible<P>(&mut self, packet: &P) -> anyhow::Result<()>
     where
         P: Packet + Encode;

--- a/crates/valence_instance/src/lib.rs
+++ b/crates/valence_instance/src/lib.rs
@@ -777,7 +777,7 @@ impl Instance {
 /// This is more efficient than sending the packet to each client individually.
 impl WritePacket for Instance {
     #[inline]
-    fn write_packet<P>(&mut self, packet: &P)
+    fn write_packet_fallible<P>(&mut self, packet: &P) -> anyhow::Result<()>
     where
         P: Packet + Encode,
     {
@@ -786,7 +786,7 @@ impl WritePacket for Instance {
             self.info.compression_threshold,
             &mut self.scratch,
         )
-        .write_packet(packet)
+        .write_packet_fallible(packet)
     }
 
     #[inline]


### PR DESCRIPTION
## Description

Added `write_packet_fallible` method to `WritePacket` trait in case the result is needed for whatever reason. Also removes some duplication by supplying a default logging message.
