### PR TITLE
Tweak `valence_nbt`

### DIFF
--- a/crates/valence_nbt/Cargo.toml
+++ b/crates/valence_nbt/Cargo.toml
@@ -10,6 +10,7 @@ version = "0.5.0"
 edition.workspace = true
 
 [features]
+default = ["snbt"] # TODO: remove me
 binary = ["dep:byteorder", "dep:cesu8"]
 snbt = []
 # When enabled, the order of fields in compounds are preserved.

--- a/crates/valence_nbt/src/binary/decode.rs
+++ b/crates/valence_nbt/src/binary/decode.rs
@@ -247,7 +247,7 @@ impl<W: Write> EncodeState<W> {
 
     fn write_compound(&mut self, c: &Compound) -> Result<()> {
         for (k, v) in c.iter() {
-            self.write_tag(Tag::element_type(v))?;
+            self.write_tag(v.tag())?;
             self.write_string(k)?;
             self.write_value(v)?;
         }

--- a/crates/valence_nbt/src/tag.rs
+++ b/crates/valence_nbt/src/tag.rs
@@ -1,8 +1,6 @@
 use std::fmt;
 use std::fmt::Formatter;
 
-use crate::Value;
-
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Tag {
     // Variant order is significant!
@@ -22,23 +20,6 @@ pub enum Tag {
 }
 
 impl Tag {
-    pub fn element_type(value: &Value) -> Self {
-        match value {
-            Value::Byte(_) => Tag::Byte,
-            Value::Short(_) => Tag::Short,
-            Value::Int(_) => Tag::Int,
-            Value::Long(_) => Tag::Long,
-            Value::Float(_) => Tag::Float,
-            Value::Double(_) => Tag::Double,
-            Value::ByteArray(_) => Tag::ByteArray,
-            Value::String(_) => Tag::String,
-            Value::List(_) => Tag::List,
-            Value::Compound(_) => Tag::Compound,
-            Value::IntArray(_) => Tag::IntArray,
-            Value::LongArray(_) => Tag::LongArray,
-        }
-    }
-
     pub const fn name(self) -> &'static str {
         match self {
             Tag::End => "end",

--- a/crates/valence_nbt/src/value.rs
+++ b/crates/valence_nbt/src/value.rs
@@ -300,3 +300,23 @@ impl From<Vec<Vec<i64>>> for List {
         List::LongArray(v)
     }
 }
+
+/// Converts a value to a singleton list.
+impl From<Value> for List {
+    fn from(value: Value) -> Self {
+        match value {
+            Value::Byte(v) => List::Byte(vec![v]),
+            Value::Short(v) => List::Short(vec![v]),
+            Value::Int(v) => List::Int(vec![v]),
+            Value::Long(v) => List::Long(vec![v]),
+            Value::Float(v) => List::Float(vec![v]),
+            Value::Double(v) => List::Double(vec![v]),
+            Value::ByteArray(v) => List::ByteArray(vec![v]),
+            Value::String(v) => List::String(vec![v]),
+            Value::List(v) => List::List(vec![v]),
+            Value::Compound(v) => List::Compound(vec![v]),
+            Value::IntArray(v) => List::IntArray(vec![v]),
+            Value::LongArray(v) => List::LongArray(vec![v]),
+        }
+    }
+}

--- a/crates/valence_nbt/src/value.rs
+++ b/crates/valence_nbt/src/value.rs
@@ -98,55 +98,9 @@ impl List {
     }
 }
 
-macro_rules! nbt_conversion {
-    ( $($nbt_type:ident = $value_type:ty => $is_function:ident $as_function:ident $as_mut_function:ident $into_function:ident)+ ) => {
-        $(
-            pub fn $is_function(&self) -> bool {
-                self.$as_function().is_some()
-            }
-
-            pub fn $as_function(&self) -> Option<&$value_type> {
-                match self {
-                    Self::$nbt_type(value) => Some(value),
-                    _ => None
-                }
-            }
-
-            pub fn $as_mut_function(&mut self) -> Option<&mut $value_type> {
-                match self {
-                    Self::$nbt_type(value) => Some(value),
-                    _ => None
-                }
-            }
-
-            pub fn $into_function(self) -> Option<$value_type> {
-                match self {
-                    Self::$nbt_type(value) => Some(value),
-                    _ => None
-                }
-            }
-        )*
-    };
-}
-
 impl Value {
-    nbt_conversion! {
-        Byte = i8 => is_byte as_byte as_byte_mut into_byte
-        Short = i16 => is_short as_short as_short_mut into_short
-        Int = i32 => is_int as_int as_int_mut into_int
-        Long = i64 => is_long as_long as_long_mut into_long
-        Float = f32 => is_float as_float as_float_mut into_float
-        Double = f64 => is_double as_double as_double_mut into_double
-        ByteArray = Vec<i8> => is_byte_array as_byte_array as_byte_array_mut into_byte_array
-        String = String => is_string as_string as_string_mut into_string
-        List = List => is_list as_list as_list_mut into_list
-        Compound = Compound => is_compound as_compound as_compound_mut into_compound
-        IntArray = Vec<i32> => is_int_array as_int_array as_int_array_mut into_int_array
-        LongArray = Vec<i64> => is_long_array as_long_array as_long_array_mut into_long_array
-    }
-
     /// Returns the type of this value.
-    pub fn get_tag(&self) -> Tag {
+    pub fn tag(&self) -> Tag {
         match self {
             Self::Byte(_) => Tag::Byte,
             Self::Short(_) => Tag::Short,


### PR DESCRIPTION
# Objective

- Fix a few small things before releasing 0.5. For #428 

# Solution

- Remove redundant `element_type` method from `Tag`.
- `get_tag` -> `tag`.
- Remove macro generated methods from `Value`.
- Create `From<Value> for List` impl which creates a new singleton list.
- Clean up snbt code a bit.
