### PR TITLE
Add warning to rustdocs when building from main branch

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,8 @@
-#![doc = include_str!("../README.md")] // Points to the main project README.
+#![cfg_attr(
+    unstable_doc,
+    doc = "**❗ NOTE:** This documentation is sourced from the `main` branch. If you're looking for the most recent stable release, go [here](https://docs.rs/valence/latest/valence/).\n\n---\n"
+)]
+#![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/valence-rs/valence/main/assets/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/valence-rs/valence/main/assets/logo.svg"

--- a/website/build.sh
+++ b/website/build.sh
@@ -22,7 +22,7 @@ zola build
 mdbook build
 
 # build rustdoc
-cargo doc --no-deps --workspace --all-features
+RUSTDOCFLAGS='--cfg unstable_doc' cargo doc --no-deps --workspace --all-features
 cp -r ../target/doc/* public/rustdoc
 
 # copy logo assets


### PR DESCRIPTION
# Objective

When viewing the API docs from valence.rs, there is no obvious indication that they are for the `main` branch. This could lead to confusion in the future.

# Solution

Add a warning to the docs, but only when building from `website/build.sh`.

> **❗ NOTE:** This documentation is sourced from the `main` branch. If you're looking for the most recent stable release, go [here](https://docs.rs/valence/latest/valence/).
