### PR TITLE
Fix encoding `ItemStack` in `TrackedData`

### DIFF
--- a/crates/valence_entity/build.rs
+++ b/crates/valence_entity/build.rs
@@ -262,7 +262,6 @@ impl Value {
         match self {
             Value::Integer(_) => quote!(VarInt(#self_lvalue)),
             Value::OptionalInt(_) => quote!(OptionalInt(#self_lvalue)),
-            Value::ItemStack(_) => quote!(Some(&#self_lvalue)),
             _ => quote!(&#self_lvalue),
         }
     }


### PR DESCRIPTION
When encoding `ItemStack`s in `TrackedData` the `ItemStack` itself is not optional as it was previously implemented. For further context, when encoding an `ItemStack` it will only encode as one byte if the `ItemStack` is empty.

# Objective

- Fixes #537 

# Solution

- Remove the optional wrapping around the `ItemStack` value when encoding it in the `TrackedData`.
