### PR TITLE
Solve inability for items with improper NBT data to be moved out of inventories

### DIFF
--- a/crates/valence_inventory/src/validate.rs
+++ b/crates/valence_inventory/src/validate.rs
@@ -167,8 +167,13 @@ pub(super) fn validate_click_slot_packet(
                 if should_swap {
                     // assert that a swap occurs
                     ensure!(
-                        *old_slot == packet.carried_item
-                            && cursor_item.0 == packet.slot_changes[0].stack,
+                        // TODO: Patch for moving items with incorrect NBT Data.
+                        // The client has added NBT data to the item which does not exist
+                        // on the item in the inventory.
+                        old_slot.item == packet.carried_item.item &&
+                        old_slot.count == packet.carried_item.count &&
+
+                        cursor_item.0 == packet.slot_changes[0].stack,
                         "swapped items must match"
                     );
                 } else {

--- a/crates/valence_inventory/src/validate.rs
+++ b/crates/valence_inventory/src/validate.rs
@@ -170,10 +170,9 @@ pub(super) fn validate_click_slot_packet(
                         // TODO: Patch for moving items with incorrect NBT Data.
                         // The client has added NBT data to the item which does not exist
                         // on the item in the inventory.
-                        old_slot.item == packet.carried_item.item &&
-                        old_slot.count == packet.carried_item.count &&
-
-                        cursor_item.0 == packet.slot_changes[0].stack,
+                        old_slot.item == packet.carried_item.item
+                            && old_slot.count == packet.carried_item.count
+                            && cursor_item.0 == packet.slot_changes[0].stack,
                         "swapped items must match"
                     );
                 } else {

--- a/crates/valence_inventory/src/validate.rs
+++ b/crates/valence_inventory/src/validate.rs
@@ -167,9 +167,8 @@ pub(super) fn validate_click_slot_packet(
                 if should_swap {
                     // assert that a swap occurs
                     ensure!(
-                        // TODO: Patch for moving items with incorrect NBT Data.
-                        // The client has added NBT data to the item which does not exist
-                        // on the item in the inventory.
+                        // There are some cases where the client will add NBT data that 
+                        // did not previously exist.
                         old_slot.item == packet.carried_item.item
                             && old_slot.count == packet.carried_item.count
                             && cursor_item.0 == packet.slot_changes[0].stack,

--- a/crates/valence_inventory/src/validate.rs
+++ b/crates/valence_inventory/src/validate.rs
@@ -167,7 +167,7 @@ pub(super) fn validate_click_slot_packet(
                 if should_swap {
                     // assert that a swap occurs
                     ensure!(
-                        // There are some cases where the client will add NBT data that 
+                        // There are some cases where the client will add NBT data that
                         // did not previously exist.
                         old_slot.item == packet.carried_item.item
                             && old_slot.count == packet.carried_item.count
@@ -358,6 +358,8 @@ fn calculate_net_item_delta(
 
 #[cfg(test)]
 mod tests {
+    use valence_server::nbt::Compound;
+    use valence_server::nbt::Value::Int;
     use valence_server::protocol::packets::play::click_slot_c2s::SlotChange;
     use valence_server::protocol::VarInt;
     use valence_server::{ItemKind, ItemStack};
@@ -461,6 +463,41 @@ mod tests {
             }]
             .into(),
             carried_item: inventory.slot(0).clone(),
+        };
+
+        validate_click_slot_packet(&packet, &player_inventory, Some(&inventory), &cursor_item)
+            .expect("packet should be valid");
+    }
+
+    #[test]
+    fn click_filled_slot_with_incorrect_nbt_and_empty_cursor_success() {
+        let player_inventory = Inventory::new(InventoryKind::Player);
+        let cursor_item = CursorItem(ItemStack::EMPTY);
+
+        let mut inventory = Inventory::new(InventoryKind::Generic9x1);
+        // Insert an item with no NBT data that should have NBT Data.
+        inventory.set_slot(0, ItemStack::new(ItemKind::DiamondPickaxe, 1, None));
+
+        // Proper NBT Compound
+        let mut compound = Compound::new();
+        compound.insert("Damage", Int(1));
+
+        let packet = ClickSlotC2s {
+            window_id: 1,
+            state_id: VarInt(0),
+            slot_idx: 0,
+            button: 0,
+            mode: ClickMode::Click,
+            slot_changes: vec![SlotChange {
+                idx: 0,
+                stack: ItemStack::EMPTY,
+            }]
+            .into(),
+            carried_item: ItemStack {
+                item: ItemKind::DiamondPickaxe,
+                count: 1,
+                nbt: Some(compound),
+            },
         };
 
         validate_click_slot_packet(&packet, &player_inventory, Some(&inventory), &cursor_item)


### PR DESCRIPTION
Hi,
# Objective

I was playing around with the chest example.
After adding an item with NBT data, I noticed I was unable to remove it from the chest.
Sourced the error down to this check. All I have done is not check the NBT data for now.

Same as in last comment of #292 .

# Solution

Only item kind and count checked, nbt ignored.

Kind Regards,
Mac