### PR TITLE
Fix valence_network timeouts + other fixes

### DIFF
--- a/crates/valence_network/src/connect.rs
+++ b/crates/valence_network/src/connect.rs
@@ -25,8 +25,8 @@ use valence_core::protocol::encode::PacketEncoder;
 use valence_core::protocol::raw::RawBytes;
 use valence_core::protocol::var_int::VarInt;
 use valence_core::protocol::Decode;
-use valence_core::text::{Color, Text};
-use valence_core::{ident, translation_key, PROTOCOL_VERSION};
+use valence_core::text::{Color, IntoText, Text};
+use valence_core::{ident, translation_key, MINECRAFT_VERSION, PROTOCOL_VERSION};
 
 use crate::legacy_ping::try_handle_legacy_ping;
 use crate::packet::{
@@ -47,6 +47,8 @@ pub(super) async fn do_accept_loop(shared: SharedNetworkState) {
         }
     };
 
+    let timeout = Duration::from_secs(5);
+
     loop {
         match shared.0.connection_sema.clone().acquire_owned().await {
             Ok(permit) => match listener.accept().await {
@@ -54,7 +56,15 @@ pub(super) async fn do_accept_loop(shared: SharedNetworkState) {
                     let shared = shared.clone();
 
                     tokio::spawn(async move {
-                        handle_connection(shared, stream, remote_addr).await;
+                        if let Err(e) = tokio::time::timeout(
+                            timeout,
+                            handle_connection(shared, stream, remote_addr),
+                        )
+                        .await
+                        {
+                            warn!("initial connection timed out: {e}");
+                        }
+
                         drop(permit);
                     });
                 }
@@ -79,26 +89,18 @@ async fn handle_connection(
         error!("failed to set TCP_NODELAY: {e}");
     }
 
-    let timeout = Duration::from_secs(5);
-
-    match tokio::time::timeout(
-        timeout,
-        try_handle_legacy_ping(&shared, &mut stream, remote_addr),
-    )
-    .await
-    .unwrap_or(Err(io::Error::new(io::ErrorKind::TimedOut, "timed out")))
-    {
-        Ok(true) => return,
-        Ok(false) => {}
+    match try_handle_legacy_ping(&shared, &mut stream, remote_addr).await {
+        Ok(true) => return, // Legacy ping succeeded.
+        Ok(false) => {}     // No legacy ping.
         Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => {}
         Err(e) => {
-            warn!("connection ended with error: {e:#}");
+            warn!("legacy ping ended with error: {e:#}");
         }
     }
 
-    let conn = PacketIo::new(stream, PacketEncoder::new(), PacketDecoder::new(), timeout);
+    let io = PacketIo::new(stream, PacketEncoder::new(), PacketDecoder::new());
 
-    if let Err(e) = handle_handshake(shared, conn, remote_addr).await {
+    if let Err(e) = handle_handshake(shared, io, remote_addr).await {
         // EOF can happen if the client disconnects while joining, which isn't
         // very erroneous.
         if let Some(e) = e.downcast_ref::<io::Error>() {
@@ -247,47 +249,54 @@ async fn handle_status(
 /// Handle the login process and return the new client's data if successful.
 async fn handle_login(
     shared: &SharedNetworkState,
-    conn: &mut PacketIo,
+    io: &mut PacketIo,
     remote_addr: SocketAddr,
     handshake: HandshakeData,
 ) -> anyhow::Result<Option<(NewClientInfo, CleanupOnDrop)>> {
     if handshake.protocol_version != PROTOCOL_VERSION {
-        // TODO: send translated disconnect msg.
+        io.send_packet(&LoginDisconnectS2c {
+            // TODO: use correct translation key.
+            reason: format!("Mismatched Minecraft version (server is on {MINECRAFT_VERSION})")
+                .color(Color::RED)
+                .into(),
+        })
+        .await?;
+
         return Ok(None);
     }
 
     let LoginHelloC2s {
         username,
         profile_id: _, // TODO
-    } = conn.recv_packet().await?;
+    } = io.recv_packet().await?;
 
     ensure!(is_valid_username(username), "invalid username");
 
     let username = username.to_owned();
 
     let info = match shared.connection_mode() {
-        ConnectionMode::Online { .. } => login_online(shared, conn, remote_addr, username).await?,
+        ConnectionMode::Online { .. } => login_online(shared, io, remote_addr, username).await?,
         ConnectionMode::Offline => login_offline(remote_addr, username)?,
         ConnectionMode::BungeeCord => {
             login_bungeecord(remote_addr, &handshake.server_address, username)?
         }
-        ConnectionMode::Velocity { secret } => login_velocity(conn, username, secret).await?,
+        ConnectionMode::Velocity { secret } => login_velocity(io, username, secret).await?,
     };
 
     if let Some(threshold) = shared.0.compression_threshold {
-        conn.send_packet(&LoginCompressionS2c {
+        io.send_packet(&LoginCompressionS2c {
             threshold: VarInt(threshold as i32),
         })
         .await?;
 
-        conn.set_compression(Some(threshold));
+        io.set_compression(Some(threshold));
     }
 
     let cleanup = match shared.0.callbacks.inner.login(shared, &info).await {
         Ok(f) => CleanupOnDrop(Some(f)),
         Err(reason) => {
             info!("disconnect at login: \"{reason}\"");
-            conn.send_packet(&LoginDisconnectS2c {
+            io.send_packet(&LoginDisconnectS2c {
                 reason: reason.into(),
             })
             .await?;
@@ -295,7 +304,7 @@ async fn handle_login(
         }
     };
 
-    conn.send_packet(&LoginSuccessS2c {
+    io.send_packet(&LoginSuccessS2c {
         uuid: info.uuid,
         username: &info.username,
         properties: Default::default(),
@@ -308,13 +317,13 @@ async fn handle_login(
 /// Login procedure for online mode.
 async fn login_online(
     shared: &SharedNetworkState,
-    conn: &mut PacketIo,
+    io: &mut PacketIo,
     remote_addr: SocketAddr,
     username: String,
 ) -> anyhow::Result<NewClientInfo> {
     let my_verify_token: [u8; 16] = rand::random();
 
-    conn.send_packet(&LoginHelloS2c {
+    io.send_packet(&LoginHelloS2c {
         server_id: "", // Always empty
         public_key: &shared.0.public_key_der,
         verify_token: &my_verify_token,
@@ -324,7 +333,7 @@ async fn login_online(
     let LoginKeyC2s {
         shared_secret,
         verify_token: encrypted_verify_token,
-    } = conn.recv_packet().await?;
+    } = io.recv_packet().await?;
 
     let shared_secret = shared
         .0
@@ -348,7 +357,7 @@ async fn login_online(
         .try_into()
         .context("shared secret has the wrong length")?;
 
-    conn.enable_encryption(&crypt_key);
+    io.enable_encryption(&crypt_key);
 
     let hash = Sha1::new()
         .chain(&shared_secret)
@@ -376,7 +385,7 @@ async fn login_online(
                 translation_key::MULTIPLAYER_DISCONNECT_UNVERIFIED_USERNAME,
                 [],
             );
-            conn.send_packet(&LoginDisconnectS2c {
+            io.send_packet(&LoginDisconnectS2c {
                 reason: reason.into(),
             })
             .await?;


### PR DESCRIPTION
# Objective

- Make timeouts in `valence_network` per connection rather than per packet.
- Add missing disconnect message when protocol version mismatch occurs.
- More consistent variable names.

# Solution
- Remove timeouts from `PacketIo` and `try_handle_legacy_ping` call.
- Add timeout to `handle_connection` call.
- Rename `conn` -> `io`.
