### PR TITLE
Make player health 20.0 by default

### DIFF
--- a/crates/valence_server/src/client.rs
+++ b/crates/valence_server/src/client.rs
@@ -13,6 +13,7 @@ use bytes::{Bytes, BytesMut};
 use derive_more::{Deref, DerefMut, From, Into};
 use tracing::warn;
 use uuid::Uuid;
+use valence_entity::living::Health;
 use valence_entity::player::PlayerEntityBundle;
 use valence_entity::query::EntityInitQuery;
 use valence_entity::tracked_data::TrackedData;
@@ -177,6 +178,7 @@ impl ClientBundle {
             player_abilities_flags: Default::default(),
             player: PlayerEntityBundle {
                 uuid: UniqueId(args.uuid),
+                living_health: Health(20.0),
                 ..Default::default()
             },
         }


### PR DESCRIPTION
# Objective

When testing making a minigame example, I noticed the player always spawned with 6 health, which is the default for living entities in Valence.

It would also cause a desync between the client and server, because the client implies that it has 20.0 health upon spawning.
