### PR TITLE
Fix `update_selected_slot_c2s`

### DIFF
--- a/crates/valence_inventory/src/lib.rs
+++ b/crates/valence_inventory/src/lib.rs
@@ -1235,11 +1235,11 @@ fn handle_update_selected_slot(
                     // The client is trying to interact with a slot that does not exist, ignore.
                     continue;
                 }
-                held.held_item_slot = convert_hotbar_slot_id(pkt.slot as u16);
+                held.held_item_slot = convert_hotbar_slot_id(pkt.slot);
 
                 events.send(UpdateSelectedSlotEvent {
                     client: packet.client,
-                    slot: pkt.slot,
+                    slot: pkt.slot as u8,
                 });
             }
         }

--- a/crates/valence_protocol/src/packets/play/update_selected_slot_c2s.rs
+++ b/crates/valence_protocol/src/packets/play/update_selected_slot_c2s.rs
@@ -3,5 +3,5 @@ use super::*;
 #[derive(Copy, Clone, Debug, Encode, Decode, Packet)]
 #[packet(id = packet_id::UPDATE_SELECTED_SLOT_C2S)]
 pub struct UpdateSelectedSlotC2s {
-    pub slot: u8,
+    pub slot: u16,
 }


### PR DESCRIPTION
# Objective

This packet wasn't right anymore because I had change it thinking it was odd that the S2c and C2s don't use the same primitive size, but it create warning so I reverse it.

# Solution

Change u8 to u16 so the packet can be decode without warning.
