### PR TITLE
Consolidate unsafe byte conversions in valence_nbt

### DIFF
--- a/crates/valence_nbt/src/binary/decode.rs
+++ b/crates/valence_nbt/src/binary/decode.rs
@@ -1,5 +1,4 @@
 use std::io::Write;
-use std::slice;
 
 use byteorder::{BigEndian, WriteBytesExt};
 

--- a/crates/valence_nbt/src/binary/decode.rs
+++ b/crates/valence_nbt/src/binary/decode.rs
@@ -5,7 +5,7 @@ use byteorder::{BigEndian, WriteBytesExt};
 
 use super::{modified_utf8, Error, Result};
 use crate::tag::Tag;
-use crate::{Compound, List, Value};
+use crate::{i8_slice_as_u8_slice, Compound, List, Value};
 
 impl Compound {
     /// Encodes uncompressed NBT binary data to the provided writer.
@@ -146,10 +146,7 @@ impl<W: Write> EncodeState<W> {
             }
         }
 
-        // SAFETY: i8 has the same layout as u8.
-        let bytes = unsafe { slice::from_raw_parts(bytes.as_ptr() as *const u8, bytes.len()) };
-
-        Ok(self.writer.write_all(bytes)?)
+        Ok(self.writer.write_all(i8_slice_as_u8_slice(bytes))?)
     }
 
     fn write_string(&mut self, s: &str) -> Result<()> {
@@ -197,10 +194,7 @@ impl<W: Write> EncodeState<W> {
                     }
                 }
 
-                // SAFETY: i8 has the same layout as u8.
-                let bytes = unsafe { slice::from_raw_parts(bl.as_ptr() as *const u8, bl.len()) };
-
-                Ok(self.writer.write_all(bytes)?)
+                Ok(self.writer.write_all(i8_slice_as_u8_slice(bl))?)
             }
             List::Short(sl) => self.write_list(sl, Tag::Short, |st, s| st.write_short(*s)),
             List::Int(il) => self.write_list(il, Tag::Int, |st, i| st.write_int(*i)),

--- a/crates/valence_nbt/src/lib.rs
+++ b/crates/valence_nbt/src/lib.rs
@@ -17,6 +17,8 @@
     clippy::dbg_macro
 )]
 
+use std::mem::ManuallyDrop;
+
 pub use compound::Compound;
 pub use tag::Tag;
 pub use value::{List, Value};
@@ -74,4 +76,40 @@ macro_rules! compound {
             )*
         ])
     }
+}
+
+/// Converts a `Vec<u8>` into a `Vec<i8>` without cloning.
+#[inline]
+pub fn u8_vec_into_i8_vec(vec: Vec<u8>) -> Vec<i8> {
+    // SAFETY: Layouts of u8 and i8 are the same and we're being careful not to drop
+    // the original vec after calling Vec::from_raw_parts.
+    unsafe {
+        let mut vec = ManuallyDrop::new(vec);
+        Vec::from_raw_parts(vec.as_mut_ptr() as *mut i8, vec.len(), vec.capacity())
+    }
+}
+
+/// Converts a `Vec<i8>` into a `Vec<u8>` without cloning.
+#[inline]
+pub fn i8_vec_into_u8_vec(vec: Vec<i8>) -> Vec<u8> {
+    // SAFETY: Layouts of u8 and i8 are the same and we're being careful not to drop
+    // the original vec after calling Vec::from_raw_parts.
+    unsafe {
+        let mut vec = ManuallyDrop::new(vec);
+        Vec::from_raw_parts(vec.as_mut_ptr() as *mut u8, vec.len(), vec.capacity())
+    }
+}
+
+/// Converts a `&[u8]` into a `&[i8]`.
+#[inline]
+pub fn u8_slice_as_i8_slice(slice: &[u8]) -> &[i8] {
+    // SAFETY: i8 has the same layout as u8.
+    unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const i8, slice.len()) }
+}
+
+/// Converts a `&[i8]` into a `&[u8]`.
+#[inline]
+pub fn i8_slice_as_u8_slice(slice: &[i8]) -> &[u8] {
+    // SAFETY: i8 has the same layout as u8.
+    unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const u8, slice.len()) }
 }

--- a/crates/valence_nbt/src/serde.rs
+++ b/crates/valence_nbt/src/serde.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::mem::ManuallyDrop;
 
 pub use ser::*;
 use thiserror::Error;

--- a/crates/valence_nbt/src/serde.rs
+++ b/crates/valence_nbt/src/serde.rs
@@ -38,23 +38,3 @@ impl serde::ser::Error for Error {
         Self::new(format!("{msg}"))
     }
 }
-
-#[inline]
-fn u8_vec_to_i8_vec(vec: Vec<u8>) -> Vec<i8> {
-    // SAFETY: Layouts of u8 and i8 are the same and we're being careful not to drop
-    // the original vec after calling Vec::from_raw_parts.
-    unsafe {
-        let mut vec = ManuallyDrop::new(vec);
-        Vec::from_raw_parts(vec.as_mut_ptr() as *mut i8, vec.len(), vec.capacity())
-    }
-}
-
-#[inline]
-fn i8_vec_to_u8_vec(vec: Vec<i8>) -> Vec<u8> {
-    // SAFETY: Layouts of u8 and i8 are the same and we're being careful not to drop
-    // the original vec after calling Vec::from_raw_parts.
-    unsafe {
-        let mut vec = ManuallyDrop::new(vec);
-        Vec::from_raw_parts(vec.as_mut_ptr() as *mut u8, vec.len(), vec.capacity())
-    }
-}

--- a/crates/valence_nbt/src/serde/de.rs
+++ b/crates/valence_nbt/src/serde/de.rs
@@ -1,4 +1,4 @@
-use std::{fmt, slice};
+use std::fmt;
 
 use serde::de::value::{MapAccessDeserializer, MapDeserializer, SeqAccessDeserializer};
 use serde::de::{self, IntoDeserializer, SeqAccess, Visitor};

--- a/crates/valence_protocol/src/impls.rs
+++ b/crates/valence_protocol/src/impls.rs
@@ -18,7 +18,7 @@ use valence_generated::block::{BlockEntityKind, BlockKind, BlockState};
 use valence_generated::item::ItemKind;
 use valence_ident::{Ident, IdentError};
 use valence_math::*;
-use valence_nbt::Compound;
+use valence_nbt::{i8_slice_as_u8_slice, u8_slice_as_i8_slice, Compound};
 use valence_text::Text;
 
 use super::var_int::VarInt;
@@ -69,9 +69,7 @@ impl Encode for i8 {
     }
 
     fn encode_slice(slice: &[i8], mut w: impl Write) -> Result<()> {
-        // SAFETY: i8 has the same layout as u8.
-        let bytes = unsafe { slice::from_raw_parts(slice.as_ptr() as *const u8, slice.len()) };
-        Ok(w.write_all(bytes)?)
+        Ok(w.write_all(i8_slice_as_u8_slice(slice))?)
     }
 }
 
@@ -546,10 +544,7 @@ impl<'a> Decode<'a> for &'a [i8] {
     fn decode(r: &mut &'a [u8]) -> Result<Self> {
         let bytes = <&[u8]>::decode(r)?;
 
-        // SAFETY: i8 and u8 have the same layout.
-        let bytes = unsafe { slice::from_raw_parts(bytes.as_ptr() as *const i8, bytes.len()) };
-
-        Ok(bytes)
+        Ok(u8_slice_as_i8_slice(bytes))
     }
 }
 


### PR DESCRIPTION
# Objective

When using valence_nbt, it's often necessary to convert to and from slices and vecs of `i8` and `u8`. But this requires unsafe code if you want to avoid copying things.

# Solution

Expose the following functions in valence_nbt:
- `u8_vec_into_i8_vec(vec: Vec<u8>) -> Vec<i8>`
- `i8_vec_into_u8_vec(vec: Vec<i8>) -> Vec<u8>`
- `u8_slice_as_i8_slice(slice: &[u8]) -> &[i8]`
- `i8_slice_as_u8_slice(slice: &[i8]) -> &[u8]`

We've also made use of these functions ourselves to reduce the total amount of unsafe code. Should also help in #263 
