### PR TITLE
Add doctests to Github CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,9 @@ jobs:
       - name: Run tests
         run: cargo test --workspace ${{ matrix.flags }}--all-features --all-targets
 
+      - name: Run doctests
+        run: cargo test --workspace ${{ matrix.flags }}--all-features --doc
+
       - name: Run valence_nbt tests without preserve_order feature
         run: cargo test -p valence_nbt --all-targets
 


### PR DESCRIPTION
# Objective

- Test documentation examples with the Github CI too.

# Solution

- Add a separate step for doctests in `valence-tests`.

[`--doc` seems to be mutually exclusive with all other targets](https://doc.rust-lang.org/cargo/commands/cargo-test.html#option-cargo-test---doc)

https://github.com/rust-lang/cargo/issues/6669 relevant.
