### PR TITLE
Add transitive reduction to `dump_schedule`

### DIFF
--- a/tools/dump_schedule/README.md
+++ b/tools/dump_schedule/README.md
@@ -2,6 +2,6 @@
 
 A simple debugging utility for visualizing Valence's schedule graph. Generates a SVG file.
 
-1. Ensure that [Graphviz](https://graphviz.org/) is installed and the `dot` command is available.
+1. Ensure that [Graphviz](https://graphviz.org/) is installed and the `dot` and `tred` commands are available.
 2. Run the program with `cargo r -p dump_schedule -- PostUpdate`
 3. Open the generated `graph.svg` in your browser or other program, e.g. `chromium graph.svg`.


### PR DESCRIPTION
# Objective

Perform [transitive reduction](https://en.wikipedia.org/wiki/Transitive_reduction) on the output of the `dump_schedule` utility to make it easier to understand.

# Solution

Send the output through the graphviz `tred` command before piping through `dot`. Can be disabled with the `--no-tred` flag.
