### PR TITLE
Allow clippy::suspicious_else_formatting in generated valence_entity source file

### DIFF
--- a/crates/valence_entity/build.rs
+++ b/crates/valence_entity/build.rs
@@ -476,6 +476,7 @@ fn build() -> anyhow::Result<TokenStream> {
 
             systems.extend([quote! {
                 #[allow(clippy::needless_borrow)]
+                #[allow(clippy::suspicious_else_formatting)]
                 fn #system_name_ident(
                     mut query: Query<(&#component_path, &mut TrackedData), Changed<#component_path>>
                 ) {


### PR DESCRIPTION
# Objective

- Remove all of the useless clippy warnings from`valence_entity` build.rs generated file.

![Screenshot_20230718_133009](https://github.com/valence-rs/valence/assets/25486263/25a01c7e-5847-4131-bb33-106103f8babd)

# Solution

- `#[allow(clippy::suspicious_else_formatting)]`
