### PR TITLE
Fix a sync issue with the packet inspector

### DIFF
--- a/tools/packet_inspector/src/lib.rs
+++ b/tools/packet_inspector/src/lib.rs
@@ -175,8 +175,6 @@ impl Proxy {
                 client_reader.set_compression(threshold);
                 server_writer.set_compression(threshold);
 
-                let state = *state_lock.read().await;
-
                 // client to server handling
                 let packet = match client_reader.recv_packet_raw().await {
                     Ok(packet) => packet,
@@ -192,6 +190,8 @@ impl Proxy {
                         bail!("connection error");
                     }
                 };
+
+                let state = *state_lock.read().await;
 
                 registry
                     .write()


### PR DESCRIPTION
# Objective

- Apparently I missed this while working on the proxy, I accidentally moved the packet state dereference into the wrong spot, causing just one packet to be sometimes misread after a state change (particularly Login -> Play).
- Whoops, sorry 😅 

# Solution

- Moved packet fetching to the correct spot
