### PR TITLE
Update to Bevy 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,12 +99,12 @@ arrayvec = "0.7.2"
 async-trait = "0.1.60"
 atty = "0.2.14"
 base64 = "0.21.0"
-bevy_app = { git = "https://github.com/bevyengine/bevy", rev = "910f984709fb58cddbb7393c948634a2540e8d72", default-features = false }
-bevy_ecs = { git = "https://github.com/bevyengine/bevy", rev = "910f984709fb58cddbb7393c948634a2540e8d72", default-features = false }
-bevy_hierarchy = { git = "https://github.com/bevyengine/bevy", rev = "910f984709fb58cddbb7393c948634a2540e8d72", default-features = false }
-bevy_log = { git = "https://github.com/bevyengine/bevy", rev = "910f984709fb58cddbb7393c948634a2540e8d72" }
+bevy_app = { version = "0.11", default-features = false }
+bevy_ecs = { version = "0.11", default-features = false }
+bevy_hierarchy = { version = "0.11", default-features = false }
+bevy_log = { version = "0.11" }
 bevy_mod_debugdump = "0.7.0"
-bevy_utils = { git = "https://github.com/bevyengine/bevy", rev = "910f984709fb58cddbb7393c948634a2540e8d72" }
+bevy_utils = { version = "0.11" }
 bitfield-struct = "0.3.1"
 byteorder = "1.4.3"
 bytes = "1.2.1"

--- a/crates/valence_advancement/src/lib.rs
+++ b/crates/valence_advancement/src/lib.rs
@@ -35,7 +35,7 @@ pub struct WriteAdvancementToCacheSet;
 
 impl Plugin for AdvancementPlugin {
     fn build(&self, app: &mut bevy_app::App) {
-        app.add_plugin(HierarchyPlugin)
+        app.add_plugins(HierarchyPlugin)
             .configure_sets(
                 PostUpdate,
                 (

--- a/crates/valence_core/src/lib.rs
+++ b/crates/valence_core/src/lib.rs
@@ -88,7 +88,7 @@ impl Plugin for CorePlugin {
         let tick_period = Duration::from_secs_f64((tick_rate.get() as f64).recip());
 
         // Make the app loop forever at the configured TPS.
-        app.add_plugin(ScheduleRunnerPlugin::run_loop(tick_period));
+        app.add_plugins(ScheduleRunnerPlugin::run_loop(tick_period));
 
         fn increment_tick_counter(mut server: ResMut<Server>) {
             server.current_tick += 1;

--- a/crates/valence_registry/src/tags.rs
+++ b/crates/valence_registry/src/tags.rs
@@ -79,7 +79,7 @@ mod tests {
     #[test]
     fn smoke_test() {
         let mut app = bevy_app::App::new();
-        app.add_plugin(RegistryPlugin);
+        app.add_plugins(RegistryPlugin);
         app.insert_resource(Server::default());
         app.update();
 

--- a/tools/playground/src/main.rs
+++ b/tools/playground/src/main.rs
@@ -36,7 +36,7 @@ fn main() {
 
     let mut app = App::new();
 
-    app.add_plugin(LogPlugin {
+    app.add_plugins(LogPlugin {
         level: args.log_level,
         ..Default::default()
     });


### PR DESCRIPTION
# Objective

Fixes #414

# Solution

Updates bevy dependencies to 0.11, while removing deprecated method usage.