### PR TITLE
Update `dump_schedule` utility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ opt-level = 1
 
 [workspace]
 members = ["crates/*", "tools/*"]
-exclude = ["tools/dump_schedule"]
+exclude = []
 resolver = "2"
 
 [workspace.package]
@@ -103,7 +103,7 @@ bevy_app = { version = "0.11", default-features = false }
 bevy_ecs = { version = "0.11", default-features = false }
 bevy_hierarchy = { version = "0.11", default-features = false }
 bevy_log = { version = "0.11" }
-bevy_mod_debugdump = "0.7.0"
+bevy_mod_debugdump = { version =  "0.8.0", default-features = false }
 bevy_utils = { version = "0.11" }
 bitfield-struct = "0.3.1"
 byteorder = "1.4.3"

--- a/tools/dump_schedule/Cargo.toml
+++ b/tools/dump_schedule/Cargo.toml
@@ -5,4 +5,5 @@ edition.workspace = true
 
 [dependencies]
 bevy_mod_debugdump.workspace = true
+clap.workspace = true
 valence.workspace = true

--- a/tools/dump_schedule/README.md
+++ b/tools/dump_schedule/README.md
@@ -1,7 +1,7 @@
 # dump_schedule
 
-A simple debugging utility for visualizing Valence's main schedule graph. Generates a SVG file.
+A simple debugging utility for visualizing Valence's schedule graph. Generates a SVG file.
 
 1. Ensure that [Graphviz](https://graphviz.org/) is installed and the `dot` command is available.
-2. Run the program with `cargo r -p dump_schedule`
+2. Run the program with `cargo r -p dump_schedule -- PostUpdate`
 3. Open the generated `graph.svg` in your browser or other program, e.g. `chromium graph.svg`.

--- a/tools/dump_schedule/src/main.rs
+++ b/tools/dump_schedule/src/main.rs
@@ -18,18 +18,52 @@
 
 use std::io;
 use std::io::Write;
+use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
+use clap::Parser;
 use valence::prelude::*;
 
+#[derive(Parser)]
+#[command(author, version, about)]
+struct Cli {
+    /// Name of the schedule to dump. If absent, the list of available
+    /// schedules is printed to stdout.
+    schedule: Option<String>,
+    /// Output SVG file path.
+    #[clap(short, long, default_value = "graph.svg")]
+    output: PathBuf,
+}
+
 fn main() -> io::Result<()> {
+    let cli = Cli::parse();
+
     let mut app = App::new();
 
     app.add_plugins(DefaultPlugins);
 
+    let schedules = app.world.resource::<Schedules>();
+
+    let Some(sched_name) = cli.schedule else {
+        print_available_schedules(schedules);
+        return Ok(());
+    };
+
+    let Some(label) = schedules
+        .iter()
+        .map(|(label, _)| label)
+        .find(|label| format!("{label:?}") == sched_name)
+    else {
+        eprintln!("Unknown schedule \"{sched_name}\"");
+        print_available_schedules(schedules);
+        std::process::exit(1)
+    };
+
+    let label = label.dyn_clone();
+
     let dot_graph = bevy_mod_debugdump::schedule_graph_dot(
         &mut app,
-        CoreSchedule::Main,
+        label,
         &bevy_mod_debugdump::schedule_graph::Settings {
             ambiguity_enable: false,
             ..Default::default()
@@ -40,7 +74,7 @@ fn main() -> io::Result<()> {
         .stdin(Stdio::piped())
         .arg("-Tsvg")
         .arg("-o")
-        .arg("graph.svg")
+        .arg(cli.output)
         .spawn()?;
 
     if let Some(stdin) = child.stdin.as_mut() {
@@ -50,4 +84,14 @@ fn main() -> io::Result<()> {
     child.wait_with_output()?;
 
     Ok(())
+}
+
+fn print_available_schedules(schedules: &Schedules) {
+    eprintln!("==== Available Schedules ====");
+
+    for (label, _) in schedules.iter() {
+        println!("{label:?}");
+    }
+
+    eprintln!("\nSee `--help` for more information.");
 }


### PR DESCRIPTION
# Objective

Update the `dump_schedule` utility since `bevy_mod_debugdump` has been updated to support bevy 0.11.

# Solution

- Update `bevy_mod_debugdump` to 0.8.
- Add more command line options to the tool.
