### PR TITLE
Simplify CI, add typos spell checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup Rust toolchain and cache
-        uses: actions-rust-lang/setup-rust-toolchain@v1.4.4
+        uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
         with:
           toolchain: "nightly-2023-06-20"
           components: "rustfmt"
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup Rust toolchain and cache
-        uses: actions-rust-lang/setup-rust-toolchain@v1.4.4
+        uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
         with:
           toolchain: "stable"
           components: "clippy"
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup Rust toolchain and cache
-        uses: actions-rust-lang/setup-rust-toolchain@v1.4.4
+        uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
 
       - name: "Copy playground"
         run: cp tools/playground/src/playground.template.rs tools/playground/src/playground.rs
@@ -105,7 +105,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup Rust toolchain and cache
-        uses: actions-rust-lang/setup-rust-toolchain@v1.4.4
+        uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
 
       - name: "Copy playground"
         run: cp tools/playground/src/playground.template.rs tools/playground/src/playground.rs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: CI
 
 on:
   pull_request:
@@ -14,23 +14,52 @@ jobs:
   valence-fmt:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Actions Repository
       - uses: actions/checkout@v3
 
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
         with:
-          toolchain: "nightly-2023-06-20"
+          toolchain: "nightly"
           components: "rustfmt"
 
-      - name: "Copy playground"
+      - name: Copy playground
         run: cp tools/playground/src/playground.template.rs tools/playground/src/playground.rs
 
       - name: cargo fmt
         run: cargo fmt --all -- --check
 
+  valence-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions Repository
+      - uses: actions/checkout@v3
+
+      - name: Setup Rust toolchain and cache
+        uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
+
+      - name: Copy playground
+        run: cp tools/playground/src/playground.template.rs tools/playground/src/playground.rs
+
+      - name: Install dependencies (Linux)
+        run: sudo apt-get update && sudo apt-get install -y libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev libclang-dev libgtk-3-dev
+
+      - name: Validate documentation
+        run: cargo doc --workspace --no-deps --all-features --document-private-items
+
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions Repository
+        uses: actions/checkout@v3
+      
+      - name: Check for spelling errors
+        uses: crate-ci/typos@v1.16.5
+
   valence-clippy:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Actions Repository
       - uses: actions/checkout@v3
 
       - name: Setup Rust toolchain and cache
@@ -39,10 +68,10 @@ jobs:
           toolchain: "stable"
           components: "clippy"
 
-      - name: "Copy playground"
+      - name: Copy playground
         run: cp tools/playground/src/playground.template.rs tools/playground/src/playground.rs
 
-      - name: Install Dependencies (Linux)
+      - name: Install dependencies (Linux)
         run: sudo apt-get update && sudo apt-get install -y libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev libclang-dev libgtk-3-dev
 
       - name: Clippy
@@ -63,15 +92,16 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
+      - name: Checkout Actions Repository
       - uses: actions/checkout@v3
 
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
 
-      - name: "Copy playground"
+      - name: Copy playground
         run: cp tools/playground/src/playground.template.rs tools/playground/src/playground.rs
 
-      - name: Install Dependencies (Linux)
+      - name: Install dependencies (Linux)
         run: sudo apt-get update && sudo apt-get install -y libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev libclang-dev libgtk-3-dev
         if: matrix.platform == 'ubuntu-latest'
 
@@ -87,6 +117,7 @@ jobs:
   extractor-tests:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Actions Repository
       - uses: actions/checkout@v3
 
       - name: Setup Java
@@ -98,26 +129,3 @@ jobs:
       - name: Test Build
         run: ./gradlew build
         working-directory: extractor
-
-  valence-docs:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup Rust toolchain and cache
-        uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
-
-      - name: "Copy playground"
-        run: cp tools/playground/src/playground.template.rs tools/playground/src/playground.rs
-
-      - name: Install Dependencies (Linux)
-        run: sudo apt-get update && sudo apt-get install -y libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev libclang-dev libgtk-3-dev
-
-      - name: Validate documentation
-        run: cargo doc --workspace --no-deps --all-features --document-private-items
-
-  typos:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Check for spelling errors
-      uses: crate-ci/typos@v1.16.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions Repository
-      - uses: actions/checkout@v3
+        uses: actions/checkout@v3
 
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions Repository
-      - uses: actions/checkout@v3
+        uses: actions/checkout@v3
 
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions Repository
-      - uses: actions/checkout@v3
+        uses: actions/checkout@v3
 
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
@@ -93,7 +93,7 @@ jobs:
 
     steps:
       - name: Checkout Actions Repository
-      - uses: actions/checkout@v3
+        uses: actions/checkout@v3
 
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions Repository
-      - uses: actions/checkout@v3
+        uses: actions/checkout@v3
 
       - name: Setup Java
         uses: actions/setup-java@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,5 +121,3 @@ jobs:
     steps:
     - name: Check for spelling errors
       uses: crate-ci/typos@v1.16.5
-      with: 
-        files: ./

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,19 +12,7 @@ env:
 
 jobs:
   valence-fmt:
-    strategy:
-      fail-fast: true
-      matrix:
-        platform: [ubuntu-latest]
-        style: [default]
-        rust:
-          - nightly-2023-06-20
-        include:
-          - style: default
-            flags: ""
-
-    runs-on: ${{ matrix.platform }}
-
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
@@ -41,19 +29,7 @@ jobs:
         run: cargo fmt --all -- --check
 
   valence-clippy:
-    strategy:
-      fail-fast: true
-      matrix:
-        platform: [windows-latest, macos-latest, ubuntu-latest]
-        style: [default]
-        rust:
-          - stable
-        include:
-          - style: default
-            flags: ""
-
-    runs-on: ${{ matrix.platform }}
-
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
@@ -68,10 +44,9 @@ jobs:
 
       - name: Install Dependencies (Linux)
         run: sudo apt-get update && sudo apt-get install -y libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev libclang-dev libgtk-3-dev
-        if: matrix.platform == 'ubuntu-latest'
 
       - name: Clippy
-        run: cargo clippy --workspace ${{ matrix.flags }}--no-deps --all-features --all-targets -- -D warnings
+        run: cargo clippy --workspace --no-deps --all-features --all-targets -- -D warnings
 
   valence-tests:
     strategy:
@@ -101,22 +76,16 @@ jobs:
         if: matrix.platform == 'ubuntu-latest'
 
       - name: Run tests
-        run: cargo test --workspace ${{ matrix.flags }}--all-features --all-targets
+        run: cargo test --workspace ${{ matrix.flags }} --all-features --all-targets
 
       - name: Run doctests
-        run: cargo test --workspace ${{ matrix.flags }}--all-features --doc
+        run: cargo test --workspace ${{ matrix.flags }} --all-features --doc
 
       - name: Run valence_nbt tests without preserve_order feature
         run: cargo test -p valence_nbt --all-targets
 
   extractor-tests:
-    strategy:
-      fail-fast: true
-      matrix:
-        platform: [windows-latest, macos-latest, ubuntu-latest]
-
-    runs-on: ${{ matrix.platform }}
-
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
@@ -131,19 +100,7 @@ jobs:
         working-directory: extractor
 
   valence-docs:
-    strategy:
-      fail-fast: true
-      matrix:
-        platform: [windows-latest, macos-latest, ubuntu-latest]
-        style: [default]
-        rust:
-          - stable
-        include:
-          - style: default
-            flags: ""
-
-    runs-on: ${{ matrix.platform }}
-
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
@@ -155,7 +112,14 @@ jobs:
 
       - name: Install Dependencies (Linux)
         run: sudo apt-get update && sudo apt-get install -y libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev libclang-dev libgtk-3-dev
-        if: matrix.platform == 'ubuntu-latest'
 
       - name: Validate documentation
-        run: cargo doc --workspace ${{ matrix.flags }}--no-deps --all-features --document-private-items
+        run: cargo doc --workspace --no-deps --all-features --document-private-items
+
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check for spelling errors
+      uses: crate-ci/typos@v1.16.5
+      with: 
+        files: ./

--- a/crates/valence_nbt/src/binary/decode.rs
+++ b/crates/valence_nbt/src/binary/decode.rs
@@ -40,30 +40,30 @@ impl Compound {
                 Value::Long(_) => 8,
                 Value::Float(_) => 4,
                 Value::Double(_) => 8,
-                Value::ByteArray(ba) => 4 + ba.len(),
-                Value::String(s) => string_size(s),
-                Value::List(l) => list_size(l),
-                Value::Compound(c) => compound_size(c),
-                Value::IntArray(ia) => 4 + ia.len() * 4,
-                Value::LongArray(la) => 4 + la.len() * 8,
+                Value::ByteArray(v) => 4 + v.len(),
+                Value::String(v) => string_size(v),
+                Value::List(v) => list_size(v),
+                Value::Compound(v) => compound_size(v),
+                Value::IntArray(v) => 4 + v.len() * 4,
+                Value::LongArray(v) => 4 + v.len() * 8,
             }
         }
 
         fn list_size(l: &List) -> usize {
             let elems_size = match l {
                 List::End => 0,
-                List::Byte(b) => b.len(),
-                List::Short(s) => s.len() * 2,
-                List::Int(i) => i.len() * 4,
-                List::Long(l) => l.len() * 8,
-                List::Float(f) => f.len() * 4,
-                List::Double(d) => d.len() * 8,
-                List::ByteArray(ba) => ba.iter().map(|b| 4 + b.len()).sum(),
-                List::String(s) => s.iter().map(|s| string_size(s)).sum(),
-                List::List(l) => l.iter().map(list_size).sum(),
-                List::Compound(c) => c.iter().map(compound_size).sum(),
-                List::IntArray(i) => i.iter().map(|i| 4 + i.len() * 4).sum(),
-                List::LongArray(l) => l.iter().map(|l| 4 + l.len() * 8).sum(),
+                List::Byte(v) => v.len(),
+                List::Short(v) => v.len() * 2,
+                List::Int(v) => v.len() * 4,
+                List::Long(v) => v.len() * 8,
+                List::Float(v) => v.len() * 4,
+                List::Double(v) => v.len() * 8,
+                List::ByteArray(v) => v.iter().map(|b| 4 + b.len()).sum(),
+                List::String(v) => v.iter().map(|s| string_size(s)).sum(),
+                List::List(v) => v.iter().map(list_size).sum(),
+                List::Compound(v) => v.iter().map(compound_size).sum(),
+                List::IntArray(v) => v.iter().map(|i| 4 + i.len() * 4).sum(),
+                List::LongArray(v) => v.iter().map(|l| 4 + l.len() * 8).sum(),
             };
 
             1 + 4 + elems_size
@@ -95,18 +95,18 @@ impl<W: Write> EncodeState<W> {
 
     fn write_value(&mut self, v: &Value) -> Result<()> {
         match v {
-            Value::Byte(b) => self.write_byte(*b),
-            Value::Short(s) => self.write_short(*s),
-            Value::Int(i) => self.write_int(*i),
-            Value::Long(l) => self.write_long(*l),
-            Value::Float(f) => self.write_float(*f),
-            Value::Double(d) => self.write_double(*d),
-            Value::ByteArray(ba) => self.write_byte_array(ba),
-            Value::String(s) => self.write_string(s),
-            Value::List(l) => self.write_any_list(l),
-            Value::Compound(c) => self.write_compound(c),
-            Value::IntArray(ia) => self.write_int_array(ia),
-            Value::LongArray(la) => self.write_long_array(la),
+            Value::Byte(v) => self.write_byte(*v),
+            Value::Short(v) => self.write_short(*v),
+            Value::Int(v) => self.write_int(*v),
+            Value::Long(v) => self.write_long(*v),
+            Value::Float(v) => self.write_float(*v),
+            Value::Double(v) => self.write_double(*v),
+            Value::ByteArray(v) => self.write_byte_array(v),
+            Value::String(v) => self.write_string(v),
+            Value::List(v) => self.write_any_list(v),
+            Value::Compound(v) => self.write_compound(v),
+            Value::IntArray(v) => self.write_int_array(v),
+            Value::LongArray(v) => self.write_long_array(v),
         }
     }
 
@@ -180,37 +180,35 @@ impl<W: Write> EncodeState<W> {
                 self.writer.write_i32::<BigEndian>(0)?;
                 Ok(())
             }
-            List::Byte(bl) => {
+            List::Byte(v) => {
                 self.write_tag(Tag::Byte)?;
 
-                match bl.len().try_into() {
+                match v.len().try_into() {
                     Ok(len) => self.write_int(len)?,
                     Err(_) => {
                         return Err(Error::new_owned(format!(
                             "byte list of length {} exceeds maximum of i32::MAX",
-                            bl.len(),
+                            v.len(),
                         )))
                     }
                 }
 
-                Ok(self.writer.write_all(i8_slice_as_u8_slice(bl))?)
+                Ok(self.writer.write_all(i8_slice_as_u8_slice(v))?)
             }
-            List::Short(sl) => self.write_list(sl, Tag::Short, |st, s| st.write_short(*s)),
-            List::Int(il) => self.write_list(il, Tag::Int, |st, i| st.write_int(*i)),
-            List::Long(ll) => self.write_list(ll, Tag::Long, |st, l| st.write_long(*l)),
-            List::Float(fl) => self.write_list(fl, Tag::Float, |st, f| st.write_float(*f)),
-            List::Double(dl) => self.write_list(dl, Tag::Double, |st, d| st.write_double(*d)),
-            List::ByteArray(bal) => {
-                self.write_list(bal, Tag::ByteArray, |st, ba| st.write_byte_array(ba))
+            List::Short(sl) => self.write_list(sl, Tag::Short, |st, v| st.write_short(*v)),
+            List::Int(il) => self.write_list(il, Tag::Int, |st, v| st.write_int(*v)),
+            List::Long(ll) => self.write_list(ll, Tag::Long, |st, v| st.write_long(*v)),
+            List::Float(fl) => self.write_list(fl, Tag::Float, |st, v| st.write_float(*v)),
+            List::Double(dl) => self.write_list(dl, Tag::Double, |st, v| st.write_double(*v)),
+            List::ByteArray(v) => {
+                self.write_list(v, Tag::ByteArray, |st, v| st.write_byte_array(v))
             }
-            List::String(sl) => self.write_list(sl, Tag::String, |st, s| st.write_string(s)),
-            List::List(ll) => self.write_list(ll, Tag::List, |st, l| st.write_any_list(l)),
-            List::Compound(cl) => self.write_list(cl, Tag::Compound, |st, c| st.write_compound(c)),
-            List::IntArray(ial) => {
-                self.write_list(ial, Tag::IntArray, |st, ia| st.write_int_array(ia))
-            }
-            List::LongArray(lal) => {
-                self.write_list(lal, Tag::LongArray, |st, la| st.write_long_array(la))
+            List::String(v) => self.write_list(v, Tag::String, |st, v| st.write_string(v)),
+            List::List(v) => self.write_list(v, Tag::List, |st, v| st.write_any_list(v)),
+            List::Compound(v) => self.write_list(v, Tag::Compound, |st, v| st.write_compound(v)),
+            List::IntArray(v) => self.write_list(v, Tag::IntArray, |st, v| st.write_int_array(v)),
+            List::LongArray(v) => {
+                self.write_list(v, Tag::LongArray, |st, v| st.write_long_array(v))
             }
         }
     }

--- a/crates/valence_network/src/packet_io.rs
+++ b/crates/valence_network/src/packet_io.rs
@@ -232,7 +232,7 @@ impl ClientConnection for RealClientConnection {
             Ok(packet) => {
                 let cost = mem::size_of::<ReceivedPacket>() + packet.body.len();
 
-                // Add the permits back that we removed eariler.
+                // Add the permits back that we removed earlier.
                 self.recv_sem.add_permits(cost);
 
                 Ok(Some(packet))

--- a/crates/valence_protocol/src/packets/play/entity_damage_s2c.rs
+++ b/crates/valence_protocol/src/packets/play/entity_damage_s2c.rs
@@ -14,7 +14,7 @@ pub struct EntityDamageS2c {
     /// not present, the value is 0. If this field is present:
     /// * and damage was dealt indirectly, such as by the use of a projectile,
     ///   this field will contain the ID of such projectile;
-    /// * and damage was dealt dirctly, such as by manually attacking, this
+    /// * and damage was dealt directly, such as by manually attacking, this
     ///   field will contain the same value as Source Cause ID.
     pub source_direct_id: VarInt,
     /// The Notchian server sends the Source Position when the damage was dealt

--- a/crates/valence_server/src/layer/chunk.rs
+++ b/crates/valence_server/src/layer/chunk.rs
@@ -181,7 +181,7 @@ impl ChunkLayer {
         self.chunks.get_mut(&pos.into())
     }
 
-    /// Insert a chunk into the instance at the given position. The preivous
+    /// Insert a chunk into the instance at the given position. The previous
     /// chunk data is returned.
     pub fn insert_chunk(
         &mut self,

--- a/crates/valence_server/src/spawn.rs
+++ b/crates/valence_server/src/spawn.rs
@@ -106,7 +106,7 @@ pub(super) fn initial_join(
         });
 
         // The login packet is prepended so that it's sent before all the other packets.
-        // Some packets don't work corectly when sent before the game join packet.
+        // Some packets don't work correctly when sent before the game join packet.
         _ = client.enc.prepend_packet(&GameJoinS2c {
             entity_id: 0, // We reserve ID 0 for clients.
             is_hardcore: spawn.is_hardcore.0,

--- a/extractor/README.md
+++ b/extractor/README.md
@@ -14,7 +14,7 @@ From this directory, run the following
 
 This will run the extractor and immediately exit, outputting the files that are listed in the logs.
 
-Next, run `copy_extractor_output.sh`. This copies the files to `extracted` so that they can be comitted.
+Next, run `copy_extractor_output.sh`. This copies the files to `extracted` so that they can be committed.
 
 ```sh
 ./copy_extractor_output.sh

--- a/src/tests/boss_bar.rs
+++ b/src/tests/boss_bar.rs
@@ -12,7 +12,7 @@ use crate::testing::ScenarioSingleClient;
 use crate::Text;
 
 #[test]
-fn test_intialize_on_join() {
+fn test_initialize_on_join() {
     let mut scenario = ScenarioSingleClient::new();
 
     // Insert a boss bar into the world

--- a/src/tests/example.rs
+++ b/src/tests/example.rs
@@ -1,6 +1,6 @@
 //! Examples of valence unit tests that need to test the behavior of the server,
 //! and not just the logic of a single function. This module is meant to be a
-//! pallette of examples for how to write such tests, with various levels of
+//! palette of examples for how to write such tests, with various levels of
 //! complexity.
 //!
 //! Some of the tests in this file may be inferior duplicates of real tests.

--- a/src/tests/world_border.rs
+++ b/src/tests/world_border.rs
@@ -10,7 +10,7 @@ use crate::world_border::{
 };
 
 #[test]
-fn test_intialize_on_join() {
+fn test_initialize_on_join() {
     let ScenarioSingleClient {
         mut app,
         client: _,

--- a/tools/packet_inspector/src/app.rs
+++ b/tools/packet_inspector/src/app.rs
@@ -78,7 +78,7 @@ impl GuiApp {
             ],
         );
 
-        // Persistant Storage
+        // Persistent Storage
         let mut shared_state = SharedState::new(ctx);
 
         if let Some(storage) = cc.storage {
@@ -132,7 +132,7 @@ impl eframe::App for GuiApp {
     }
 }
 
-// This function is getting waaaay too complcated and messy
+// This function is getting waaaay too complicated and messy
 fn handle_events(state: Arc<RwLock<SharedState>>) {
     tokio::spawn(async move {
         let mut proxy_thread: Option<JoinHandle<_>> = None;

--- a/tools/packet_inspector/src/lib.rs
+++ b/tools/packet_inspector/src/lib.rs
@@ -81,9 +81,9 @@ impl Proxy {
         let registry = PACKET_REGISTRY.get().unwrap().clone();
         let c2s = tokio::spawn(async move {
             loop {
-                let threashold = *threshold.read().await;
-                client_reader.set_compression(threashold);
-                server_writer.set_compression(threashold);
+                let threshold = *threshold.read().await;
+                client_reader.set_compression(threshold);
+                server_writer.set_compression(threshold);
                 // client to server handling
                 let packet = client_reader.recv_packet_raw().await?;
 
@@ -97,7 +97,7 @@ impl Proxy {
                     .process(
                         crate::packet_registry::PacketSide::Serverbound,
                         state,
-                        threashold,
+                        threshold,
                         &packet,
                     )
                     .await?;
@@ -123,9 +123,9 @@ impl Proxy {
         let registry = PACKET_REGISTRY.get().unwrap().clone();
         let s2c = tokio::spawn(async move {
             loop {
-                let threashold_value = *threshold.read().await;
-                server_reader.set_compression(threashold_value);
-                client_writer.set_compression(threashold_value);
+                let threshold_value = *threshold.read().await;
+                server_reader.set_compression(threshold_value);
+                client_writer.set_compression(threshold_value);
                 // server to client handling
                 let packet = server_reader.recv_packet_raw().await?;
 
@@ -152,7 +152,7 @@ impl Proxy {
                     .process(
                         crate::packet_registry::PacketSide::Clientbound,
                         state,
-                        threashold_value,
+                        threshold_value,
                         &packet,
                     )
                     .await?;

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,5 @@
+[files]
+extend-exclude = ["/assets/*.svg", "/extracted/*"]
+
+[default]
+extend-ignore-re = ['\d+ths', 'CC BY-NC-ND']


### PR DESCRIPTION
# Objective

- Fix #431
- Make the CI simpler.

# Solution

- Add `typos` spell checker job.
- Don't run jobs in a matrix if they don't have to.
- Update versions where possible.
- Reorder jobs.
