### PR TITLE
Add online mode detection in the Packet Inspector

### DIFF
--- a/tools/packet_inspector/Cargo.toml
+++ b/tools/packet_inspector/Cargo.toml
@@ -24,6 +24,7 @@ cli = ["clap"]
 
 [dependencies]
 anyhow = { workspace = true }
+thiserror = { workspace = true }
 bytes = { workspace = true }
 flate2 = { workspace = true }
 flume = { workspace = true }

--- a/tools/packet_inspector/build.rs
+++ b/tools/packet_inspector/build.rs
@@ -147,8 +147,8 @@ fn write_transformer(packets: &[Packet]) -> anyhow::Result<()> {
             name
         };
 
-        let state_map = acc.entry(side).or_insert_with(HashMap::new);
-        let id_map = state_map.entry(state).or_insert_with(Vec::new);
+        let state_map = acc.entry(side).or_default();
+        let id_map = state_map.entry(state).or_default();
         id_map.push(name);
 
         acc

--- a/tools/packet_inspector/src/app.rs
+++ b/tools/packet_inspector/src/app.rs
@@ -158,13 +158,8 @@ fn handle_events(state: Arc<RwLock<SharedState>>) {
                     let state = state.clone();
 
                     proxy_thread = Some(tokio::spawn(async move {
-                        let proxy = Proxy::new(listener_addr, server_addr);
+                        let proxy = Proxy::start(listener_addr, server_addr).await?;
                         let receiver = proxy.subscribe().await;
-
-                        tokio::spawn(async move {
-                            proxy.run().await?;
-                            Ok::<(), anyhow::Error>(())
-                        });
 
                         while let Ok(packet) = receiver.recv_async().await {
                             let state = state.read().unwrap();

--- a/tools/packet_inspector/src/lib.rs
+++ b/tools/packet_inspector/src/lib.rs
@@ -2,99 +2,203 @@ mod packet_io;
 mod packet_registry;
 
 use std::net::SocketAddr;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
+use std::time::Duration;
 
-pub use packet_registry::Packet;
-use tokio::net::TcpStream;
+use anyhow::bail;
+
+use bytes::{BufMut, BytesMut};
+
+use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::RwLock;
+use tokio::task::JoinHandle;
+
 use valence::protocol::decode::PacketFrame;
 use valence::protocol::packets::handshaking::handshake_c2s::HandshakeNextState;
 use valence::protocol::packets::handshaking::HandshakeC2s;
-use valence::protocol::packets::login::{LoginCompressionS2c, LoginSuccessS2c};
-use valence::protocol::{Decode, Packet as ValencePacket};
+use valence::protocol::packets::login::{
+    LoginCompressionS2c, LoginDisconnectS2c, LoginHelloS2c, LoginSuccessS2c,
+};
+use valence::protocol::{Decode, Encode, Packet as ValencePacket};
+use valence::text::color::NamedColor;
+use valence::text::{Color, IntoText};
 use valence::CompressionThreshold;
 
 use crate::packet_io::PacketIo;
 use crate::packet_registry::PacketRegistry;
-pub use crate::packet_registry::{PacketSide, PacketState};
-
-static PACKET_REGISTRY: OnceLock<Arc<RwLock<PacketRegistry>>> = OnceLock::new();
+pub use crate::packet_registry::{Packet, PacketSide, PacketState};
 
 include!(concat!(env!("OUT_DIR"), "/packets.rs"));
 
+/// Messages for talking to the running proxy task
+#[derive(Debug, Clone)]
+pub enum ProxyMessage {
+    Stop,
+    // In the future there could be a message like
+    // InjectPacket(SocketAddr, PacketFrame)
+}
+
+#[derive(Debug)]
+pub enum DisconnectionReason {
+    OnlineModeRequired,
+    Error(anyhow::Error),
+}
+
+/// Messages sent by the proxy for the controlling GUI/CLI.
+#[derive(Debug)]
+pub enum ProxyLog {
+    /// A new client has connected to the listener.
+    ClientConnected(SocketAddr),
+    /// A client has disconnected from the listener.
+    ClientDisconnected(SocketAddr, DisconnectionReason),
+}
+
 pub struct Proxy {
-    listener_addr: SocketAddr,
-    server_addr: SocketAddr,
+    pub main_task: JoinHandle<anyhow::Result<()>>,
+    pub message_tx: flume::Sender<ProxyMessage>,
+    pub logs_rx: flume::Receiver<ProxyLog>,
+    pub packet_registry: Arc<RwLock<PacketRegistry>>,
 }
 
 impl Proxy {
-    pub fn new(listener_addr: SocketAddr, server_addr: SocketAddr) -> Self {
-        PACKET_REGISTRY.get_or_init(|| {
+    /// Creates a new proxy, and starts its listener task.
+    pub async fn start(listener_addr: SocketAddr, server_addr: SocketAddr) -> anyhow::Result<Self> {
+        let (message_tx, message_rx) = flume::unbounded();
+        let (logs_tx, logs_rx) = flume::unbounded();
+
+        let packet_registry = Arc::new(RwLock::new({
             let registry = PacketRegistry::new();
             registry.register_all(&STD_PACKETS);
-            Arc::new(RwLock::new(registry))
-        });
+            registry
+        }));
 
-        Proxy {
-            listener_addr,
+        let main_task = tokio::spawn(Self::run_main_task(
+            packet_registry.clone(),
+            TcpListener::bind(listener_addr).await?,
             server_addr,
+            message_rx,
+            logs_tx,
+        ));
+
+        Ok(Self {
+            main_task,
+            message_tx,
+            logs_rx,
+            packet_registry,
+        })
+    }
+
+    /// Subscribes to the proxy's [`PacketRegistry`].
+    pub async fn subscribe(&self) -> flume::Receiver<Packet> {
+        self.packet_registry.read().await.subscribe()
+    }
+
+    /// Sends a request to stop the proxy and awaits its task's termination. There's a hardcoded
+    /// 5 second long timeout after which the task is considered unresponsive and automatically
+    /// aborted.
+    pub async fn stop(self) {
+        // The task may have already stopped, so we can ignore a Disconnected error
+        let _ = self.message_tx.send_async(ProxyMessage::Stop).await;
+
+        let abort_handle = self.main_task.abort_handle();
+        tokio::select! {
+            _ = self.main_task => {},
+
+            // If the main task doesn't stop after 5 seconds, we force terminate it
+            _ = tokio::time::sleep(Duration::from_secs(5)) => {
+                abort_handle.abort();
+            },
         }
     }
 
-    pub async fn subscribe(&self) -> flume::Receiver<Packet> {
-        PACKET_REGISTRY.get().unwrap().read().await.subscribe()
-    }
+    /// The main listener task is responsible for handling the TCP listener and managing child
+    /// tasks for each client connected to the inspector.
+    async fn run_main_task(
+        packet_registry: Arc<RwLock<PacketRegistry>>,
+        listener: TcpListener,
+        server_addr: SocketAddr,
+        message_rx: flume::Receiver<ProxyMessage>,
+        logs_tx: flume::Sender<ProxyLog>,
+    ) -> anyhow::Result<()> {
+        let mut individual_tasks = vec![];
+        loop {
+            tokio::select! {
+                r = listener.accept() => {
+                    let (stream, addr) = r?;
 
-    pub async fn run(&self) -> anyhow::Result<()> {
-        let listener = tokio::net::TcpListener::bind(self.listener_addr).await?;
+                    logs_tx.send_async(ProxyLog::ClientConnected(addr)).await?;
+                    individual_tasks.push(tokio::spawn(Self::run_individual_proxy(
+                        stream,
+                        TcpStream::connect(server_addr).await?,
+                        logs_tx.clone(),
+                        packet_registry.clone(),
+                    )));
+                }
+                m = message_rx.recv_async() => match m {
+                    Ok(ProxyMessage::Stop) | Err(_) => {
+                        tracing::trace!("Stopping the proxy task...");
 
-        while let Ok((client, _addr)) = listener.accept().await {
-            let server_addr = self.server_addr;
-            tokio::spawn(async move {
-                let server = TcpStream::connect(server_addr).await?;
+                        // TODO: stop these tasks properly instead of just leaving the TCP connections for timeout
+                        for task in individual_tasks.drain(..) {
+                            task.abort();
+                        }
 
-                if let Err(e) = Self::process(client, server).await {
-                    if !e.to_string().contains("unexpected end of file") {
-                        // bit meh to do it like this but it works
-                        tracing::error!("Error: {:?}", e);
+                        return Ok(());
                     }
                 }
-
-                Ok::<(), anyhow::Error>(())
-            });
+            }
         }
-        Ok(())
     }
 
-    async fn process(client: TcpStream, server: TcpStream) -> anyhow::Result<()> {
+    /// Each client connected to the inspector is handled in its own individual task, defined here.
+    async fn run_individual_proxy(
+        client: TcpStream,
+        server: TcpStream,
+        a_logs_tx: flume::Sender<ProxyLog>,
+        packet_registry: Arc<RwLock<PacketRegistry>>,
+    ) -> anyhow::Result<()> {
+        let client_addr = client.peer_addr()?;
+
         let client = PacketIo::new(client);
         let server = PacketIo::new(server);
 
         let (mut client_reader, mut client_writer) = client.split();
         let (mut server_reader, mut server_writer) = server.split();
 
-        let current_state_inner = Arc::new(RwLock::new(PacketState::Handshaking));
-        let threshold_inner: Arc<RwLock<CompressionThreshold>> =
-            Arc::new(RwLock::new(CompressionThreshold::DEFAULT));
+        let a_state = Arc::new(RwLock::new(PacketState::Handshaking));
+        let a_threshold = Arc::new(RwLock::new(CompressionThreshold::DEFAULT));
 
-        let current_state = current_state_inner.clone();
-        let threshold = threshold_inner.clone();
-        let registry = PACKET_REGISTRY.get().unwrap().clone();
+        let registry = packet_registry.clone();
+        let state_lock = a_state.clone();
+        let threshold_lock = a_threshold.clone();
+        let logs_tx = a_logs_tx.clone();
         let c2s = tokio::spawn(async move {
             loop {
-                let threshold = *threshold.read().await;
+                let threshold = *threshold_lock.read().await;
                 client_reader.set_compression(threshold);
                 server_writer.set_compression(threshold);
-                // client to server handling
-                let packet = client_reader.recv_packet_raw().await?;
 
-                let state = {
-                    let state = current_state.read().await;
-                    *state
+                let state = *state_lock.read().await;
+
+                // client to server handling
+                let packet = match client_reader.recv_packet_raw().await {
+                    Ok(packet) => packet,
+                    Err(e) => {
+                        server_writer.shutdown().await?;
+                        logs_tx
+                            .send_async(ProxyLog::ClientDisconnected(
+                                client_addr,
+                                DisconnectionReason::Error(e.into()),
+                            ))
+                            .await?;
+
+                        bail!("connection error");
+                    }
                 };
 
-                let registry = registry.write().await;
                 registry
+                    .write()
+                    .await
                     .process(
                         crate::packet_registry::PacketSide::Serverbound,
                         state,
@@ -105,7 +209,7 @@ impl Proxy {
 
                 if state == PacketState::Handshaking {
                     if let Some(handshake) = extrapolate_packet::<HandshakeC2s>(&packet) {
-                        *current_state.write().await = match handshake.next_state {
+                        *state_lock.write().await = match handshake.next_state {
                             HandshakeNextState::Status => PacketState::Status,
                             HandshakeNextState::Login => PacketState::Login,
                         };
@@ -114,37 +218,37 @@ impl Proxy {
 
                 server_writer.send_packet_raw(&packet).await?;
             }
-
-            #[allow(unreachable_code)]
-            Ok::<(), anyhow::Error>(())
         });
 
-        let current_state = current_state_inner.clone();
-        let threshold = threshold_inner.clone();
-        let registry = PACKET_REGISTRY.get().unwrap().clone();
+        let registry = packet_registry.clone();
+        let state_lock = a_state.clone();
+        let threshold_lock = a_threshold.clone();
+        let logs_tx = a_logs_tx.clone();
         let s2c = tokio::spawn(async move {
             loop {
-                let threshold_value = *threshold.read().await;
-                server_reader.set_compression(threshold_value);
-                client_writer.set_compression(threshold_value);
-                // server to client handling
-                let packet = server_reader.recv_packet_raw().await?;
+                let threshold = *threshold_lock.read().await;
+                server_reader.set_compression(threshold);
+                client_writer.set_compression(threshold);
 
-                let state = {
-                    let state = current_state.read().await;
-                    *state
+                // server to client handling
+                let packet = match server_reader.recv_packet_raw().await {
+                    Ok(packet) => packet,
+                    Err(e) => {
+                        client_writer.shutdown().await?;
+                        return Err(anyhow::Error::from(e));
+                    }
                 };
 
+                let state = *state_lock.read().await;
+
                 if state == PacketState::Login {
-                    if let Some(compression) = extrapolate_packet::<LoginCompressionS2c>(&packet) {
-                        if compression.threshold.0 >= 0 {
-                            threshold.write().await.0 = compression.threshold.0;
-                        }
-                    };
+                    if let Some(LoginCompressionS2c { threshold }) = extrapolate_packet(&packet) {
+                        *threshold_lock.write().await = CompressionThreshold(threshold.0);
+                    }
 
                     if extrapolate_packet::<LoginSuccessS2c>(&packet).is_some() {
-                        *current_state.write().await = PacketState::Play;
-                    };
+                        *state_lock.write().await = PacketState::Play;
+                    }
                 }
 
                 registry
@@ -153,16 +257,51 @@ impl Proxy {
                     .process(
                         crate::packet_registry::PacketSide::Clientbound,
                         state,
-                        threshold_value,
+                        threshold,
                         &packet,
                     )
                     .await?;
 
+                // (The check is done in this if rather than the one above, to still send the
+                // encryption request packet to the inspector)
+                if state == PacketState::Login {
+                    if extrapolate_packet::<LoginHelloS2c>(&packet).is_some() {
+                        // The server is requesting encryption, we can't support that
+
+                        let disconnect_packet = LoginDisconnectS2c {
+                            reason: "This server is running in online mode, \
+                                which is unsupported by the Packet Inspector."
+                                .into_text()
+                                .color(Color::Named(NamedColor::Red))
+                                .into_cow_text(),
+                        };
+
+                        client_writer
+                            .send_packet_raw(&PacketFrame {
+                                id: LoginDisconnectS2c::ID,
+                                body: {
+                                    let mut writer = BytesMut::new().writer();
+                                    disconnect_packet.encode(&mut writer)?;
+                                    writer.into_inner()
+                                },
+                            })
+                            .await?;
+
+                        client_writer.shutdown().await?;
+
+                        logs_tx
+                            .send_async(ProxyLog::ClientDisconnected(
+                                client_addr,
+                                DisconnectionReason::OnlineModeRequired,
+                            ))
+                            .await?;
+
+                        bail!("server is running in online mode");
+                    }
+                }
+
                 client_writer.send_packet_raw(&packet).await?;
             }
-
-            #[allow(unreachable_code)]
-            Ok::<(), anyhow::Error>(())
         });
 
         // wait for either to finish

--- a/tools/packet_inspector/src/lib.rs
+++ b/tools/packet_inspector/src/lib.rs
@@ -85,7 +85,7 @@ impl Proxy {
         })
     }
 
-    /// Subscribes to the proxy's [`PacketRegistry`].
+    /// Subscribes to the proxy's packet registry.
     pub async fn subscribe(&self) -> flume::Receiver<Packet> {
         self.packet_registry.read().await.subscribe()
     }

--- a/tools/packet_inspector/src/packet_io.rs
+++ b/tools/packet_inspector/src/packet_io.rs
@@ -141,6 +141,11 @@ impl PacketIoWriter {
         self.threshold = threshold;
         self.enc.set_compression(threshold);
     }
+
+    pub async fn shutdown(&mut self) -> std::io::Result<()> {
+        self.writer.shutdown().await?;
+        Ok(())
+    }
 }
 
 pub(crate) struct PacketIo {

--- a/tools/packet_inspector/src/packet_registry.rs
+++ b/tools/packet_inspector/src/packet_registry.rs
@@ -82,6 +82,12 @@ impl PacketRegistry {
     }
 }
 
+impl Default for PacketRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(Clone, Debug, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Packet {


### PR DESCRIPTION

# Objective

- The packet inspector didn't respond properly when the server had encryption enabled
- Fixes #404 

# Solution

- The proxy now listens for authentication packets (LoginHelloS2c), kicking the player out with an appropriate message and shutting down the connection when that happens.
- The proxy code was also refactored a fair bit to allow easier two-way communication between the proxy tasks and the UI code, although so far it's mostly unused (I only wrote code for the CLI to print online mode errors whenever the server requests online mode, the GUI hasn't changed, although I may come back and add more info there in the future).

Also, for the sake of completeness, here's how the error looks like in-game:
![Screenshot](https://github.com/valence-rs/valence/assets/67662357/748e7fd9-efe1-4b43-b8d3-6ebd39251f51)
