### PR TITLE
Add Deref and DerefMut to all components (where appropriate)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,7 @@ cesu8 = "1.1.0"
 cfb8 = "0.8.1"
 clap = { version = "4.0.30", features = ["derive"] }
 criterion = "0.5.1"
+derive_more = "0.99.17"
 directories = "5.0.0"
 eframe = { version = "0.22.0", default-features = false }
 egui = "0.22.0"

--- a/crates/valence_advancement/Cargo.toml
+++ b/crates/valence_advancement/Cargo.toml
@@ -13,4 +13,5 @@ valence_server.workspace = true
 bevy_app.workspace = true
 bevy_ecs.workspace = true
 bevy_hierarchy.workspace = true
+derive_more.workspace = true
 rustc-hash.workspace = true

--- a/crates/valence_advancement/src/lib.rs
+++ b/crates/valence_advancement/src/lib.rs
@@ -5,7 +5,6 @@ pub mod event;
 
 use std::borrow::Cow;
 use std::io::Write;
-use derive_more::{Deref, DerefMut};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use bevy_app::prelude::*;
@@ -13,6 +12,7 @@ use bevy_ecs::prelude::*;
 use bevy_ecs::system::SystemParam;
 pub use bevy_hierarchy;
 use bevy_hierarchy::{Children, HierarchyPlugin, Parent};
+use derive_more::{Deref, DerefMut};
 use event::{handle_advancement_tab_change, AdvancementTabChangeEvent};
 use rustc_hash::FxHashMap;
 use valence_server::client::{Client, FlushPacketsSet, SpawnClientsSet};

--- a/crates/valence_advancement/src/lib.rs
+++ b/crates/valence_advancement/src/lib.rs
@@ -5,6 +5,7 @@ pub mod event;
 
 use std::borrow::Cow;
 use std::io::Write;
+use derive_more::{Deref, DerefMut};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use bevy_app::prelude::*;
@@ -321,7 +322,7 @@ fn send_advancement_update_packet(
 }
 
 /// Advancement's id. May not be updated.
-#[derive(Component)]
+#[derive(Component, Deref)]
 pub struct Advancement(Ident<Cow<'static, str>>);
 
 impl Advancement {
@@ -366,7 +367,7 @@ impl AdvancementDisplay {
 }
 
 /// Criteria's identifier. May not be updated
-#[derive(Component)]
+#[derive(Component, Deref)]
 pub struct AdvancementCriteria(Ident<Cow<'static, str>>);
 
 impl AdvancementCriteria {
@@ -382,7 +383,7 @@ impl AdvancementCriteria {
 /// Requirements for advancement to be completed.
 /// All columns should be completed, column is completed when any of criteria in
 /// this column is completed.
-#[derive(Component, Default)]
+#[derive(Component, Default, Deref, DerefMut)]
 pub struct AdvancementRequirements(pub Vec<Vec<Entity>>);
 
 #[derive(Component, Default)]

--- a/crates/valence_boss_bar/Cargo.toml
+++ b/crates/valence_boss_bar/Cargo.toml
@@ -15,3 +15,4 @@ valence_server.workspace = true
 bitfield-struct.workspace = true
 bevy_app.workspace = true
 bevy_ecs.workspace = true
+derive_more.workspace = true

--- a/crates/valence_boss_bar/src/components.rs
+++ b/crates/valence_boss_bar/src/components.rs
@@ -6,6 +6,7 @@ use valence_server::protocol::packets::play::boss_bar_s2c::{
     BossBarAction, BossBarColor, BossBarDivision, BossBarFlags, ToPacketAction,
 };
 use valence_server::{Text, UniqueId};
+use derive_more::{Deref, DerefMut};
 
 /// The bundle of components that make up a boss bar.
 #[derive(Bundle, Default)]
@@ -19,7 +20,7 @@ pub struct BossBarBundle {
 }
 
 /// The title of a boss bar.
-#[derive(Component, Clone, Default)]
+#[derive(Component, Clone, Default, Deref, DerefMut)]
 pub struct BossBarTitle(pub Text);
 
 impl ToPacketAction for BossBarTitle {
@@ -29,7 +30,7 @@ impl ToPacketAction for BossBarTitle {
 }
 
 /// The health of a boss bar.
-#[derive(Component, Default)]
+#[derive(Component, Default, Deref, DerefMut)]
 pub struct BossBarHealth(pub f32);
 
 impl ToPacketAction for BossBarHealth {

--- a/crates/valence_boss_bar/src/components.rs
+++ b/crates/valence_boss_bar/src/components.rs
@@ -1,12 +1,12 @@
 use std::borrow::Cow;
 
 use bevy_ecs::prelude::{Bundle, Component};
+use derive_more::{Deref, DerefMut};
 use valence_entity::EntityLayerId;
 use valence_server::protocol::packets::play::boss_bar_s2c::{
     BossBarAction, BossBarColor, BossBarDivision, BossBarFlags, ToPacketAction,
 };
 use valence_server::{Text, UniqueId};
-use derive_more::{Deref, DerefMut};
 
 /// The bundle of components that make up a boss bar.
 #[derive(Bundle, Default)]

--- a/crates/valence_entity/Cargo.toml
+++ b/crates/valence_entity/Cargo.toml
@@ -13,6 +13,7 @@ anyhow.workspace = true
 bevy_app.workspace = true
 bevy_ecs.workspace = true
 bitfield-struct.workspace = true
+derive_more.workspace = true
 valence_math.workspace = true
 paste.workspace = true
 rustc-hash.workspace = true

--- a/crates/valence_entity/src/hitbox.rs
+++ b/crates/valence_entity/src/hitbox.rs
@@ -4,6 +4,7 @@ use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use valence_math::{Aabb, DVec3, UVec3, Vec3Swizzles};
 use valence_protocol::Direction;
+use derive_more::Deref;
 
 use crate::*;
 
@@ -69,13 +70,13 @@ impl Plugin for HitboxPlugin {
 
 /// Size of hitbox. The only way to manipulate it without losing it on the next
 /// tick is using a marker entity. Marker entity's hitbox is never updated.
-#[derive(Component, Debug, PartialEq)]
+#[derive(Component, Debug, PartialEq, Deref)]
 pub struct HitboxShape(pub Aabb);
 
 /// Hitbox, aabb of which is calculated each tick using its position and
 /// [`Hitbox`]. In order to change size of this hitbox you need to change
 /// [`Hitbox`].
-#[derive(Component, Debug)]
+#[derive(Component, Debug, Deref)]
 pub struct Hitbox(Aabb);
 
 impl HitboxShape {

--- a/crates/valence_entity/src/hitbox.rs
+++ b/crates/valence_entity/src/hitbox.rs
@@ -2,9 +2,9 @@
 
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
+use derive_more::Deref;
 use valence_math::{Aabb, DVec3, UVec3, Vec3Swizzles};
 use valence_protocol::Direction;
-use derive_more::Deref;
 
 use crate::*;
 

--- a/crates/valence_entity/src/lib.rs
+++ b/crates/valence_entity/src/lib.rs
@@ -27,6 +27,7 @@ pub mod tracked_data;
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 pub use manager::EntityManager;
+use derive_more::{Deref, DerefMut};
 use paste::paste;
 use tracing::warn;
 use tracked_data::TrackedData;
@@ -163,7 +164,7 @@ fn clear_tracked_data_changes(mut tracked_data: Query<&mut TrackedData, Changed<
 }
 
 /// Contains the entity layer an entity is on.
-#[derive(Component, Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Component, Copy, Clone, PartialEq, Eq, Debug, Deref)]
 pub struct EntityLayerId(pub Entity);
 
 impl Default for EntityLayerId {
@@ -179,7 +180,7 @@ impl PartialEq<OldEntityLayerId> for EntityLayerId {
 }
 
 /// The value of [`EntityLayerId`] from the end of the previous tick.
-#[derive(Component, Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Component, Copy, Clone, PartialEq, Eq, Debug, Deref)]
 pub struct OldEntityLayerId(Entity);
 
 impl OldEntityLayerId {
@@ -200,7 +201,7 @@ impl PartialEq<EntityLayerId> for OldEntityLayerId {
     }
 }
 
-#[derive(Component, Copy, Clone, PartialEq, Default, Debug)]
+#[derive(Component, Copy, Clone, PartialEq, Default, Debug, Deref, DerefMut)]
 pub struct Position(pub DVec3);
 
 impl Position {
@@ -234,7 +235,7 @@ impl PartialEq<OldPosition> for Position {
 /// The value of [`Position`] from the end of the previous tick.
 ///
 /// **NOTE**: You should not modify this component after the entity is spawned.
-#[derive(Component, Clone, PartialEq, Default, Debug)]
+#[derive(Component, Clone, PartialEq, Default, Debug, Deref)]
 pub struct OldPosition(DVec3);
 
 impl OldPosition {
@@ -308,7 +309,7 @@ impl Look {
     }
 }
 
-#[derive(Component, Copy, Clone, PartialEq, Eq, Default, Debug)]
+#[derive(Component, Copy, Clone, PartialEq, Eq, Default, Debug, Deref, DerefMut)]
 pub struct OnGround(pub bool);
 
 /// A Minecraft entity's ID according to the protocol.
@@ -318,7 +319,7 @@ pub struct OnGround(pub bool);
 /// something else on the tick the entity is added. If you need to know the ID
 /// ahead of time, set this component to the value returned by
 /// [`EntityManager::next_id`] before spawning.
-#[derive(Component, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Component, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deref)]
 pub struct EntityId(i32);
 
 impl EntityId {
@@ -335,11 +336,11 @@ impl Default for EntityId {
     }
 }
 
-#[derive(Component, Copy, Clone, PartialEq, Default, Debug)]
+#[derive(Component, Copy, Clone, PartialEq, Default, Debug, Deref, DerefMut)]
 pub struct HeadYaw(pub f32);
 
 /// Entity velocity in m/s.
-#[derive(Component, Copy, Clone, Default, Debug)]
+#[derive(Component, Copy, Clone, Default, Debug, Deref, DerefMut)]
 pub struct Velocity(pub Vec3);
 
 impl Velocity {
@@ -353,7 +354,7 @@ impl Velocity {
 
 // TODO: don't make statuses and animations components.
 
-#[derive(Component, Copy, Clone, Default, Debug)]
+#[derive(Component, Copy, Clone, Default, Debug, Deref, DerefMut)]
 pub struct EntityStatuses(pub u64);
 
 impl EntityStatuses {
@@ -370,7 +371,7 @@ impl EntityStatuses {
     }
 }
 
-#[derive(Component, Default, Debug, Copy, Clone)]
+#[derive(Component, Default, Debug, Copy, Clone, Deref, DerefMut)]
 pub struct EntityAnimations(pub u8);
 
 impl EntityAnimations {
@@ -397,7 +398,7 @@ impl EntityAnimations {
 /// - **Falling Block**: Block state
 /// - **Fishing Bobber**: Hook entity ID
 /// - **Warden**: Initial pose
-#[derive(Component, Default, Debug)]
+#[derive(Component, Default, Debug, Deref, DerefMut)]
 pub struct ObjectData(pub i32);
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Encode, Decode)]

--- a/crates/valence_entity/src/lib.rs
+++ b/crates/valence_entity/src/lib.rs
@@ -26,8 +26,8 @@ pub mod tracked_data;
 
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
-pub use manager::EntityManager;
 use derive_more::{Deref, DerefMut};
+pub use manager::EntityManager;
 use paste::paste;
 use tracing::warn;
 use tracked_data::TrackedData;

--- a/crates/valence_inventory/Cargo.toml
+++ b/crates/valence_inventory/Cargo.toml
@@ -11,5 +11,6 @@ license.workspace = true
 [dependencies]
 bevy_app.workspace = true
 bevy_ecs.workspace = true
+derive_more.workspace = true
 tracing.workspace = true
 valence_server.workspace = true

--- a/crates/valence_inventory/src/lib.rs
+++ b/crates/valence_inventory/src/lib.rs
@@ -25,6 +25,7 @@ use std::ops::Range;
 
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
+use derive_more::{Deref, DerefMut};
 use tracing::{debug, warn};
 use valence_server::client::{Client, FlushPacketsSet, SpawnClientsSet};
 use valence_server::event_loop::{EventLoopPreUpdate, PacketEvent};
@@ -401,7 +402,7 @@ impl ClientInventoryState {
 }
 
 /// Indicates which hotbar slot the player is currently holding.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Component)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Component, Deref)]
 pub struct HeldItem {
     held_item_slot: u16,
 }
@@ -416,7 +417,7 @@ impl HeldItem {
 
 /// The item stack that the client thinks it's holding under the mouse
 /// cursor.
-#[derive(Component, Clone, PartialEq, Default, Debug)]
+#[derive(Component, Clone, PartialEq, Default, Debug, Deref, DerefMut)]
 pub struct CursorItem(pub Option<ItemStack>);
 
 /// Used to indicate that the client with this component is currently viewing

--- a/crates/valence_player_list/Cargo.toml
+++ b/crates/valence_player_list/Cargo.toml
@@ -12,4 +12,5 @@ license.workspace = true
 bevy_app.workspace = true
 bevy_ecs.workspace = true
 bitfield-struct.workspace = true
+derive_more.workspace = true
 valence_server.workspace = true

--- a/crates/valence_player_list/src/lib.rs
+++ b/crates/valence_player_list/src/lib.rs
@@ -22,6 +22,7 @@ use std::borrow::Cow;
 
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
+use derive_more::{Deref, DerefMut};
 use valence_server::client::{Client, Properties, Username};
 use valence_server::keepalive::Ping;
 use valence_server::layer::UpdateLayersPreClientSet;
@@ -140,11 +141,11 @@ pub struct PlayerListEntryBundle {
 pub struct PlayerListEntry;
 
 /// Displayed name for a player list entry. Appears as [`Username`] if `None`.
-#[derive(Component, Default, Debug)]
+#[derive(Component, Default, Debug, Deref, DerefMut)]
 pub struct DisplayName(pub Option<Text>);
 
 /// If a player list entry is visible. Defaults to `true`.
-#[derive(Component, Copy, Clone, Debug)]
+#[derive(Component, Copy, Clone, Debug, Deref, DerefMut)]
 pub struct Listed(pub bool);
 
 impl Default for Listed {

--- a/crates/valence_scoreboard/Cargo.toml
+++ b/crates/valence_scoreboard/Cargo.toml
@@ -11,5 +11,6 @@ license.workspace = true
 [dependencies]
 bevy_app.workspace = true
 bevy_ecs.workspace = true
+derive_more.workspace = true
 valence_server.workspace = true
 tracing.workspace = true

--- a/crates/valence_scoreboard/src/components.rs
+++ b/crates/valence_scoreboard/src/components.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use bevy_ecs::prelude::*;
+use derive_more::{Deref, DerefMut};
 use valence_server::entity::EntityLayerId;
 use valence_server::protocol::packets::play::scoreboard_display_s2c::ScoreboardPosition;
 use valence_server::protocol::packets::play::scoreboard_objective_update_s2c::ObjectiveRenderType;
@@ -12,7 +13,7 @@ use valence_server::Text;
 /// Limited to 16 characters.
 ///
 /// Directly analogous to an Objective's Name.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Component)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Component, Deref)]
 pub struct Objective(pub(crate) String);
 
 impl Objective {
@@ -34,7 +35,7 @@ impl Objective {
 
 /// Optional display name for an objective. If not present, the objective's name
 /// is used.
-#[derive(Debug, Clone, PartialEq, Component)]
+#[derive(Debug, Clone, PartialEq, Component, Deref, DerefMut)]
 pub struct ObjectiveDisplay(pub Text);
 
 /// A mapping of keys to their scores.

--- a/crates/valence_server/Cargo.toml
+++ b/crates/valence_server/Cargo.toml
@@ -15,6 +15,7 @@ bevy_ecs.workspace = true
 bevy_utils.workspace = true          # Needed for `ScheduleLabel` derive macro.
 bitfield-struct.workspace = true
 bytes.workspace = true
+derive_more.workspace = true
 valence_math.workspace = true
 rand.workspace = true
 tracing.workspace = true

--- a/crates/valence_server/src/abilities.rs
+++ b/crates/valence_server/src/abilities.rs
@@ -3,6 +3,7 @@ use bevy_ecs::prelude::*;
 pub use valence_protocol::packets::play::player_abilities_s2c::PlayerAbilitiesFlags;
 use valence_protocol::packets::play::{PlayerAbilitiesS2c, UpdatePlayerAbilitiesC2s};
 use valence_protocol::{GameMode, WritePacket};
+use derive_more::{Deref, DerefMut};
 
 use crate::client::{update_game_mode, Client, UpdateClientsSet};
 use crate::event_loop::{EventLoopPreUpdate, PacketEvent};
@@ -10,7 +11,7 @@ use crate::event_loop::{EventLoopPreUpdate, PacketEvent};
 /// [`Component`] that stores the player's flying speed ability.
 ///
 /// [`Default`] value: `0.05`.
-#[derive(Component)]
+#[derive(Component, Deref, DerefMut)]
 pub struct FlyingSpeed(pub f32);
 
 impl Default for FlyingSpeed {
@@ -23,7 +24,7 @@ impl Default for FlyingSpeed {
 /// The lower the value, the higher the field of view.
 ///
 /// [`Default`] value: `0.1`.
-#[derive(Component)]
+#[derive(Component, Deref, DerefMut)]
 pub struct FovModifier(pub f32);
 
 impl Default for FovModifier {

--- a/crates/valence_server/src/abilities.rs
+++ b/crates/valence_server/src/abilities.rs
@@ -1,9 +1,9 @@
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
+use derive_more::{Deref, DerefMut};
 pub use valence_protocol::packets::play::player_abilities_s2c::PlayerAbilitiesFlags;
 use valence_protocol::packets::play::{PlayerAbilitiesS2c, UpdatePlayerAbilitiesC2s};
 use valence_protocol::{GameMode, WritePacket};
-use derive_more::{Deref, DerefMut};
 
 use crate::client::{update_game_mode, Client, UpdateClientsSet};
 use crate::event_loop::{EventLoopPreUpdate, PacketEvent};

--- a/crates/valence_server/src/action.rs
+++ b/crates/valence_server/src/action.rs
@@ -3,6 +3,7 @@ use bevy_ecs::prelude::*;
 use valence_protocol::packets::play::player_action_c2s::PlayerAction;
 use valence_protocol::packets::play::{PlayerActionC2s, PlayerActionResponseS2c};
 use valence_protocol::{BlockPos, Direction, VarInt, WritePacket};
+use derive_more::Deref;
 
 use crate::client::{Client, UpdateClientsSet};
 use crate::event_loop::{EventLoopPreUpdate, PacketEvent};
@@ -35,7 +36,7 @@ pub enum DiggingState {
     Stop,
 }
 
-#[derive(Component, Copy, Clone, PartialEq, Eq, Default, Debug)]
+#[derive(Component, Copy, Clone, PartialEq, Eq, Default, Debug, Deref)]
 pub struct ActionSequence(i32);
 
 impl ActionSequence {

--- a/crates/valence_server/src/action.rs
+++ b/crates/valence_server/src/action.rs
@@ -1,9 +1,9 @@
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
+use derive_more::Deref;
 use valence_protocol::packets::play::player_action_c2s::PlayerAction;
 use valence_protocol::packets::play::{PlayerActionC2s, PlayerActionResponseS2c};
 use valence_protocol::{BlockPos, Direction, VarInt, WritePacket};
-use derive_more::Deref;
 
 use crate::client::{Client, UpdateClientsSet};
 use crate::event_loop::{EventLoopPreUpdate, PacketEvent};

--- a/crates/valence_server/src/client.rs
+++ b/crates/valence_server/src/client.rs
@@ -11,6 +11,7 @@ use bevy_ecs::query::WorldQuery;
 use bevy_ecs::system::Command;
 use byteorder::{NativeEndian, ReadBytesExt};
 use bytes::{Bytes, BytesMut};
+use derive_more::{Deref, DerefMut};
 use tracing::warn;
 use uuid::Uuid;
 use valence_entity::player::PlayerEntityBundle;
@@ -416,7 +417,7 @@ impl EntityRemoveBuf {
     }
 }
 
-#[derive(Component, Clone, PartialEq, Eq, Default, Debug)]
+#[derive(Component, Clone, PartialEq, Eq, Default, Debug, Deref)]
 pub struct Username(pub String);
 
 impl fmt::Display for Username {
@@ -454,10 +455,10 @@ impl Deref for Properties {
     }
 }
 
-#[derive(Component, Clone, PartialEq, Eq, Debug)]
+#[derive(Component, Clone, PartialEq, Eq, Debug, Deref)]
 pub struct Ip(pub IpAddr);
 
-#[derive(Component, Clone, PartialEq, Eq, Debug)]
+#[derive(Component, Clone, PartialEq, Eq, Debug, Deref)]
 pub struct ViewDistance(u8);
 
 impl ViewDistance {
@@ -485,7 +486,7 @@ impl Default for ViewDistance {
 
 /// The [`ViewDistance`] at the end of the previous tick. Automatically updated
 /// as [`ViewDistance`] is changed.
-#[derive(Component, Clone, PartialEq, Eq, Default, Debug)]
+#[derive(Component, Clone, PartialEq, Eq, Default, Debug, Deref)]
 
 pub struct OldViewDistance(u8);
 
@@ -524,7 +525,7 @@ impl OldViewItem<'_> {
 ///
 /// A client can only see one chunk layer at a time. Mutating this component
 /// will cause the client to respawn in the new chunk layer.
-#[derive(Component, Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Component, Copy, Clone, PartialEq, Eq, Debug, Deref, DerefMut)]
 pub struct VisibleChunkLayer(pub Entity);
 
 impl Default for VisibleChunkLayer {
@@ -534,7 +535,7 @@ impl Default for VisibleChunkLayer {
 }
 
 /// The value of [`VisibleChunkLayer`] from the end of the previous tick.
-#[derive(Component, PartialEq, Eq, Debug)]
+#[derive(Component, PartialEq, Eq, Debug, Deref)]
 pub struct OldVisibleChunkLayer(Entity);
 
 impl OldVisibleChunkLayer {
@@ -554,7 +555,7 @@ impl OldVisibleChunkLayer {
 pub struct VisibleEntityLayers(pub BTreeSet<Entity>);
 
 /// The value of [`VisibleEntityLayers`] from the end of the previous tick.
-#[derive(Component, Default, Debug)]
+#[derive(Component, Default, Debug, Deref)]
 pub struct OldVisibleEntityLayers(BTreeSet<Entity>);
 
 impl OldVisibleEntityLayers {

--- a/crates/valence_server/src/keepalive.rs
+++ b/crates/valence_server/src/keepalive.rs
@@ -2,6 +2,7 @@ use std::time::{Duration, Instant};
 
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
+use derive_more::Deref;
 use tracing::warn;
 use valence_protocol::packets::play::{KeepAliveC2s, KeepAliveS2c};
 use valence_protocol::WritePacket;
@@ -41,7 +42,7 @@ pub struct KeepaliveState {
 }
 
 /// Delay measured in milliseconds. Negative values indicate absence.
-#[derive(Component, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[derive(Component, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Deref)]
 pub struct Ping(pub i32);
 
 impl Default for Ping {

--- a/crates/valence_server/src/op_level.rs
+++ b/crates/valence_server/src/op_level.rs
@@ -2,6 +2,7 @@ use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use valence_protocol::packets::play::EntityStatusS2c;
 use valence_protocol::WritePacket;
+use derive_more::Deref;
 
 use crate::client::{Client, UpdateClientsSet};
 
@@ -13,7 +14,7 @@ impl Plugin for OpLevelPlugin {
     }
 }
 
-#[derive(Component, Clone, PartialEq, Eq, Default, Debug)]
+#[derive(Component, Clone, PartialEq, Eq, Default, Debug, Deref)]
 pub struct OpLevel(u8);
 
 impl OpLevel {

--- a/crates/valence_server/src/op_level.rs
+++ b/crates/valence_server/src/op_level.rs
@@ -1,8 +1,8 @@
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
+use derive_more::Deref;
 use valence_protocol::packets::play::EntityStatusS2c;
 use valence_protocol::WritePacket;
-use derive_more::Deref;
 
 use crate::client::{Client, UpdateClientsSet};
 

--- a/crates/valence_server/src/spawn.rs
+++ b/crates/valence_server/src/spawn.rs
@@ -4,6 +4,7 @@ use std::borrow::Cow;
 
 use bevy_ecs::prelude::*;
 use bevy_ecs::query::WorldQuery;
+use derive_more::{Deref, DerefMut};
 use valence_entity::EntityLayerId;
 use valence_protocol::packets::play::{GameJoinS2c, PlayerRespawnS2c, PlayerSpawnPositionS2c};
 use valence_protocol::{BlockPos, GameMode, GlobalPos, Ident, VarInt, WritePacket};
@@ -18,32 +19,32 @@ use crate::layer::ChunkLayer;
 #[derive(Component, Clone, PartialEq, Eq, Default, Debug)]
 pub struct DeathLocation(pub Option<(Ident<String>, BlockPos)>);
 
-#[derive(Component, Copy, Clone, PartialEq, Eq, Default, Debug)]
+#[derive(Component, Copy, Clone, PartialEq, Eq, Default, Debug, Deref, DerefMut)]
 pub struct IsHardcore(pub bool);
 
 /// Hashed world seed used for biome noise.
-#[derive(Component, Copy, Clone, PartialEq, Eq, Default, Debug)]
+#[derive(Component, Copy, Clone, PartialEq, Eq, Default, Debug, Deref, DerefMut)]
 pub struct HashedSeed(pub u64);
 
-#[derive(Component, Copy, Clone, PartialEq, Eq, Default, Debug)]
+#[derive(Component, Copy, Clone, PartialEq, Eq, Default, Debug, Deref, DerefMut)]
 pub struct ReducedDebugInfo(pub bool);
 
-#[derive(Component, Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Component, Copy, Clone, PartialEq, Eq, Debug, Deref, DerefMut)]
 pub struct HasRespawnScreen(pub bool);
 
 /// If the client is spawning into a debug world.
-#[derive(Component, Copy, Clone, PartialEq, Eq, Default, Debug)]
+#[derive(Component, Copy, Clone, PartialEq, Eq, Default, Debug, Deref, DerefMut)]
 pub struct IsDebug(pub bool);
 
 /// Changes the perceived horizon line (used for superflat worlds).
-#[derive(Component, Copy, Clone, PartialEq, Eq, Default, Debug)]
+#[derive(Component, Copy, Clone, PartialEq, Eq, Default, Debug, Deref, DerefMut)]
 pub struct IsFlat(pub bool);
 
-#[derive(Component, Copy, Clone, PartialEq, Eq, Default, Debug)]
+#[derive(Component, Copy, Clone, PartialEq, Eq, Default, Debug, Deref, DerefMut)]
 pub struct PortalCooldown(pub i32);
 
 /// The initial previous gamemode. Used for the F3+F4 gamemode switcher.
-#[derive(Component, Copy, Clone, PartialEq, Eq, Default, Debug)]
+#[derive(Component, Copy, Clone, PartialEq, Eq, Default, Debug, Deref, DerefMut)]
 pub struct PrevGameMode(pub Option<GameMode>);
 
 impl Default for HasRespawnScreen {

--- a/crates/valence_server_common/Cargo.toml
+++ b/crates/valence_server_common/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 [dependencies]
 bevy_ecs.workspace = true
 bevy_app.workspace = true
+derive_more.workspace = true
 uuid.workspace = true
 rand.workspace = true
 valence_protocol.workspace = true

--- a/crates/valence_server_common/src/uuid.rs
+++ b/crates/valence_server_common/src/uuid.rs
@@ -1,4 +1,5 @@
 use bevy_ecs::prelude::*;
+use derive_more::Deref;
 use uuid::Uuid;
 
 /// The universally unique identifier of an entity. Component wrapper for a
@@ -6,7 +7,7 @@ use uuid::Uuid;
 ///
 /// This component is expected to remain _unique_ and _constant_ during the
 /// lifetime of the entity. The [`Default`] impl generates a new random UUID.
-#[derive(Component, Copy, Clone, PartialEq, Eq, Debug, PartialOrd, Ord, Hash)]
+#[derive(Component, Copy, Clone, PartialEq, Eq, Debug, PartialOrd, Ord, Hash, Deref)]
 pub struct UniqueId(pub Uuid);
 
 /// Generates a new random UUID.

--- a/crates/valence_weather/Cargo.toml
+++ b/crates/valence_weather/Cargo.toml
@@ -12,3 +12,4 @@ license.workspace = true
 valence_server.workspace = true
 bevy_ecs.workspace = true
 bevy_app.workspace = true
+derive_more.workspace = true

--- a/crates/valence_weather/src/lib.rs
+++ b/crates/valence_weather/src/lib.rs
@@ -20,6 +20,7 @@
 
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
+use derive_more::{Deref, DerefMut};
 use valence_server::client::{Client, FlushPacketsSet, UpdateClientsSet, VisibleChunkLayer};
 use valence_server::protocol::packets::play::game_state_change_s2c::GameEventKind;
 use valence_server::protocol::packets::play::GameStateChangeS2c;
@@ -56,12 +57,12 @@ pub struct WeatherBundle {
 
 /// Component containing the rain level. Valid values are in \[0, 1] with 0
 /// being no rain and 1 being full rain.
-#[derive(Component, Default, PartialEq, PartialOrd)]
+#[derive(Component, Default, PartialEq, PartialOrd, Deref, DerefMut)]
 pub struct Rain(pub f32);
 
 /// Component containing the thunder level. Valid values are in \[0, 1] with 0
 /// being no rain and 1 being full rain.
-#[derive(Component, Default, PartialEq, PartialOrd)]
+#[derive(Component, Default, PartialEq, PartialOrd, Deref, DerefMut)]
 pub struct Thunder(pub f32);
 
 fn init_weather_on_layer_join(

--- a/crates/valence_world_border/Cargo.toml
+++ b/crates/valence_world_border/Cargo.toml
@@ -11,4 +11,5 @@ license.workspace = true
 [dependencies]
 bevy_app.workspace = true
 bevy_ecs.workspace = true
+derive_more.workspace = true
 valence_server.workspace = true

--- a/crates/valence_world_border/src/lib.rs
+++ b/crates/valence_world_border/src/lib.rs
@@ -20,6 +20,7 @@
 
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
+use derive_more::{Deref, DerefMut};
 use valence_server::client::{Client, UpdateClientsSet, VisibleChunkLayer};
 use valence_server::protocol::packets::play::{
     WorldBorderCenterChangedS2c, WorldBorderInitializeS2c, WorldBorderInterpolateSizeS2c,
@@ -28,7 +29,6 @@ use valence_server::protocol::packets::play::{
 };
 use valence_server::protocol::WritePacket;
 use valence_server::{ChunkLayer, Server};
-use derive_more::{Deref, DerefMut};
 
 // https://minecraft.fandom.com/wiki/World_border
 pub const DEFAULT_PORTAL_LIMIT: i32 = 29999984;

--- a/crates/valence_world_border/src/lib.rs
+++ b/crates/valence_world_border/src/lib.rs
@@ -28,6 +28,7 @@ use valence_server::protocol::packets::play::{
 };
 use valence_server::protocol::WritePacket;
 use valence_server::{ChunkLayer, Server};
+use derive_more::{Deref, DerefMut};
 
 // https://minecraft.fandom.com/wiki/World_border
 pub const DEFAULT_PORTAL_LIMIT: i32 = 29999984;
@@ -96,7 +97,7 @@ pub struct WorldBorderLerp {
     /// automatically.
     pub remaining_ticks: u64,
 }
-#[derive(Component, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[derive(Component, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Deref, DerefMut)]
 pub struct WorldBorderWarnTime(pub i32);
 
 impl Default for WorldBorderWarnTime {
@@ -105,7 +106,7 @@ impl Default for WorldBorderWarnTime {
     }
 }
 
-#[derive(Component, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[derive(Component, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Deref, DerefMut)]
 pub struct WorldBorderWarnBlocks(pub i32);
 
 impl Default for WorldBorderWarnBlocks {
@@ -114,7 +115,7 @@ impl Default for WorldBorderWarnBlocks {
     }
 }
 
-#[derive(Component, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[derive(Component, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Deref, DerefMut)]
 pub struct WorldBorderPortalTpBoundary(pub i32);
 
 impl Default for WorldBorderPortalTpBoundary {


### PR DESCRIPTION
## Objective

- Add `Deref` and `DerefMut` to all components using `derive_more` crate
- Closes #444

## Solution

- Add `derive_more` crate to top level `Cargo.toml` and use cargo workspace dependency in necessary crates
- Derive `DerefMut` trait to components that provide mutable access to underlying data
- Derive `Deref` trait to components that provide immutable access to underlying data

## Compile times

I made some compilation time benchmarks on my machine (i don't know good way to do compile time benchmarks so i ran debug mode compilation couple of times before and after the change)

Clean `Valence` compilation
- Before: 2m 2s
- After: 2m 5s

Clean default `playground` example
- Before: 11s
- After: 11s

