### PR TITLE
Add `cargo-udeps` to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,3 +183,22 @@ jobs:
         with:
           name: bad-depgraph
           path: bad-depgraph/
+  udeps:
+    name: Check for unused dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions Repository
+        uses: actions/checkout@v3
+
+      - name: Setup Rust toolchain and cache
+        uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
+        with:
+          toolchain: "nightly"
+
+      - name: Install cargo-udeps
+        uses: baptiste0928/cargo-install@v2.1.0
+        with:
+          crate: cargo-udeps
+
+      - name: Check for unused dependencies
+        run: cargo udeps --all --all-features

--- a/crates/valence_text/Cargo.toml
+++ b/crates/valence_text/Cargo.toml
@@ -9,7 +9,6 @@ documentation.workspace = true
 license.workspace = true
 
 [dependencies]
-anyhow.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true


### PR DESCRIPTION
# Objective

Unused dependencies can be left in `Cargo.toml` by accident.

# Solution

- Add `cargo-udeps` to CI.
