### PR TITLE
Sorted Chunk View

### DIFF
--- a/crates/valence_client/src/lib.rs
+++ b/crates/valence_client/src/lib.rs
@@ -590,10 +590,7 @@ pub struct View {
 
 impl ViewItem<'_> {
     pub fn get(&self) -> ChunkView {
-        ChunkView {
-            pos: self.pos.chunk_pos(),
-            dist: self.view_dist.0,
-        }
+        ChunkView::new(self.pos.chunk_pos(), self.view_dist.0)
     }
 }
 
@@ -605,10 +602,7 @@ pub struct OldView {
 
 impl OldViewItem<'_> {
     pub fn get(&self) -> ChunkView {
-        ChunkView {
-            pos: self.old_pos.chunk_pos(),
-            dist: self.old_view_dist.0,
-        }
+        ChunkView::new(self.old_pos.chunk_pos(), self.old_view_dist.0)
     }
 }
 
@@ -921,7 +915,7 @@ fn read_data_in_old_view(
             let view = ChunkView::new(old_chunk_pos, old_view_dist.0);
 
             // Iterate over all visible chunks from the previous tick.
-            view.for_each(|pos| {
+            for pos in view.iter() {
                 if let Some(chunk) = inst.chunk(pos) {
                     // Mark this chunk as being in view of a client.
                     chunk.set_viewed();
@@ -994,7 +988,7 @@ fn read_data_in_old_view(
                         }
                     }
                 }
-            });
+            }
         },
     );
 }
@@ -1054,7 +1048,7 @@ fn update_view(
                     //       client will do the unloading for us in that case?
 
                     // Unload all chunks and entities in the old view.
-                    old_view.for_each(|pos| {
+                    for pos in old_view.iter() {
                         if let Some(chunk) = old_inst.chunk(pos) {
                             // Unload the chunk if its state is not "removed", since we already
                             // unloaded "removed" chunks earlier.
@@ -1075,12 +1069,12 @@ fn update_view(
                                 }
                             }
                         }
-                    });
+                    }
                 }
 
                 if let Ok(inst) = instances.get(loc.0) {
                     // Load all chunks and entities in new view.
-                    view.for_each(|pos| {
+                    for pos in view.iter() {
                         if let Some(chunk) = inst.chunk(pos) {
                             // Mark this chunk as being in view of a client.
                             chunk.set_viewed();
@@ -1098,7 +1092,7 @@ fn update_view(
                                 }
                             }
                         }
-                    });
+                    }
                 } else {
                     debug!("Client entered nonexistent instance ({loc:?}).");
                 }
@@ -1109,7 +1103,7 @@ fn update_view(
                     // Unload chunks and entities in the old view and load chunks and entities in
                     // the new view. We don't need to do any work where the old and new view
                     // overlap.
-                    old_view.diff_for_each(view, |pos| {
+                    for pos in old_view.diff(view) {
                         if let Some(chunk) = inst.chunk(pos) {
                             // Unload the chunk if its state is not "removed", since we already
                             // unloaded "removed" chunks earlier.
@@ -1130,9 +1124,9 @@ fn update_view(
                                 }
                             }
                         }
-                    });
+                    }
 
-                    view.diff_for_each(old_view, |pos| {
+                    for pos in view.diff(old_view) {
                         if let Some(chunk) = inst.chunk(pos) {
                             // Load the chunk unless it's already unloaded.
                             if chunk.state() != ChunkState::Removed
@@ -1155,7 +1149,7 @@ fn update_view(
                                 }
                             }
                         }
-                    });
+                    }
                 }
             }
         },

--- a/crates/valence_core/build/chunk_pos.rs
+++ b/crates/valence_core/build/chunk_pos.rs
@@ -1,0 +1,40 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+
+const MAX_VIEW_DIST: u8 = 32; // This can be increased to 64 if we want.
+const EXTRA_VIEW_RADIUS: i32 = 2;
+
+pub fn build() -> TokenStream {
+    let entries = (0..=MAX_VIEW_DIST).map(|dist| {
+        let dist = dist as i32 + EXTRA_VIEW_RADIUS;
+
+        let mut positions = vec![];
+
+        for z in -dist..=dist {
+            for x in -dist..=dist {
+                if x * x + z * z <= dist * dist {
+                    positions.push((x as i8, z as i8));
+                }
+            }
+        }
+
+        positions.sort_by_key(|&(x, z)| (x as i32).pow(2) + (z as i32).pow(2));
+
+        let array_elems = positions.into_iter().map(|(x, z)| quote!((#x, #z)));
+
+        quote! {
+            &[ #(#array_elems),* ]
+        }
+    });
+
+    let array_len = MAX_VIEW_DIST as usize + 1;
+
+    quote! {
+        /// The maximum view distance for a [`ChunkView`].
+        pub const MAX_VIEW_DIST: u8 = #MAX_VIEW_DIST;
+
+        const EXTRA_VIEW_RADIUS: i32 = 2;
+
+        static CHUNK_VIEW_LUT: [&[(i8, i8)]; #array_len] = [ #(#entries),* ];
+    }
+}

--- a/crates/valence_core/build/main.rs
+++ b/crates/valence_core/build/main.rs
@@ -1,5 +1,6 @@
 use valence_build_utils::{rerun_if_changed, write_generated_file};
 
+mod chunk_pos;
 mod item;
 mod packet_id;
 mod sound;
@@ -17,6 +18,7 @@ pub fn main() -> anyhow::Result<()> {
     write_generated_file(sound::build()?, "sound.rs")?;
     write_generated_file(translation_key::build()?, "translation_key.rs")?;
     write_generated_file(packet_id::build()?, "packet_id.rs")?;
+    write_generated_file(chunk_pos::build(), "chunk_pos.rs")?;
 
     Ok(())
 }


### PR DESCRIPTION
## Description

Change `ChunkView` so that iteration is done in sorted order by the distance to the center of the view. This is accomplished by precomputing a lookup table at compile time for all the possible view distances.

As a result of this change, the most important packets for clients to receive will typically arrive first. This is especially important when clients are loading into a new area, since the chunks closest to the client ought to be loaded first.