### PR TITLE
Add ahash feature to valence_nbt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ license = "MIT"
 
 [workspace.dependencies]
 aes = "0.8.2"
+ahash = "0.8.3"
 anyhow = { version = "1.0.70", features = ["backtrace"] }
 approx = "0.5.1"
 arrayvec = "0.7.2"

--- a/crates/valence_nbt/Cargo.toml
+++ b/crates/valence_nbt/Cargo.toml
@@ -10,6 +10,7 @@ edition.workspace = true
 repository.workspace = true
 
 [features]
+ahash = ["dep:ahash"]
 binary = ["dep:byteorder", "dep:cesu8"]
 snbt = []
 # When enabled, the order of fields in compounds are preserved.
@@ -17,6 +18,7 @@ preserve_order = ["dep:indexmap"]
 serde = ["dep:serde", "dep:thiserror", "indexmap?/serde"]
 
 [dependencies]
+ahash = { workspace = true, optional = true }
 byteorder = { workspace = true, optional = true }
 cesu8 = { workspace = true, optional = true }
 indexmap = { workspace = true, optional = true }

--- a/crates/valence_nbt/src/compound.rs
+++ b/crates/valence_nbt/src/compound.rs
@@ -20,8 +20,11 @@ pub struct Compound {
 #[cfg(not(feature = "preserve_order"))]
 type Map = std::collections::BTreeMap<String, Value>;
 
-#[cfg(feature = "preserve_order")]
+#[cfg(all(feature = "preserve_order", not(feature = "ahash")))]
 type Map = indexmap::IndexMap<String, Value>;
+
+#[cfg(all(feature = "preserve_order", feature = "ahash"))]
+type Map = indexmap::IndexMap<String, Value, ahash::RandomState>;
 
 impl fmt::Debug for Compound {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/valence_nbt/src/compound.rs
+++ b/crates/valence_nbt/src/compound.rs
@@ -34,7 +34,9 @@ impl fmt::Debug for Compound {
 
 impl Compound {
     pub fn new() -> Self {
-        Self { map: Map::default() }
+        Self {
+            map: Map::default()
+        }
     }
 
     pub fn with_capacity(cap: usize) -> Self {

--- a/crates/valence_nbt/src/compound.rs
+++ b/crates/valence_nbt/src/compound.rs
@@ -34,7 +34,7 @@ impl fmt::Debug for Compound {
 
 impl Compound {
     pub fn new() -> Self {
-        Self { map: Map::new() }
+        Self { map: Map::default() }
     }
 
     pub fn with_capacity(cap: usize) -> Self {
@@ -46,7 +46,7 @@ impl Compound {
                 Map::new()
             },
             #[cfg(feature = "preserve_order")]
-            map: Map::with_capacity(cap),
+            map: Map::with_capacity_and_hasher(cap, Default::default()),
         }
     }
 

--- a/crates/valence_nbt/src/compound.rs
+++ b/crates/valence_nbt/src/compound.rs
@@ -35,7 +35,7 @@ impl fmt::Debug for Compound {
 impl Compound {
     pub fn new() -> Self {
         Self {
-            map: Map::default()
+            map: Map::default(),
         }
     }
 


### PR DESCRIPTION
# Objective

- Add the option to use the `ahash` hasher in `valence_nbt`. This hasher is faster than the std hasher, at the cost of being less resistant to hash DOS attacks.

# Solution

- Added an `ahash` feature to the `valence_nbt` crate to allow the user to optionally select this.
