### PR TITLE
Replace fandom references with new wiki

### DIFF
--- a/crates/valence_anvil/README.md
+++ b/crates/valence_anvil/README.md
@@ -1,3 +1,3 @@
 # valence_anvil
 
-Support for Minecraft's [anvil file format](https://minecraft.fandom.com/wiki/Anvil_file_format).
+Support for Minecraft's [anvil file format](https://minecraft.wiki/w/Anvil_file_format).

--- a/crates/valence_ident/README.md
+++ b/crates/valence_ident/README.md
@@ -1,3 +1,3 @@
 # valence_ident
 
-A library for parsing Minecraft's [resource locations](https://minecraft.fandom.com/wiki/Resource_location) (also known as "resource identifiers" and "namespaced IDs")
+A library for parsing Minecraft's [resource locations](https://minecraft.wiki/w/Resource_location) (also known as "resource identifiers" and "namespaced IDs")

--- a/crates/valence_nbt/README.md
+++ b/crates/valence_nbt/README.md
@@ -3,7 +3,7 @@
 A library for encoding and decoding Minecraft's [Named Binary Tag] (NBT)
 format.
 
-[Named Binary Tag]: https://minecraft.fandom.com/wiki/NBT_format
+[Named Binary Tag]: https://minecraft.wiki/w/NBT_format
 
 # Features
 - `binary`: Adds support for serializing and deserializing in Java edition's binary format.

--- a/crates/valence_network/src/lib.rs
+++ b/crates/valence_network/src/lib.rs
@@ -658,7 +658,7 @@ pub struct PlayerSampleEntry {
     /// The name of the player.
     ///
     /// This string can contain
-    /// [legacy formatting codes](https://minecraft.fandom.com/wiki/Formatting_codes).
+    /// [legacy formatting codes](https://minecraft.wiki/w/Formatting_codes).
     pub name: String,
     /// The player UUID.
     pub id: Uuid,

--- a/crates/valence_text/README.md
+++ b/crates/valence_text/README.md
@@ -1,3 +1,3 @@
 # valence_text
 
-A library for parsing and writing Minecraft's [JSON text format](https://minecraft.fandom.com/wiki/Raw_JSON_text_format)
+A library for parsing and writing Minecraft's [JSON text format](https://minecraft.wiki/w/Raw_JSON_text_format)

--- a/crates/valence_text/src/lib.rs
+++ b/crates/valence_text/src/lib.rs
@@ -26,7 +26,7 @@ pub use into_text::IntoText;
 ///
 /// For more information, see the relevant [Minecraft Wiki article].
 ///
-/// [Minecraft Wiki article]: https://minecraft.fandom.com/wiki/Raw_JSON_text_format
+/// [Minecraft Wiki article]: https://minecraft.wiki/w/Raw_JSON_text_format
 ///
 /// # Examples
 ///
@@ -116,11 +116,11 @@ pub enum TextContent {
     ScoreboardValue { score: ScoreboardValueContent },
     /// Displays the name of one or more entities found by a [`selector`].
     ///
-    /// [`selector`]: https://minecraft.fandom.com/wiki/Target_selectors
+    /// [`selector`]: https://minecraft.wiki/w/Target_selectors
     EntityNames {
         /// A string containing a [`selector`].
         ///
-        /// [`selector`]: https://minecraft.fandom.com/wiki/Target_selectors
+        /// [`selector`]: https://minecraft.wiki/w/Target_selectors
         selector: Cow<'static, str>,
         /// An optional custom separator used when the selector returns multiple
         /// entities. Defaults to the ", " text with gray color.
@@ -133,7 +133,7 @@ pub enum TextContent {
         /// A [`keybind identifier`], to be displayed as the name of the button
         /// that is currently bound to that action.
         ///
-        /// [`keybind identifier`]: https://minecraft.fandom.com/wiki/Controls#Configurable_controls
+        /// [`keybind identifier`]: https://minecraft.wiki/w/Controls#Configurable_controls
         keybind: Cow<'static, str>,
     },
     /// Displays NBT values from block entities.
@@ -171,7 +171,7 @@ pub struct ScoreboardValueContent {
     /// The name of the score holder whose score should be displayed. This
     /// can be a [`selector`] or an explicit name.
     ///
-    /// [`selector`]: https://minecraft.fandom.com/wiki/Target_selectors
+    /// [`selector`]: https://minecraft.wiki/w/Target_selectors
     pub name: Cow<'static, str>,
     /// The internal name of the objective to display the player's score in.
     pub objective: Cow<'static, str>,
@@ -301,7 +301,7 @@ impl Text {
     /// Creates a text component for a keybind. The keybind should be a valid
     /// [`keybind identifier`].
     ///
-    /// [`keybind identifier`]: https://minecraft.fandom.com/wiki/Controls#Configurable_controls
+    /// [`keybind identifier`]: https://minecraft.wiki/w/Controls#Configurable_controls
     pub fn keybind(keybind: impl Into<Cow<'static, str>>) -> Self {
         Self(Box::new(TextInner {
             content: TextContent::Keybind {

--- a/crates/valence_world_border/README.md
+++ b/crates/valence_world_border/README.md
@@ -1,6 +1,6 @@
 # valence_world_border
 
-Contains the plugin for working with Minecraft's [world border](https://minecraft.fandom.com/wiki/World_border).
+Contains the plugin for working with Minecraft's [world border](https://minecraft.wiki/w/World_border).
 
 To enable world border functionality for a layer, insert the [`WorldBorderBundle`] component on the layer entity.
 Note that the layer entity must have the [`ChunkLayer`] component for this to work.

--- a/crates/valence_world_border/src/lib.rs
+++ b/crates/valence_world_border/src/lib.rs
@@ -30,7 +30,7 @@ use valence_server::protocol::packets::play::{
 use valence_server::protocol::WritePacket;
 use valence_server::{ChunkLayer, Server};
 
-// https://minecraft.fandom.com/wiki/World_border
+// https://minecraft.wiki/w/World_border
 pub const DEFAULT_PORTAL_LIMIT: i32 = 29999984;
 pub const DEFAULT_DIAMETER: f64 = (DEFAULT_PORTAL_LIMIT * 2) as f64;
 pub const DEFAULT_WARN_TIME: i32 = 15;


### PR DESCRIPTION
# Objective

- Replace references to the old Fandom wiki with the new wiki. See [here](https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom) for details

# Solution

- Replace references to the old Fandom wiki with the new wiki
