### PR TITLE
Configure cargo to use `-Ctarget-cpu=native`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-Ctarget-cpu=native"]


### PR DESCRIPTION
# Objective

Tell rustc to use native CPU features when building the project. Especially useful for the benchmarks.

# Solution

Add a `.cargo/config.toml` with the following contents:

```toml
[build]
rustflags = ["-Ctarget-cpu=native"]
```
