### PR TITLE
Fix username validation for GeyserMC

### DIFF
--- a/crates/valence_client/src/lib.rs
+++ b/crates/valence_client/src/lib.rs
@@ -463,40 +463,10 @@ impl EntityRemoveBuf {
 #[derive(Component, Clone, PartialEq, Eq, Default, Debug)]
 pub struct Username(pub String);
 
-impl Username {
-    pub fn is_valid(&self) -> bool {
-        is_valid_username(&self.0)
-    }
-}
-
 impl fmt::Display for Username {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)
     }
-}
-
-/// Returns whether or not the given string is a valid Minecraft username.
-///
-/// A valid username is 3 to 16 characters long with only ASCII alphanumeric
-/// characters. The username must match the regex `^[a-zA-Z0-9_]{3,16}$` to be
-/// considered valid.
-///
-/// # Examples
-///
-/// ```
-/// # use valence_client::is_valid_username;
-///
-/// assert!(is_valid_username("00a"));
-/// assert!(is_valid_username("jeb_"));
-///
-/// assert!(!is_valid_username("notavalidusername"));
-/// assert!(!is_valid_username("NotValid!"));
-/// ```
-pub fn is_valid_username(username: &str) -> bool {
-    (3..=16).contains(&username.len())
-        && username
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
 #[derive(Component, Clone, PartialEq, Eq, Default, Debug)]

--- a/crates/valence_network/src/connect.rs
+++ b/crates/valence_network/src/connect.rs
@@ -18,7 +18,6 @@ use sha2::{Digest, Sha256};
 use tokio::net::{TcpListener, TcpStream};
 use tracing::{error, info, trace, warn};
 use uuid::Uuid;
-use valence_client::is_valid_username;
 use valence_core::property::Property;
 use valence_core::protocol::decode::PacketDecoder;
 use valence_core::protocol::encode::PacketEncoder;
@@ -261,8 +260,6 @@ async fn handle_login(
         profile_id: _, // TODO
     } = conn.recv_packet().await?;
 
-    ensure!(is_valid_username(username), "invalid username");
-
     let username = username.to_owned();
 
     let info = match shared.connection_mode() {
@@ -395,11 +392,6 @@ async fn login_online(
     }
 
     let profile: GameProfile = resp.json().await.context("parsing game profile")?;
-
-    ensure!(
-        is_valid_username(&profile.name),
-        "invalid game profile username"
-    );
 
     ensure!(profile.name == username, "usernames do not match");
 


### PR DESCRIPTION
# Objective

Remove unnecessary username validation to support GeyserMC usernames.

# Solution

Remove `is_valid_username` as discussed in #416.
