### PR TITLE
Generify `valence_nbt` to allow other types of String

### DIFF
--- a/crates/java_string/src/slice.rs
+++ b/crates/java_string/src/slice.rs
@@ -1703,6 +1703,20 @@ impl AsRef<[u8]> for JavaStr {
     }
 }
 
+impl AsRef<JavaStr> for str {
+    #[inline]
+    fn as_ref(&self) -> &JavaStr {
+        JavaStr::from_str(self)
+    }
+}
+
+impl AsRef<JavaStr> for String {
+    #[inline]
+    fn as_ref(&self) -> &JavaStr {
+        JavaStr::from_str(self)
+    }
+}
+
 impl Clone for Box<JavaStr> {
     #[inline]
     fn clone(&self) -> Self {
@@ -1818,6 +1832,13 @@ impl From<JavaString> for Box<JavaStr> {
 impl<'a> From<&'a str> for &'a JavaStr {
     #[inline]
     fn from(value: &'a str) -> Self {
+        JavaStr::from_str(value)
+    }
+}
+
+impl<'a> From<&'a String> for &'a JavaStr {
+    #[inline]
+    fn from(value: &'a String) -> Self {
         JavaStr::from_str(value)
     }
 }

--- a/crates/valence_anvil/src/lib.rs
+++ b/crates/valence_anvil/src/lib.rs
@@ -555,14 +555,16 @@ impl Region {
             Compression::Gzip => valence_nbt::to_binary(
                 chunk,
                 GzEncoder::new(&mut compress_cursor, flate2::Compression::default()),
-                "",
+                &String::new(),
             )?,
             Compression::Zlib => valence_nbt::to_binary(
                 chunk,
                 ZlibEncoder::new(&mut compress_cursor, flate2::Compression::default()),
-                "",
+                &String::new(),
             )?,
-            Compression::None => valence_nbt::to_binary(chunk, &mut compress_cursor, "")?,
+            Compression::None => {
+                valence_nbt::to_binary(chunk, &mut compress_cursor, &String::new())?
+            }
         }
         let compress_buf = compress_cursor.into_inner();
 

--- a/crates/valence_anvil/src/lib.rs
+++ b/crates/valence_anvil/src/lib.rs
@@ -177,7 +177,7 @@ impl RegionFolder {
         pos_z: i32,
     ) -> Result<Option<RawChunk<S>>, RegionError>
     where
-        S: for<'a> FromModifiedUtf8<'a> + Hash + Eq + Ord,
+        S: for<'a> FromModifiedUtf8<'a> + Hash + Ord,
     {
         let region_x = pos_x.div_euclid(32);
         let region_z = pos_z.div_euclid(32);
@@ -210,14 +210,14 @@ impl RegionFolder {
 
     /// Sets the raw chunk at the given position, overwriting the old chunk if
     /// it exists.
-    pub fn set_chunk<S: ToModifiedUtf8>(
+    pub fn set_chunk<S>(
         &mut self,
         pos_x: i32,
         pos_z: i32,
         chunk: &Compound<S>,
     ) -> Result<(), RegionError>
     where
-        S: Hash + Eq + Ord + Default,
+        S: ToModifiedUtf8 + Hash + Ord,
     {
         let region_x = pos_x.div_euclid(32);
         let region_z = pos_z.div_euclid(32);
@@ -435,7 +435,7 @@ impl Region {
         region_root: &Path,
     ) -> Result<Option<RawChunk<S>>, RegionError>
     where
-        S: for<'a> FromModifiedUtf8<'a> + Hash + Eq + Ord,
+        S: for<'a> FromModifiedUtf8<'a> + Hash + Ord,
     {
         let chunk_idx = Self::chunk_idx(pos_x, pos_z);
 
@@ -551,7 +551,7 @@ impl Region {
         Ok(true)
     }
 
-    fn set_chunk<S: ToModifiedUtf8>(
+    fn set_chunk<S>(
         &mut self,
         pos_x: i32,
         pos_z: i32,
@@ -561,7 +561,7 @@ impl Region {
         region_root: &Path,
     ) -> Result<(), RegionError>
     where
-        S: Hash + Eq + Ord + Default,
+        S: ToModifiedUtf8 + Hash + Ord,
     {
         // erase the chunk from allocated chunks (not from disk)
         self.delete_chunk(pos_x, pos_z, false, region_root)?;
@@ -573,16 +573,14 @@ impl Region {
             Compression::Gzip => valence_nbt::to_binary(
                 chunk,
                 GzEncoder::new(&mut compress_cursor, flate2::Compression::default()),
-                &S::default(),
+                "",
             )?,
             Compression::Zlib => valence_nbt::to_binary(
                 chunk,
                 ZlibEncoder::new(&mut compress_cursor, flate2::Compression::default()),
-                &S::default(),
+                "",
             )?,
-            Compression::None => {
-                valence_nbt::to_binary(chunk, &mut compress_cursor, &S::default())?
-            }
+            Compression::None => valence_nbt::to_binary(chunk, &mut compress_cursor, "")?,
         }
         let compress_buf = compress_cursor.into_inner();
 

--- a/crates/valence_anvil/src/lib.rs
+++ b/crates/valence_anvil/src/lib.rs
@@ -18,6 +18,7 @@
 )]
 
 use std::fs::{DirEntry, File};
+use std::hash::Hash;
 use std::io::{Cursor, ErrorKind, Read, Seek, SeekFrom, Write};
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
@@ -31,6 +32,7 @@ use flate2::bufread::{GzDecoder, ZlibDecoder};
 use flate2::write::{GzEncoder, ZlibEncoder};
 use lru::LruCache;
 use thiserror::Error;
+use valence_nbt::binary::{FromModifiedUtf8, ToModifiedUtf8};
 use valence_nbt::Compound;
 
 #[cfg(feature = "bevy_plugin")]
@@ -169,7 +171,14 @@ impl RegionFolder {
     /// loading it. Returns `Ok(None)` if the chunk does not exist and no
     /// errors occurred attempting to load it. Returns `Err(_)` if an error
     /// occurred attempting to load the chunk.
-    pub fn get_chunk(&mut self, pos_x: i32, pos_z: i32) -> Result<Option<RawChunk>, RegionError> {
+    pub fn get_chunk<S>(
+        &mut self,
+        pos_x: i32,
+        pos_z: i32,
+    ) -> Result<Option<RawChunk<S>>, RegionError>
+    where
+        S: for<'a> FromModifiedUtf8<'a> + Hash + Eq + Ord,
+    {
         let region_x = pos_x.div_euclid(32);
         let region_z = pos_z.div_euclid(32);
 
@@ -201,12 +210,15 @@ impl RegionFolder {
 
     /// Sets the raw chunk at the given position, overwriting the old chunk if
     /// it exists.
-    pub fn set_chunk(
+    pub fn set_chunk<S: ToModifiedUtf8>(
         &mut self,
         pos_x: i32,
         pos_z: i32,
-        chunk: &Compound,
-    ) -> Result<(), RegionError> {
+        chunk: &Compound<S>,
+    ) -> Result<(), RegionError>
+    where
+        S: Hash + Eq + Ord + Default,
+    {
         let region_x = pos_x.div_euclid(32);
         let region_z = pos_z.div_euclid(32);
 
@@ -312,8 +324,8 @@ impl RegionFolder {
 }
 
 /// A chunk represented by the raw compound data.
-pub struct RawChunk {
-    pub data: Compound,
+pub struct RawChunk<S = String> {
+    pub data: Compound<S>,
     pub timestamp: u32,
 }
 
@@ -415,13 +427,16 @@ impl Region {
         })
     }
 
-    fn get_chunk(
+    fn get_chunk<S>(
         &mut self,
         pos_x: i32,
         pos_z: i32,
         decompress_buf: &mut Vec<u8>,
         region_root: &Path,
-    ) -> Result<Option<RawChunk>, RegionError> {
+    ) -> Result<Option<RawChunk<S>>, RegionError>
+    where
+        S: for<'a> FromModifiedUtf8<'a> + Hash + Eq + Ord,
+    {
         let chunk_idx = Self::chunk_idx(pos_x, pos_z);
 
         let location = self.locations[chunk_idx];
@@ -536,15 +551,18 @@ impl Region {
         Ok(true)
     }
 
-    fn set_chunk(
+    fn set_chunk<S: ToModifiedUtf8>(
         &mut self,
         pos_x: i32,
         pos_z: i32,
-        chunk: &Compound,
+        chunk: &Compound<S>,
         options: WriteOptions,
         compress_buf: &mut Vec<u8>,
         region_root: &Path,
-    ) -> Result<(), RegionError> {
+    ) -> Result<(), RegionError>
+    where
+        S: Hash + Eq + Ord + Default,
+    {
         // erase the chunk from allocated chunks (not from disk)
         self.delete_chunk(pos_x, pos_z, false, region_root)?;
 
@@ -555,15 +573,15 @@ impl Region {
             Compression::Gzip => valence_nbt::to_binary(
                 chunk,
                 GzEncoder::new(&mut compress_cursor, flate2::Compression::default()),
-                &String::new(),
+                &S::default(),
             )?,
             Compression::Zlib => valence_nbt::to_binary(
                 chunk,
                 ZlibEncoder::new(&mut compress_cursor, flate2::Compression::default()),
-                &String::new(),
+                &S::default(),
             )?,
             Compression::None => {
-                valence_nbt::to_binary(chunk, &mut compress_cursor, &String::new())?
+                valence_nbt::to_binary(chunk, &mut compress_cursor, &S::default())?
             }
         }
         let compress_buf = compress_cursor.into_inner();

--- a/crates/valence_nbt/Cargo.toml
+++ b/crates/valence_nbt/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 
 [features]
 binary = ["dep:byteorder", "dep:cesu8"]
+java_string = ["dep:java_string"]
 snbt = []
 # When enabled, the order of fields in compounds are preserved.
 preserve_order = ["dep:indexmap"]
@@ -20,6 +21,7 @@ serde = ["dep:serde", "dep:thiserror", "indexmap?/serde"]
 byteorder = { workspace = true, optional = true }
 cesu8 = { workspace = true, optional = true }
 indexmap = { workspace = true, optional = true }
+java_string = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 thiserror = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }

--- a/crates/valence_nbt/src/binary.rs
+++ b/crates/valence_nbt/src/binary.rs
@@ -45,8 +45,8 @@ mod modified_utf8;
 #[cfg(test)]
 mod tests;
 
-pub use decode::from_binary;
-pub use encode::{to_binary, written_size};
+pub use decode::{from_binary, FromModifiedUtf8, FromModifiedUtf8Error};
+pub use encode::{to_binary, written_size, ToModifiedUtf8};
 pub use error::*;
 
 use crate::Tag;

--- a/crates/valence_nbt/src/binary.rs
+++ b/crates/valence_nbt/src/binary.rs
@@ -18,7 +18,7 @@
 //!
 //! let mut buf = vec![];
 //!
-//! to_binary(&c, &mut buf, "").unwrap();
+//! to_binary(&c, &mut buf, &String::new()).unwrap();
 //! ```
 //!
 //! Decode NBT data from its binary form.

--- a/crates/valence_nbt/src/binary.rs
+++ b/crates/valence_nbt/src/binary.rs
@@ -18,7 +18,7 @@
 //!
 //! let mut buf = vec![];
 //!
-//! to_binary(&c, &mut buf, &String::new()).unwrap();
+//! to_binary(&c, &mut buf, "").unwrap();
 //! ```
 //!
 //! Decode NBT data from its binary form.

--- a/crates/valence_nbt/src/binary/modified_utf8.rs
+++ b/crates/valence_nbt/src/binary/modified_utf8.rs
@@ -76,10 +76,9 @@ fn encode_surrogate(surrogate: u16) -> [u8; 3] {
     ]
 }
 
-pub(crate) fn encoded_len(text: &str) -> usize {
+pub(crate) fn encoded_len(bytes: &[u8]) -> usize {
     let mut n = 0;
     let mut i = 0;
-    let bytes = text.as_bytes();
 
     while i < bytes.len() {
         match bytes[i] {
@@ -119,7 +118,7 @@ fn equivalence() {
         write_modified_utf8(&mut ours, s).unwrap();
 
         assert_eq!(theirs, ours);
-        assert_eq!(theirs.len(), encoded_len(s));
+        assert_eq!(theirs.len(), encoded_len(s.as_bytes()));
     }
 
     check("Mary had a little lamb\0");

--- a/crates/valence_nbt/src/binary/tests.rs
+++ b/crates/valence_nbt/src/binary/tests.rs
@@ -10,7 +10,7 @@ fn round_trip() {
 
     let compound = example_compound();
 
-    to_binary(&compound, &mut buf, &ROOT_NAME.to_owned()).unwrap();
+    to_binary(&compound, &mut buf, ROOT_NAME).unwrap();
 
     println!("{buf:?}");
 
@@ -29,7 +29,7 @@ fn check_min_sizes() {
         let dbg = format!("{min_val:?}");
         let mut buf = vec![];
 
-        to_binary(&compound!("" => min_val), &mut buf, &String::new()).unwrap();
+        to_binary(&compound!("" => min_val), &mut buf, "").unwrap();
 
         assert_eq!(
             expected_size,
@@ -93,9 +93,9 @@ fn correct_length() {
     let c = example_compound();
 
     let mut buf = vec![];
-    to_binary(&c, &mut buf, &"abc".to_owned()).unwrap();
+    to_binary(&c, &mut buf, "abc").unwrap();
 
-    assert_eq!(written_size(&c, &"abc".to_owned()), buf.len());
+    assert_eq!(written_size(&c, "abc"), buf.len());
 }
 
 fn example_compound() -> Compound {

--- a/crates/valence_nbt/src/binary/tests.rs
+++ b/crates/valence_nbt/src/binary/tests.rs
@@ -10,7 +10,7 @@ fn round_trip() {
 
     let compound = example_compound();
 
-    to_binary(&compound, &mut buf, ROOT_NAME).unwrap();
+    to_binary(&compound, &mut buf, &ROOT_NAME.to_owned()).unwrap();
 
     println!("{buf:?}");
 
@@ -29,7 +29,7 @@ fn check_min_sizes() {
         let dbg = format!("{min_val:?}");
         let mut buf = vec![];
 
-        to_binary(&compound!("" => min_val), &mut buf, "").unwrap();
+        to_binary(&compound!("" => min_val), &mut buf, &String::new()).unwrap();
 
         assert_eq!(
             expected_size,
@@ -66,7 +66,7 @@ fn deeply_nested_compound_decode() {
     buf.push(Tag::End as u8); // End root compound
 
     // Should not overflow the stack
-    let _ = from_binary(&mut buf.as_slice());
+    let _ = from_binary::<String>(&mut buf.as_slice());
 }
 
 #[test]
@@ -85,7 +85,7 @@ fn deeply_nested_list_decode() {
     buf.push(Tag::End as u8); // End root compound
 
     // Should not overflow the stack
-    let _ = from_binary(&mut buf.as_slice());
+    let _ = from_binary::<String>(&mut buf.as_slice());
 }
 
 #[test]
@@ -93,9 +93,9 @@ fn correct_length() {
     let c = example_compound();
 
     let mut buf = vec![];
-    to_binary(&c, &mut buf, "abc").unwrap();
+    to_binary(&c, &mut buf, &"abc".to_owned()).unwrap();
 
-    assert_eq!(written_size(&c, "abc"), buf.len());
+    assert_eq!(written_size(&c, &"abc".to_owned()), buf.len());
 }
 
 fn example_compound() -> Compound {

--- a/crates/valence_nbt/src/compound.rs
+++ b/crates/valence_nbt/src/compound.rs
@@ -26,7 +26,7 @@ impl<S: fmt::Debug> fmt::Debug for Compound<S> {
 
 impl<S> PartialEq for Compound<S>
 where
-    S: Eq + Ord + Hash,
+    S: Ord + Hash,
 {
     fn eq(&self, other: &Self) -> bool {
         self.map == other.map
@@ -36,7 +36,7 @@ where
 #[cfg(feature = "serde")]
 impl<Str> serde::Serialize for Compound<Str>
 where
-    Str: Eq + Ord + Hash + serde::Serialize,
+    Str: Ord + Hash + serde::Serialize,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -49,7 +49,7 @@ where
 #[cfg(feature = "serde")]
 impl<'de, S> serde::Deserialize<'de> for Compound<S>
 where
-    S: Eq + Ord + Hash + serde::Deserialize<'de>,
+    S: Ord + Hash + serde::Deserialize<'de>,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -91,12 +91,12 @@ impl<S> Compound<S> {
 
 impl<S> Compound<S>
 where
-    S: Eq + Ord + Hash,
+    S: Ord + Hash,
 {
     pub fn get<Q>(&self, k: &Q) -> Option<&Value<S>>
     where
         Q: ?Sized + AsBorrowed<S>,
-        <Q as AsBorrowed<S>>::Borrowed: Hash + Eq + Ord,
+        <Q as AsBorrowed<S>>::Borrowed: Hash + Ord,
         S: Borrow<<Q as AsBorrowed<S>>::Borrowed>,
     {
         self.map.get(k.as_borrowed())
@@ -105,7 +105,7 @@ where
     pub fn contains_key<Q>(&self, k: &Q) -> bool
     where
         Q: ?Sized + AsBorrowed<S>,
-        <Q as AsBorrowed<S>>::Borrowed: Hash + Eq + Ord,
+        <Q as AsBorrowed<S>>::Borrowed: Hash + Ord,
         S: Borrow<<Q as AsBorrowed<S>>::Borrowed>,
     {
         self.map.contains_key(k.as_borrowed())
@@ -114,7 +114,7 @@ where
     pub fn get_mut<Q>(&mut self, k: &Q) -> Option<&mut Value<S>>
     where
         Q: ?Sized + AsBorrowed<S>,
-        <Q as AsBorrowed<S>>::Borrowed: Hash + Eq + Ord,
+        <Q as AsBorrowed<S>>::Borrowed: Hash + Ord,
         S: Borrow<<Q as AsBorrowed<S>>::Borrowed>,
     {
         self.map.get_mut(k.as_borrowed())
@@ -123,7 +123,7 @@ where
     pub fn get_key_value<Q>(&self, k: &Q) -> Option<(&S, &Value<S>)>
     where
         Q: ?Sized + AsBorrowed<S>,
-        <Q as AsBorrowed<S>>::Borrowed: Hash + Eq + Ord,
+        <Q as AsBorrowed<S>>::Borrowed: Hash + Ord,
         S: Borrow<<Q as AsBorrowed<S>>::Borrowed>,
     {
         self.map.get_key_value(k.as_borrowed())
@@ -140,7 +140,7 @@ where
     pub fn remove<Q>(&mut self, k: &Q) -> Option<Value<S>>
     where
         Q: ?Sized + AsBorrowed<S>,
-        <Q as AsBorrowed<S>>::Borrowed: Hash + Eq + Ord,
+        <Q as AsBorrowed<S>>::Borrowed: Hash + Ord,
         S: Borrow<<Q as AsBorrowed<S>>::Borrowed>,
     {
         self.map.remove(k.as_borrowed())
@@ -149,7 +149,7 @@ where
     pub fn remove_entry<Q>(&mut self, k: &Q) -> Option<(S, Value<S>)>
     where
         S: Borrow<Q>,
-        Q: ?Sized + Eq + Ord + Hash,
+        Q: ?Sized + Ord + Hash,
     {
         self.map.remove_entry(k)
     }
@@ -337,7 +337,7 @@ where
 
 impl<S> Extend<(S, Value<S>)> for Compound<S>
 where
-    S: Eq + Ord + Hash,
+    S: Ord + Hash,
 {
     fn extend<T>(&mut self, iter: T)
     where
@@ -349,7 +349,7 @@ where
 
 impl<S> FromIterator<(S, Value<S>)> for Compound<S>
 where
-    S: Eq + Ord + Hash,
+    S: Ord + Hash,
 {
     fn from_iter<T>(iter: T) -> Self
     where
@@ -368,7 +368,7 @@ pub enum Entry<'a, S = String> {
 
 impl<'a, S> Entry<'a, S>
 where
-    S: Eq + Hash + Ord,
+    S: Hash + Ord,
 {
     pub fn key(&self) -> &S {
         match self {
@@ -418,7 +418,7 @@ pub struct VacantEntry<'a, S = String> {
 
 impl<'a, S> VacantEntry<'a, S>
 where
-    S: Eq + Ord + Hash,
+    S: Ord + Hash,
 {
     pub fn key(&self) -> &S {
         self.ve.key()
@@ -438,7 +438,7 @@ pub struct OccupiedEntry<'a, S = String> {
 
 impl<'a, S> OccupiedEntry<'a, S>
 where
-    S: Eq + Hash + Ord,
+    S: Hash + Ord,
 {
     pub fn key(&self) -> &S {
         self.oe.key()
@@ -467,8 +467,8 @@ where
 
 impl<S, Q> Index<&'_ Q> for Compound<S>
 where
-    S: Borrow<Q> + Eq + Ord + Hash,
-    Q: ?Sized + Eq + Ord + Hash,
+    S: Borrow<Q> + Ord + Hash,
+    Q: ?Sized + Ord + Hash,
 {
     type Output = Value<S>;
 
@@ -479,8 +479,8 @@ where
 
 impl<S, Q> IndexMut<&'_ Q> for Compound<S>
 where
-    S: Borrow<Q> + Eq + Hash + Ord,
-    Q: ?Sized + Eq + Ord + Hash,
+    S: Borrow<Q> + Hash + Ord,
+    Q: ?Sized + Ord + Hash,
 {
     fn index_mut(&mut self, index: &Q) -> &mut Self::Output {
         self.map.get_mut(index).expect("no entry found for key")

--- a/crates/valence_nbt/src/compound.rs
+++ b/crates/valence_nbt/src/compound.rs
@@ -279,8 +279,8 @@ where
     }
 }
 
-/// Trait that can be used as a key to query a compound. Basically something that can be converted
-/// to a type `B` such that `S: Borrow<B>`.
+/// Trait that can be used as a key to query a compound. Basically something
+/// that can be converted to a type `B` such that `S: Borrow<B>`.
 pub trait AsBorrowed<S> {
     type Borrowed: ?Sized;
 

--- a/crates/valence_nbt/src/compound.rs
+++ b/crates/valence_nbt/src/compound.rs
@@ -274,6 +274,57 @@ where
     }
 }
 
+#[cfg(feature = "java_string")]
+impl Compound<java_string::JavaString> {
+    pub fn jget<'a, Q>(&self, k: Q) -> Option<&Value<java_string::JavaString>>
+    where
+        Q: Into<&'a java_string::JavaStr>,
+    {
+        self.get(k.into())
+    }
+
+    pub fn jcontains_key<'a, Q>(&self, k: Q) -> bool
+    where
+        Q: Into<&'a java_string::JavaStr>,
+    {
+        self.contains_key(k.into())
+    }
+
+    pub fn jget_mut<'a, Q>(&mut self, k: Q) -> Option<&mut Value<java_string::JavaString>>
+    where
+        Q: Into<&'a java_string::JavaStr>,
+    {
+        self.get_mut(k.into())
+    }
+
+    pub fn jget_key_value<'a, Q>(
+        &self,
+        k: Q,
+    ) -> Option<(&java_string::JavaString, &Value<java_string::JavaString>)>
+    where
+        Q: Into<&'a java_string::JavaStr>,
+    {
+        self.get_key_value(k.into())
+    }
+
+    pub fn jremove<'a, Q>(&mut self, k: Q) -> Option<Value<java_string::JavaString>>
+    where
+        Q: Into<&'a java_string::JavaStr>,
+    {
+        self.remove(k.into())
+    }
+
+    pub fn jremove_entry<'a, Q>(
+        &mut self,
+        k: Q,
+    ) -> Option<(java_string::JavaString, Value<java_string::JavaString>)>
+    where
+        Q: Into<&'a java_string::JavaStr>,
+    {
+        self.remove_entry(k.into())
+    }
+}
+
 impl<S> Extend<(S, Value<S>)> for Compound<S>
 where
     S: Eq + Ord + Hash,

--- a/crates/valence_nbt/src/compound.rs
+++ b/crates/valence_nbt/src/compound.rs
@@ -7,29 +7,66 @@ use std::ops::{Index, IndexMut};
 use crate::Value;
 
 /// A map type with [`String`] keys and [`Value`] values.
-#[derive(Clone, PartialEq, Default)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(transparent)
-)]
-pub struct Compound {
-    map: Map,
+#[derive(Clone, Default)]
+pub struct Compound<S = String> {
+    map: Map<S>,
 }
 
 #[cfg(not(feature = "preserve_order"))]
-type Map = std::collections::BTreeMap<String, Value>;
+type Map<S> = std::collections::BTreeMap<S, Value<S>>;
 
 #[cfg(feature = "preserve_order")]
-type Map = indexmap::IndexMap<String, Value>;
+type Map<S> = indexmap::IndexMap<S, Value<S>>;
 
-impl fmt::Debug for Compound {
+impl<S: fmt::Debug> fmt::Debug for Compound<S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.map.fmt(f)
     }
 }
 
-impl Compound {
+impl<S> PartialEq for Compound<S>
+where
+    S: Eq + Ord + Hash,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.map == other.map
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<Str> serde::Serialize for Compound<Str>
+where
+    Str: Eq + Ord + Hash + serde::Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.map.serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, S> serde::Deserialize<'de> for Compound<S>
+where
+    S: Eq + Ord + Hash + serde::Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Map::<S>::deserialize(deserializer).map(|map| Self { map })
+    }
+
+    fn deserialize_in_place<D>(deserializer: D, place: &mut Self) -> Result<(), D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Map::<S>::deserialize_in_place(deserializer, &mut place.map)
+    }
+}
+
+impl<S> Compound<S> {
     pub fn new() -> Self {
         Self { map: Map::new() }
     }
@@ -50,10 +87,15 @@ impl Compound {
     pub fn clear(&mut self) {
         self.map.clear();
     }
+}
 
-    pub fn get<Q>(&self, k: &Q) -> Option<&Value>
+impl<S> Compound<S>
+where
+    S: Eq + Ord + Hash,
+{
+    pub fn get<Q>(&self, k: &Q) -> Option<&Value<S>>
     where
-        String: Borrow<Q>,
+        S: Borrow<Q>,
         Q: ?Sized + Eq + Ord + Hash,
     {
         self.map.get(k)
@@ -61,47 +103,47 @@ impl Compound {
 
     pub fn contains_key<Q>(&self, k: &Q) -> bool
     where
-        String: Borrow<Q>,
+        S: Borrow<Q>,
         Q: ?Sized + Eq + Ord + Hash,
     {
         self.map.contains_key(k)
     }
 
-    pub fn get_mut<Q>(&mut self, k: &Q) -> Option<&mut Value>
+    pub fn get_mut<Q>(&mut self, k: &Q) -> Option<&mut Value<S>>
     where
-        String: Borrow<Q>,
+        S: Borrow<Q>,
         Q: ?Sized + Eq + Ord + Hash,
     {
         self.map.get_mut(k)
     }
 
-    pub fn get_key_value<Q>(&self, k: &Q) -> Option<(&String, &Value)>
+    pub fn get_key_value<Q>(&self, k: &Q) -> Option<(&S, &Value<S>)>
     where
-        String: Borrow<Q>,
+        S: Borrow<Q>,
         Q: ?Sized + Eq + Ord + Hash,
     {
         self.map.get_key_value(k)
     }
 
-    pub fn insert<K, V>(&mut self, k: K, v: V) -> Option<Value>
+    pub fn insert<K, V>(&mut self, k: K, v: V) -> Option<Value<S>>
     where
-        K: Into<String>,
-        V: Into<Value>,
+        K: Into<S>,
+        V: Into<Value<S>>,
     {
         self.map.insert(k.into(), v.into())
     }
 
-    pub fn remove<Q>(&mut self, k: &Q) -> Option<Value>
+    pub fn remove<Q>(&mut self, k: &Q) -> Option<Value<S>>
     where
-        String: Borrow<Q>,
+        S: Borrow<Q>,
         Q: ?Sized + Eq + Ord + Hash,
     {
         self.map.remove(k)
     }
 
-    pub fn remove_entry<Q>(&mut self, k: &Q) -> Option<(String, Value)>
+    pub fn remove_entry<Q>(&mut self, k: &Q) -> Option<(S, Value<S>)>
     where
-        String: Borrow<Q>,
+        S: Borrow<Q>,
         Q: ?Sized + Eq + Ord + Hash,
     {
         self.map.remove_entry(k)
@@ -117,9 +159,9 @@ impl Compound {
         }
     }
 
-    pub fn entry<K>(&mut self, k: K) -> Entry
+    pub fn entry<K>(&mut self, k: K) -> Entry<S>
     where
-        K: Into<String>,
+        K: Into<S>,
     {
         #[cfg(not(feature = "preserve_order"))]
         use std::collections::btree_map::Entry as EntryImpl;
@@ -141,31 +183,31 @@ impl Compound {
         self.map.is_empty()
     }
 
-    pub fn iter(&self) -> Iter {
+    pub fn iter(&self) -> Iter<S> {
         Iter {
             iter: self.map.iter(),
         }
     }
 
-    pub fn iter_mut(&mut self) -> IterMut {
+    pub fn iter_mut(&mut self) -> IterMut<S> {
         IterMut {
             iter: self.map.iter_mut(),
         }
     }
 
-    pub fn keys(&self) -> Keys {
+    pub fn keys(&self) -> Keys<S> {
         Keys {
             iter: self.map.keys(),
         }
     }
 
-    pub fn values(&self) -> Values {
+    pub fn values(&self) -> Values<S> {
         Values {
             iter: self.map.values(),
         }
     }
 
-    pub fn values_mut(&mut self) -> ValuesMut {
+    pub fn values_mut(&mut self) -> ValuesMut<S> {
         ValuesMut {
             iter: self.map.values_mut(),
         }
@@ -173,7 +215,7 @@ impl Compound {
 
     pub fn retain<F>(&mut self, f: F)
     where
-        F: FnMut(&String, &mut Value) -> bool,
+        F: FnMut(&S, &mut Value<S>) -> bool,
     {
         self.map.retain(f)
     }
@@ -212,7 +254,7 @@ impl Compound {
     ///     }
     /// );
     /// ```
-    pub fn merge(&mut self, other: Compound) {
+    pub fn merge(&mut self, other: Compound<S>) {
         for (k, v) in other {
             match (self.entry(k), v) {
                 (Entry::Occupied(mut oe), Value::Compound(other)) => {
@@ -232,19 +274,25 @@ impl Compound {
     }
 }
 
-impl Extend<(String, Value)> for Compound {
+impl<S> Extend<(S, Value<S>)> for Compound<S>
+where
+    S: Eq + Ord + Hash,
+{
     fn extend<T>(&mut self, iter: T)
     where
-        T: IntoIterator<Item = (String, Value)>,
+        T: IntoIterator<Item = (S, Value<S>)>,
     {
         self.map.extend(iter)
     }
 }
 
-impl FromIterator<(String, Value)> for Compound {
+impl<S> FromIterator<(S, Value<S>)> for Compound<S>
+where
+    S: Eq + Ord + Hash,
+{
     fn from_iter<T>(iter: T) -> Self
     where
-        T: IntoIterator<Item = (String, Value)>,
+        T: IntoIterator<Item = (S, Value<S>)>,
     {
         Self {
             map: Map::from_iter(iter),
@@ -252,30 +300,33 @@ impl FromIterator<(String, Value)> for Compound {
     }
 }
 
-pub enum Entry<'a> {
-    Vacant(VacantEntry<'a>),
-    Occupied(OccupiedEntry<'a>),
+pub enum Entry<'a, S = String> {
+    Vacant(VacantEntry<'a, S>),
+    Occupied(OccupiedEntry<'a, S>),
 }
 
-impl<'a> Entry<'a> {
-    pub fn key(&self) -> &String {
+impl<'a, S> Entry<'a, S>
+where
+    S: Eq + Hash + Ord,
+{
+    pub fn key(&self) -> &S {
         match self {
             Entry::Vacant(ve) => ve.key(),
             Entry::Occupied(oe) => oe.key(),
         }
     }
 
-    pub fn or_insert(self, default: impl Into<Value>) -> &'a mut Value {
+    pub fn or_insert(self, default: impl Into<Value<S>>) -> &'a mut Value<S> {
         match self {
             Entry::Vacant(ve) => ve.insert(default),
             Entry::Occupied(oe) => oe.into_mut(),
         }
     }
 
-    pub fn or_insert_with<F, V>(self, default: F) -> &'a mut Value
+    pub fn or_insert_with<F, V>(self, default: F) -> &'a mut Value<S>
     where
         F: FnOnce() -> V,
-        V: Into<Value>,
+        V: Into<Value<S>>,
     {
         match self {
             Entry::Vacant(ve) => ve.insert(default()),
@@ -285,7 +336,7 @@ impl<'a> Entry<'a> {
 
     pub fn and_modify<F>(self, f: F) -> Self
     where
-        F: FnOnce(&mut Value),
+        F: FnOnce(&mut Value<S>),
     {
         match self {
             Entry::Vacant(ve) => Entry::Vacant(ve),
@@ -297,71 +348,77 @@ impl<'a> Entry<'a> {
     }
 }
 
-pub struct VacantEntry<'a> {
+pub struct VacantEntry<'a, S = String> {
     #[cfg(not(feature = "preserve_order"))]
-    ve: std::collections::btree_map::VacantEntry<'a, String, Value>,
+    ve: std::collections::btree_map::VacantEntry<'a, S, Value<S>>,
     #[cfg(feature = "preserve_order")]
-    ve: indexmap::map::VacantEntry<'a, String, Value>,
+    ve: indexmap::map::VacantEntry<'a, S, Value<S>>,
 }
 
-impl<'a> VacantEntry<'a> {
-    pub fn key(&self) -> &String {
+impl<'a, S> VacantEntry<'a, S>
+where
+    S: Eq + Ord + Hash,
+{
+    pub fn key(&self) -> &S {
         self.ve.key()
     }
 
-    pub fn insert(self, v: impl Into<Value>) -> &'a mut Value {
+    pub fn insert(self, v: impl Into<Value<S>>) -> &'a mut Value<S> {
         self.ve.insert(v.into())
     }
 }
 
-pub struct OccupiedEntry<'a> {
+pub struct OccupiedEntry<'a, S = String> {
     #[cfg(not(feature = "preserve_order"))]
-    oe: std::collections::btree_map::OccupiedEntry<'a, String, Value>,
+    oe: std::collections::btree_map::OccupiedEntry<'a, S, Value<S>>,
     #[cfg(feature = "preserve_order")]
-    oe: indexmap::map::OccupiedEntry<'a, String, Value>,
+    oe: indexmap::map::OccupiedEntry<'a, S, Value<S>>,
 }
 
-impl<'a> OccupiedEntry<'a> {
-    pub fn key(&self) -> &String {
+impl<'a, S> OccupiedEntry<'a, S>
+where
+    S: Eq + Hash + Ord,
+{
+    pub fn key(&self) -> &S {
         self.oe.key()
     }
 
-    pub fn get(&self) -> &Value {
+    pub fn get(&self) -> &Value<S> {
         self.oe.get()
     }
 
-    pub fn get_mut(&mut self) -> &mut Value {
+    pub fn get_mut(&mut self) -> &mut Value<S> {
         self.oe.get_mut()
     }
 
-    pub fn into_mut(self) -> &'a mut Value {
+    pub fn into_mut(self) -> &'a mut Value<S> {
         self.oe.into_mut()
     }
 
-    pub fn insert(&mut self, v: impl Into<Value>) -> Value {
+    pub fn insert(&mut self, v: impl Into<Value<S>>) -> Value<S> {
         self.oe.insert(v.into())
     }
 
-    pub fn remove(self) -> Value {
+    pub fn remove(self) -> Value<S> {
         self.oe.remove()
     }
 }
 
-impl<Q> Index<&'_ Q> for Compound
+impl<S, Q> Index<&'_ Q> for Compound<S>
 where
-    String: Borrow<Q>,
+    S: Borrow<Q> + Eq + Ord + Hash,
     Q: ?Sized + Eq + Ord + Hash,
 {
-    type Output = Value;
+    type Output = Value<S>;
 
     fn index(&self, index: &Q) -> &Self::Output {
         self.map.index(index)
     }
 }
 
-impl<Q> IndexMut<&'_ Q> for Compound
+impl<S, Q> IndexMut<&'_ Q> for Compound<S>
 where
-    String: Borrow<Q>,
+    S: Borrow<Q> + Eq + Hash + Ord,
     Q: ?Sized + Eq + Ord + Hash,
 {
     fn index_mut(&mut self, index: &Q) -> &mut Self::Output {
@@ -402,9 +459,9 @@ macro_rules! impl_iterator_traits {
     }
 }
 
-impl<'a> IntoIterator for &'a Compound {
-    type Item = (&'a String, &'a Value);
-    type IntoIter = Iter<'a>;
+impl<'a, S> IntoIterator for &'a Compound<S> {
+    type Item = (&'a S, &'a Value<S>);
+    type IntoIter = Iter<'a, S>;
 
     fn into_iter(self) -> Self::IntoIter {
         Iter {
@@ -414,18 +471,18 @@ impl<'a> IntoIterator for &'a Compound {
 }
 
 #[derive(Clone)]
-pub struct Iter<'a> {
+pub struct Iter<'a, S = String> {
     #[cfg(not(feature = "preserve_order"))]
-    iter: std::collections::btree_map::Iter<'a, String, Value>,
+    iter: std::collections::btree_map::Iter<'a, S, Value<S>>,
     #[cfg(feature = "preserve_order")]
-    iter: indexmap::map::Iter<'a, String, Value>,
+    iter: indexmap::map::Iter<'a, S, Value<S>>,
 }
 
-impl_iterator_traits!((Iter<'a>) => (&'a String, &'a Value));
+impl_iterator_traits!((Iter<'a, S>) => (&'a S, &'a Value<S>));
 
-impl<'a> IntoIterator for &'a mut Compound {
-    type Item = (&'a String, &'a mut Value);
-    type IntoIter = IterMut<'a>;
+impl<'a, S> IntoIterator for &'a mut Compound<S> {
+    type Item = (&'a S, &'a mut Value<S>);
+    type IntoIter = IterMut<'a, S>;
 
     fn into_iter(self) -> Self::IntoIter {
         IterMut {
@@ -434,18 +491,18 @@ impl<'a> IntoIterator for &'a mut Compound {
     }
 }
 
-pub struct IterMut<'a> {
+pub struct IterMut<'a, S = String> {
     #[cfg(not(feature = "preserve_order"))]
-    iter: std::collections::btree_map::IterMut<'a, String, Value>,
+    iter: std::collections::btree_map::IterMut<'a, S, Value<S>>,
     #[cfg(feature = "preserve_order")]
-    iter: indexmap::map::IterMut<'a, String, Value>,
+    iter: indexmap::map::IterMut<'a, S, Value<S>>,
 }
 
-impl_iterator_traits!((IterMut<'a>) => (&'a String, &'a mut Value));
+impl_iterator_traits!((IterMut<'a, S>) => (&'a S, &'a mut Value<S>));
 
-impl IntoIterator for Compound {
-    type Item = (String, Value);
-    type IntoIter = IntoIter;
+impl<S> IntoIterator for Compound<S> {
+    type Item = (S, Value<S>);
+    type IntoIter = IntoIter<S>;
 
     fn into_iter(self) -> Self::IntoIter {
         IntoIter {
@@ -454,43 +511,43 @@ impl IntoIterator for Compound {
     }
 }
 
-pub struct IntoIter {
+pub struct IntoIter<S = String> {
     #[cfg(not(feature = "preserve_order"))]
-    iter: std::collections::btree_map::IntoIter<String, Value>,
+    iter: std::collections::btree_map::IntoIter<S, Value<S>>,
     #[cfg(feature = "preserve_order")]
-    iter: indexmap::map::IntoIter<String, Value>,
+    iter: indexmap::map::IntoIter<S, Value<S>>,
 }
 
-impl_iterator_traits!((IntoIter) => (String, Value));
+impl_iterator_traits!((IntoIter<S>) => (S, Value<S>));
 
 #[derive(Clone)]
-pub struct Keys<'a> {
+pub struct Keys<'a, S = String> {
     #[cfg(not(feature = "preserve_order"))]
-    iter: std::collections::btree_map::Keys<'a, String, Value>,
+    iter: std::collections::btree_map::Keys<'a, S, Value<S>>,
     #[cfg(feature = "preserve_order")]
-    iter: indexmap::map::Keys<'a, String, Value>,
+    iter: indexmap::map::Keys<'a, S, Value<S>>,
 }
 
-impl_iterator_traits!((Keys<'a>) => &'a String);
+impl_iterator_traits!((Keys<'a, S>) => &'a S);
 
 #[derive(Clone)]
-pub struct Values<'a> {
+pub struct Values<'a, S = String> {
     #[cfg(not(feature = "preserve_order"))]
-    iter: std::collections::btree_map::Values<'a, String, Value>,
+    iter: std::collections::btree_map::Values<'a, S, Value<S>>,
     #[cfg(feature = "preserve_order")]
-    iter: indexmap::map::Values<'a, String, Value>,
+    iter: indexmap::map::Values<'a, S, Value<S>>,
 }
 
-impl_iterator_traits!((Values<'a>) => &'a Value);
+impl_iterator_traits!((Values<'a, S>) => &'a Value<S>);
 
-pub struct ValuesMut<'a> {
+pub struct ValuesMut<'a, S = String> {
     #[cfg(not(feature = "preserve_order"))]
-    iter: std::collections::btree_map::ValuesMut<'a, String, Value>,
+    iter: std::collections::btree_map::ValuesMut<'a, S, Value<S>>,
     #[cfg(feature = "preserve_order")]
-    iter: indexmap::map::ValuesMut<'a, String, Value>,
+    iter: indexmap::map::ValuesMut<'a, S, Value<S>>,
 }
 
-impl_iterator_traits!((ValuesMut<'a>) => &'a mut Value);
+impl_iterator_traits!((ValuesMut<'a, S>) => &'a mut Value<S>);
 
 #[cfg(test)]
 mod tests {
@@ -501,7 +558,7 @@ mod tests {
 
         let letters = ["g", "b", "d", "e", "h", "z", "m", "a", "q"];
 
-        let mut c = Compound::new();
+        let mut c = Compound::<String>::new();
         for l in letters {
             c.insert(l, 0_i8);
         }

--- a/crates/valence_nbt/src/lib.rs
+++ b/crates/valence_nbt/src/lib.rs
@@ -67,16 +67,44 @@ pub mod value;
 ///
 /// println!("{c:?}");
 /// ```
+///
+/// It is also possible to specify a custom string type like this:
+/// ```
+/// # use std::borrow::Cow;
+///
+/// use valence_nbt::compound;
+///
+/// let c = compound! { <Cow<str>>
+///     "foo" => 123_i8,
+/// };
+///
+/// println!("{c:?}");
+/// ```
 #[macro_export]
 macro_rules! compound {
-    ($($key:expr => $value:expr),* $(,)?) => {
-        <$crate::Compound as ::std::iter::FromIterator<(::std::string::String, $crate::Value)>>::from_iter([
+    (<$string_type:ty> $($key:expr => $value:expr),* $(,)?) => {
+        <$crate::Compound<$string_type> as ::std::iter::FromIterator<($string_type, $crate::Value<$string_type>)>>::from_iter([
             $(
                 (
-                    ::std::convert::Into::<::std::string::String>::into($key),
-                    ::std::convert::Into::<$crate::Value>::into($value)
+                    ::std::convert::Into::<$string_type>::into($key),
+                    ::std::convert::Into::<$crate::Value<$string_type>>::into($value)
                 ),
             )*
         ])
+    };
+
+    ($($key:expr => $value:expr),* $(,)?) => {
+        compound!(<::std::string::String> $($key => $value),*)
+    };
+}
+
+/// A convenience macro for constructing [`Compound`]`<`[`JavaString`]`>`s
+///
+/// [`JavaString`]: java_string::JavaString
+#[cfg(feature = "java_string")]
+#[macro_export]
+macro_rules! jcompound {
+    ($($key:expr => $value:expr),*, $(,)?) => {
+        compound!(<::java_string::JavaString> $($key => $value),*)
     }
 }

--- a/crates/valence_nbt/src/list.rs
+++ b/crates/valence_nbt/src/list.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::hash::Hash;
 use std::iter::FusedIterator;
 
@@ -553,9 +554,22 @@ impl From<Vec<String>> for List<String> {
     }
 }
 
+impl<'a> From<Vec<Cow<'a, str>>> for List<Cow<'a, str>> {
+    fn from(v: Vec<Cow<'a, str>>) -> Self {
+        List::String(v)
+    }
+}
+
 #[cfg(feature = "java_string")]
 impl From<Vec<java_string::JavaString>> for List<java_string::JavaString> {
     fn from(v: Vec<java_string::JavaString>) -> Self {
+        List::String(v)
+    }
+}
+
+#[cfg(feature = "java_string")]
+impl<'a> From<Vec<Cow<'a, java_string::JavaStr>>> for List<Cow<'a, java_string::JavaStr>> {
+    fn from(v: Vec<Cow<'a, java_string::JavaStr>>) -> Self {
         List::String(v)
     }
 }

--- a/crates/valence_nbt/src/list.rs
+++ b/crates/valence_nbt/src/list.rs
@@ -553,6 +553,13 @@ impl From<Vec<String>> for List<String> {
     }
 }
 
+#[cfg(feature = "java_string")]
+impl From<Vec<java_string::JavaString>> for List<java_string::JavaString> {
+    fn from(v: Vec<java_string::JavaString>) -> Self {
+        List::String(v)
+    }
+}
+
 impl<S> From<Vec<List<S>>> for List<S> {
     fn from(v: Vec<List<S>>) -> Self {
         List::List(v)

--- a/crates/valence_nbt/src/list.rs
+++ b/crates/valence_nbt/src/list.rs
@@ -38,7 +38,7 @@ pub enum List<S = String> {
 
 impl<S> PartialEq for List<S>
 where
-    S: Eq + Ord + Hash,
+    S: Ord + Hash,
 {
     fn eq(&self, other: &Self) -> bool {
         match self {

--- a/crates/valence_nbt/src/serde/de.rs
+++ b/crates/valence_nbt/src/serde/de.rs
@@ -15,7 +15,7 @@ use crate::{Compound, List, Value};
 
 impl<'de, S> Deserialize<'de> for Value<S>
 where
-    S: Deserialize<'de> + Eq + Ord + Hash,
+    S: Deserialize<'de> + Ord + Hash,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -25,7 +25,7 @@ where
 
         impl<'de, S> Visitor<'de> for ValueVisitor<S>
         where
-            S: Deserialize<'de> + Eq + Ord + Hash,
+            S: Deserialize<'de> + Ord + Hash,
         {
             type Value = Value<S>;
 
@@ -159,7 +159,7 @@ where
 
 impl<'de, S> Deserialize<'de> for List<S>
 where
-    S: Deserialize<'de> + Eq + Ord + Hash,
+    S: Deserialize<'de> + Ord + Hash,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -169,7 +169,7 @@ where
 
         impl<'de, S> Visitor<'de> for ListVisitor<S>
         where
-            S: Deserialize<'de> + Eq + Ord + Hash,
+            S: Deserialize<'de> + Ord + Hash,
         {
             type Value = List<S>;
 
@@ -229,7 +229,7 @@ fn deserialize_seq_remainder<'de, T, A, S, C>(
 where
     T: Deserialize<'de>,
     A: de::SeqAccess<'de>,
-    C: Fn(Vec<T>) -> List<S>,
+    C: FnOnce(Vec<T>) -> List<S>,
 {
     let mut vec = match seq.size_hint() {
         Some(n) => Vec::with_capacity(n + 1),

--- a/crates/valence_nbt/src/serde/de.rs
+++ b/crates/valence_nbt/src/serde/de.rs
@@ -1,6 +1,11 @@
 use std::fmt;
+use std::hash::Hash;
+use std::marker::PhantomData;
 
-use serde::de::value::{MapAccessDeserializer, MapDeserializer, SeqAccessDeserializer};
+use serde::de::value::{
+    MapAccessDeserializer, MapDeserializer, SeqAccessDeserializer, StrDeserializer,
+    StringDeserializer,
+};
 use serde::de::{self, IntoDeserializer, SeqAccess, Visitor};
 use serde::{forward_to_deserialize_any, Deserialize, Deserializer};
 
@@ -8,15 +13,21 @@ use super::Error;
 use crate::conv::{i8_vec_into_u8_vec, u8_slice_as_i8_slice, u8_vec_into_i8_vec};
 use crate::{Compound, List, Value};
 
-impl<'de> Deserialize<'de> for Value {
+impl<'de, S> Deserialize<'de> for Value<S>
+where
+    S: Deserialize<'de> + Eq + Ord + Hash,
+{
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        struct ValueVisitor;
+        struct ValueVisitor<S>(PhantomData<S>);
 
-        impl<'de> Visitor<'de> for ValueVisitor {
-            type Value = Value;
+        impl<'de, S> Visitor<'de> for ValueVisitor<S>
+        where
+            S: Deserialize<'de> + Eq + Ord + Hash,
+        {
+            type Value = Value<S>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 write!(formatter, "a valid NBT type")
@@ -103,14 +114,14 @@ impl<'de> Deserialize<'de> for Value {
             where
                 E: de::Error,
             {
-                Ok(Value::String(v.into()))
+                S::deserialize(StrDeserializer::new(v)).map(Value::String)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
             where
                 E: de::Error,
             {
-                Ok(Value::String(v))
+                S::deserialize(StringDeserializer::new(v)).map(Value::String)
             }
 
             fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
@@ -142,19 +153,25 @@ impl<'de> Deserialize<'de> for Value {
             }
         }
 
-        deserializer.deserialize_any(ValueVisitor)
+        deserializer.deserialize_any(ValueVisitor::<S>(PhantomData))
     }
 }
 
-impl<'de> Deserialize<'de> for List {
+impl<'de, S> Deserialize<'de> for List<S>
+where
+    S: Deserialize<'de> + Eq + Ord + Hash,
+{
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        struct ListVisitor;
+        struct ListVisitor<S>(PhantomData<S>);
 
-        impl<'de> Visitor<'de> for ListVisitor {
-            type Value = List;
+        impl<'de, S> Visitor<'de> for ListVisitor<S>
+        where
+            S: Deserialize<'de> + Eq + Ord + Hash,
+        {
+            type Value = List<S>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 write!(formatter, "a sequence or bytes")
@@ -164,20 +181,20 @@ impl<'de> Deserialize<'de> for List {
             where
                 A: de::SeqAccess<'de>,
             {
-                match seq.next_element::<Value>()? {
+                match seq.next_element::<Value<S>>()? {
                     Some(v) => match v {
-                        Value::Byte(v) => deserialize_seq_remainder(v, seq),
-                        Value::Short(v) => deserialize_seq_remainder(v, seq),
-                        Value::Int(v) => deserialize_seq_remainder(v, seq),
-                        Value::Long(v) => deserialize_seq_remainder(v, seq),
-                        Value::Float(v) => deserialize_seq_remainder(v, seq),
-                        Value::Double(v) => deserialize_seq_remainder(v, seq),
-                        Value::ByteArray(v) => deserialize_seq_remainder(v, seq),
-                        Value::String(v) => deserialize_seq_remainder(v, seq),
-                        Value::List(v) => deserialize_seq_remainder(v, seq),
-                        Value::Compound(v) => deserialize_seq_remainder(v, seq),
-                        Value::IntArray(v) => deserialize_seq_remainder(v, seq),
-                        Value::LongArray(v) => deserialize_seq_remainder(v, seq),
+                        Value::Byte(v) => deserialize_seq_remainder(v, seq, From::from),
+                        Value::Short(v) => deserialize_seq_remainder(v, seq, From::from),
+                        Value::Int(v) => deserialize_seq_remainder(v, seq, From::from),
+                        Value::Long(v) => deserialize_seq_remainder(v, seq, From::from),
+                        Value::Float(v) => deserialize_seq_remainder(v, seq, From::from),
+                        Value::Double(v) => deserialize_seq_remainder(v, seq, From::from),
+                        Value::ByteArray(v) => deserialize_seq_remainder(v, seq, From::from),
+                        Value::String(v) => deserialize_seq_remainder(v, seq, List::String),
+                        Value::List(v) => deserialize_seq_remainder(v, seq, From::from),
+                        Value::Compound(v) => deserialize_seq_remainder(v, seq, From::from),
+                        Value::IntArray(v) => deserialize_seq_remainder(v, seq, From::from),
+                        Value::LongArray(v) => deserialize_seq_remainder(v, seq, From::from),
                     },
                     None => Ok(List::End),
                 }
@@ -198,17 +215,21 @@ impl<'de> Deserialize<'de> for List {
             }
         }
 
-        deserializer.deserialize_seq(ListVisitor)
+        deserializer.deserialize_seq(ListVisitor::<S>(PhantomData))
     }
 }
 
 /// Deserializes the remainder of a sequence after having
 /// determined the type of the first element.
-fn deserialize_seq_remainder<'de, T, A, R>(first: T, mut seq: A) -> Result<R, A::Error>
+fn deserialize_seq_remainder<'de, T, A, S, C>(
+    first: T,
+    mut seq: A,
+    conv: C,
+) -> Result<List<S>, A::Error>
 where
     T: Deserialize<'de>,
-    Vec<T>: Into<R>,
     A: de::SeqAccess<'de>,
+    C: Fn(Vec<T>) -> List<S>,
 {
     let mut vec = match seq.size_hint() {
         Some(n) => Vec::with_capacity(n + 1),
@@ -221,7 +242,7 @@ where
         vec.push(v);
     }
 
-    Ok(vec.into())
+    Ok(conv(vec))
 }
 
 impl<'de> Deserializer<'de> for Compound {

--- a/crates/valence_nbt/src/serde/ser.rs
+++ b/crates/valence_nbt/src/serde/ser.rs
@@ -1,3 +1,4 @@
+use std::hash::Hash;
 use std::marker::PhantomData;
 
 use serde::ser::{Impossible, SerializeMap, SerializeSeq, SerializeStruct};
@@ -7,7 +8,10 @@ use super::Error;
 use crate::conv::{i8_slice_as_u8_slice, u8_vec_into_i8_vec};
 use crate::{Compound, List, Value};
 
-impl Serialize for Value {
+impl<Str> Serialize for Value<Str>
+where
+    Str: Serialize + Eq + Ord + Hash,
+{
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -20,7 +24,7 @@ impl Serialize for Value {
             Value::Float(v) => serializer.serialize_f32(*v),
             Value::Double(v) => serializer.serialize_f64(*v),
             Value::ByteArray(v) => serializer.serialize_bytes(i8_slice_as_u8_slice(v)),
-            Value::String(v) => serializer.serialize_str(v),
+            Value::String(v) => v.serialize(serializer),
             Value::List(v) => v.serialize(serializer),
             Value::Compound(v) => v.serialize(serializer),
             Value::IntArray(v) => v.serialize(serializer),
@@ -29,7 +33,10 @@ impl Serialize for Value {
     }
 }
 
-impl Serialize for List {
+impl<Str> Serialize for List<Str>
+where
+    Str: Serialize + Eq + Ord + Hash,
+{
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,

--- a/crates/valence_nbt/src/serde/ser.rs
+++ b/crates/valence_nbt/src/serde/ser.rs
@@ -10,7 +10,7 @@ use crate::{Compound, List, Value};
 
 impl<Str> Serialize for Value<Str>
 where
-    Str: Serialize + Eq + Ord + Hash,
+    Str: Serialize + Ord + Hash,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -35,7 +35,7 @@ where
 
 impl<Str> Serialize for List<Str>
 where
-    Str: Serialize + Eq + Ord + Hash,
+    Str: Serialize + Ord + Hash,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/crates/valence_nbt/src/value.rs
+++ b/crates/valence_nbt/src/value.rs
@@ -349,6 +349,62 @@ impl<'a> From<Cow<'a, str>> for Value<String> {
     }
 }
 
+#[cfg(feature = "java_string")]
+impl From<java_string::JavaString> for Value<java_string::JavaString> {
+    fn from(value: java_string::JavaString) -> Self {
+        Self::String(value)
+    }
+}
+
+#[cfg(feature = "java_string")]
+impl From<&java_string::JavaString> for Value<java_string::JavaString> {
+    fn from(value: &java_string::JavaString) -> Self {
+        Self::String(value.clone())
+    }
+}
+
+#[cfg(feature = "java_string")]
+impl<'a> From<&'a java_string::JavaStr> for Value<java_string::JavaString> {
+    fn from(value: &'a java_string::JavaStr) -> Self {
+        Self::String(value.to_owned())
+    }
+}
+
+#[cfg(feature = "java_string")]
+impl<'a> From<Cow<'a, java_string::JavaStr>> for Value<java_string::JavaString> {
+    fn from(value: Cow<'a, java_string::JavaStr>) -> Self {
+        Self::String(value.into_owned())
+    }
+}
+
+#[cfg(feature = "java_string")]
+impl From<String> for Value<java_string::JavaString> {
+    fn from(value: String) -> Self {
+        Self::String(java_string::JavaString::from(value))
+    }
+}
+
+#[cfg(feature = "java_string")]
+impl From<&String> for Value<java_string::JavaString> {
+    fn from(value: &String) -> Self {
+        Self::String(java_string::JavaString::from(value))
+    }
+}
+
+#[cfg(feature = "java_string")]
+impl<'a> From<&'a str> for Value<java_string::JavaString> {
+    fn from(value: &'a str) -> Self {
+        Self::String(java_string::JavaString::from(value))
+    }
+}
+
+#[cfg(feature = "java_string")]
+impl<'a> From<Cow<'a, str>> for Value<java_string::JavaString> {
+    fn from(value: Cow<'a, str>) -> Self {
+        Self::String(java_string::JavaString::from(value))
+    }
+}
+
 impl<S> From<Vec<i32>> for Value<S> {
     fn from(v: Vec<i32>) -> Self {
         Self::IntArray(v)

--- a/crates/valence_nbt/src/value.rs
+++ b/crates/valence_nbt/src/value.rs
@@ -183,7 +183,7 @@ macro_rules! impl_value {
             }
         }
 
-        impl <$($lifetime,)? S> PartialEq<Self> for $name<$($lifetime,)? S> where S: Eq + Ord + Hash {
+        impl <$($lifetime,)? S> PartialEq<Self> for $name<$($lifetime,)? S> where S: Ord + Hash {
             fn eq(&self, other: &Self) -> bool {
                 match self {
                     Self::Byte(v) => matches!(other, Self::Byte(other_v) if v == other_v),

--- a/crates/valence_nbt/src/value.rs
+++ b/crates/valence_nbt/src/value.rs
@@ -349,59 +349,142 @@ impl<'a> From<Cow<'a, str>> for Value<String> {
     }
 }
 
+impl From<String> for Value<Cow<'_, str>> {
+    fn from(v: String) -> Self {
+        Self::String(Cow::Owned(v))
+    }
+}
+
+impl<'a> From<&'a String> for Value<Cow<'a, str>> {
+    fn from(v: &'a String) -> Self {
+        Self::String(Cow::Borrowed(v))
+    }
+}
+
+impl<'a> From<&'a str> for Value<Cow<'a, str>> {
+    fn from(v: &'a str) -> Self {
+        Self::String(Cow::Borrowed(v))
+    }
+}
+
+impl<'a> From<Cow<'a, str>> for Value<Cow<'a, str>> {
+    fn from(v: Cow<'a, str>) -> Self {
+        Self::String(v)
+    }
+}
+
 #[cfg(feature = "java_string")]
 impl From<java_string::JavaString> for Value<java_string::JavaString> {
-    fn from(value: java_string::JavaString) -> Self {
-        Self::String(value)
+    fn from(v: java_string::JavaString) -> Self {
+        Self::String(v)
     }
 }
 
 #[cfg(feature = "java_string")]
 impl From<&java_string::JavaString> for Value<java_string::JavaString> {
-    fn from(value: &java_string::JavaString) -> Self {
-        Self::String(value.clone())
+    fn from(v: &java_string::JavaString) -> Self {
+        Self::String(v.clone())
     }
 }
 
 #[cfg(feature = "java_string")]
 impl<'a> From<&'a java_string::JavaStr> for Value<java_string::JavaString> {
-    fn from(value: &'a java_string::JavaStr) -> Self {
-        Self::String(value.to_owned())
+    fn from(v: &'a java_string::JavaStr) -> Self {
+        Self::String(v.to_owned())
     }
 }
 
 #[cfg(feature = "java_string")]
 impl<'a> From<Cow<'a, java_string::JavaStr>> for Value<java_string::JavaString> {
-    fn from(value: Cow<'a, java_string::JavaStr>) -> Self {
-        Self::String(value.into_owned())
+    fn from(v: Cow<'a, java_string::JavaStr>) -> Self {
+        Self::String(v.into_owned())
     }
 }
 
 #[cfg(feature = "java_string")]
 impl From<String> for Value<java_string::JavaString> {
-    fn from(value: String) -> Self {
-        Self::String(java_string::JavaString::from(value))
+    fn from(v: String) -> Self {
+        Self::String(java_string::JavaString::from(v))
     }
 }
 
 #[cfg(feature = "java_string")]
 impl From<&String> for Value<java_string::JavaString> {
-    fn from(value: &String) -> Self {
-        Self::String(java_string::JavaString::from(value))
+    fn from(v: &String) -> Self {
+        Self::String(java_string::JavaString::from(v))
     }
 }
 
 #[cfg(feature = "java_string")]
 impl<'a> From<&'a str> for Value<java_string::JavaString> {
-    fn from(value: &'a str) -> Self {
-        Self::String(java_string::JavaString::from(value))
+    fn from(v: &'a str) -> Self {
+        Self::String(java_string::JavaString::from(v))
     }
 }
 
 #[cfg(feature = "java_string")]
 impl<'a> From<Cow<'a, str>> for Value<java_string::JavaString> {
-    fn from(value: Cow<'a, str>) -> Self {
-        Self::String(java_string::JavaString::from(value))
+    fn from(v: Cow<'a, str>) -> Self {
+        Self::String(java_string::JavaString::from(v))
+    }
+}
+
+#[cfg(feature = "java_string")]
+impl From<java_string::JavaString> for Value<Cow<'_, java_string::JavaStr>> {
+    fn from(v: java_string::JavaString) -> Self {
+        Self::String(Cow::Owned(v))
+    }
+}
+
+#[cfg(feature = "java_string")]
+impl<'a> From<&'a java_string::JavaString> for Value<Cow<'a, java_string::JavaStr>> {
+    fn from(v: &'a java_string::JavaString) -> Self {
+        Self::String(Cow::Borrowed(v))
+    }
+}
+
+#[cfg(feature = "java_string")]
+impl<'a> From<&'a java_string::JavaStr> for Value<Cow<'a, java_string::JavaStr>> {
+    fn from(v: &'a java_string::JavaStr) -> Self {
+        Self::String(Cow::Borrowed(v))
+    }
+}
+
+#[cfg(feature = "java_string")]
+impl<'a> From<Cow<'a, java_string::JavaStr>> for Value<Cow<'a, java_string::JavaStr>> {
+    fn from(v: Cow<'a, java_string::JavaStr>) -> Self {
+        Self::String(v)
+    }
+}
+
+#[cfg(feature = "java_string")]
+impl From<String> for Value<Cow<'_, java_string::JavaStr>> {
+    fn from(v: String) -> Self {
+        Self::String(Cow::Owned(java_string::JavaString::from(v)))
+    }
+}
+
+#[cfg(feature = "java_string")]
+impl<'a> From<&'a String> for Value<Cow<'a, java_string::JavaStr>> {
+    fn from(v: &'a String) -> Self {
+        Self::String(Cow::Borrowed(java_string::JavaStr::from_str(v)))
+    }
+}
+
+#[cfg(feature = "java_string")]
+impl<'a> From<&'a str> for Value<Cow<'a, java_string::JavaStr>> {
+    fn from(v: &'a str) -> Self {
+        Self::String(Cow::Borrowed(java_string::JavaStr::from_str(v)))
+    }
+}
+
+#[cfg(feature = "java_string")]
+impl<'a> From<Cow<'a, str>> for Value<Cow<'a, java_string::JavaStr>> {
+    fn from(v: Cow<'a, str>) -> Self {
+        Self::String(match v {
+            Cow::Borrowed(str) => Cow::Borrowed(java_string::JavaStr::from_str(str)),
+            Cow::Owned(str) => Cow::Owned(java_string::JavaString::from(str)),
+        })
     }
 }
 

--- a/crates/valence_nbt/src/value.rs
+++ b/crates/valence_nbt/src/value.rs
@@ -1,11 +1,12 @@
 use std::borrow::Cow;
+use std::hash::Hash;
 
 use crate::tag::Tag;
 use crate::{Compound, List};
 
 /// Represents an arbitrary NBT value.
-#[derive(Clone, PartialEq, Debug)]
-pub enum Value {
+#[derive(Clone, Debug)]
+pub enum Value<S = String> {
     Byte(i8),
     Short(i16),
     Int(i32),
@@ -13,17 +14,17 @@ pub enum Value {
     Float(f32),
     Double(f64),
     ByteArray(Vec<i8>),
-    String(String),
-    List(List),
-    Compound(Compound),
+    String(S),
+    List(List<S>),
+    Compound(Compound<S>),
     IntArray(Vec<i32>),
     LongArray(Vec<i64>),
 }
 
 /// Represents a reference to an arbitrary NBT value, where the tag is not part
 /// of the reference.
-#[derive(Copy, Clone, PartialEq, Debug)]
-pub enum ValueRef<'a> {
+#[derive(Copy, Clone, Debug)]
+pub enum ValueRef<'a, S = String> {
     Byte(&'a i8),
     Short(&'a i16),
     Int(&'a i32),
@@ -31,17 +32,17 @@ pub enum ValueRef<'a> {
     Float(&'a f32),
     Double(&'a f64),
     ByteArray(&'a [i8]),
-    String(&'a str),
-    List(&'a List),
-    Compound(&'a Compound),
+    String(&'a S),
+    List(&'a List<S>),
+    Compound(&'a Compound<S>),
     IntArray(&'a [i32]),
     LongArray(&'a [i64]),
 }
 
 /// Represents a mutable reference to an arbitrary NBT value, where the tag is
 /// not part of the reference.
-#[derive(PartialEq, Debug)]
-pub enum ValueMut<'a> {
+#[derive(Debug)]
+pub enum ValueMut<'a, S = String> {
     Byte(&'a mut i8),
     Short(&'a mut i16),
     Int(&'a mut i32),
@@ -49,9 +50,9 @@ pub enum ValueMut<'a> {
     Float(&'a mut f32),
     Double(&'a mut f64),
     ByteArray(&'a mut Vec<i8>),
-    String(&'a mut String),
-    List(&'a mut List),
-    Compound(&'a mut Compound),
+    String(&'a mut S),
+    List(&'a mut List<S>),
+    Compound(&'a mut Compound<S>),
     IntArray(&'a mut Vec<i32>),
     LongArray(&'a mut Vec<i64>),
 }
@@ -94,7 +95,7 @@ macro_rules! impl_value {
             }
         }
 
-        impl $(<$lifetime>)? $name $(<$lifetime>)? {
+        impl <$($lifetime,)? S> $name<$($lifetime,)? S> {
             /// Returns the type of this value.
             pub fn tag(&self) -> Tag {
                 match self {
@@ -134,51 +135,70 @@ macro_rules! impl_value {
             }
         }
 
-        impl $(<$lifetime>)? From<$($reference)* i8> for $name $(<$lifetime>)? {
+        impl <$($lifetime,)? S> From<$($reference)* i8> for $name<$($lifetime,)? S> {
             fn from(v: $($reference)* i8) -> Self {
                 Self::Byte(v)
             }
         }
 
-        impl $(<$lifetime>)? From<$($reference)* i16> for $name $(<$lifetime>)? {
+        impl <$($lifetime,)? S> From<$($reference)* i16> for $name<$($lifetime,)? S> {
             fn from(v: $($reference)* i16) -> Self {
                 Self::Short(v)
             }
         }
 
-        impl $(<$lifetime>)? From<$($reference)* i32> for $name $(<$lifetime>)? {
+        impl <$($lifetime,)? S> From<$($reference)* i32> for $name<$($lifetime,)? S> {
             fn from(v: $($reference)* i32) -> Self {
                 Self::Int(v)
             }
         }
 
-        impl $(<$lifetime>)? From<$($reference)* i64> for $name $(<$lifetime>)? {
+        impl <$($lifetime,)? S> From<$($reference)* i64> for $name<$($lifetime,)? S> {
             fn from(v: $($reference)* i64) -> Self {
                 Self::Long(v)
             }
         }
 
-        impl $(<$lifetime>)? From<$($reference)* f32> for $name $(<$lifetime>)? {
+        impl <$($lifetime,)? S> From<$($reference)* f32> for $name<$($lifetime,)? S> {
             fn from(v: $($reference)* f32) -> Self {
                 Self::Float(v)
             }
         }
 
-        impl $(<$lifetime>)? From<$($reference)* f64> for $name $(<$lifetime>)? {
+        impl <$($lifetime,)? S> From<$($reference)* f64> for $name<$($lifetime,)? S> {
             fn from(v: $($reference)* f64) -> Self {
                 Self::Double(v)
             }
         }
 
-        impl $(<$lifetime>)? From<$($reference)* List> for $name $(<$lifetime>)? {
-            fn from(v: $($reference)* List) -> Self {
+        impl <$($lifetime,)? S> From<$($reference)* List<S>> for $name<$($lifetime,)? S> {
+            fn from(v: $($reference)* List<S>) -> Self {
                 Self::List(v)
             }
         }
 
-        impl $(<$lifetime>)? From<$($reference)* Compound> for $name $(<$lifetime>)? {
-            fn from(v: $($reference)* Compound) -> Self {
+        impl <$($lifetime,)? S> From<$($reference)* Compound<S>> for $name<$($lifetime,)? S> {
+            fn from(v: $($reference)* Compound<S>) -> Self {
                 Self::Compound(v)
+            }
+        }
+
+        impl <$($lifetime,)? S> PartialEq<Self> for $name<$($lifetime,)? S> where S: Eq + Ord + Hash {
+            fn eq(&self, other: &Self) -> bool {
+                match self {
+                    Self::Byte(v) => matches!(other, Self::Byte(other_v) if v == other_v),
+                    Self::Short(v) => matches!(other, Self::Short(other_v) if v == other_v),
+                    Self::Int(v) => matches!(other, Self::Int(other_v) if v == other_v),
+                    Self::Long(v) => matches!(other, Self::Long(other_v) if v == other_v),
+                    Self::Float(v) => matches!(other, Self::Float(other_v) if v == other_v),
+                    Self::Double(v) => matches!(other, Self::Double(other_v) if v == other_v),
+                    Self::ByteArray(v) => matches!(other, Self::ByteArray(other_v) if v == other_v),
+                    Self::String(v) => matches!(other, Self::String(other_v) if v == other_v),
+                    Self::List(v) => matches!(other, Self::List(other_v) if v == other_v),
+                    Self::Compound(v) => matches!(other, Self::Compound(other_v) if v == other_v),
+                    Self::IntArray(v) => matches!(other, Self::IntArray(other_v) if v == other_v),
+                    Self::LongArray(v) => matches!(other, Self::LongArray(other_v) if v == other_v),
+                }
             }
         }
     }
@@ -188,9 +208,9 @@ impl_value!(Value,,(*),);
 impl_value!(ValueRef, 'a, (**), &'a);
 impl_value!(ValueMut, 'a, (**), &'a mut);
 
-impl Value {
+impl<S> Value<S> {
     /// Converts a reference to a value to a [ValueRef].
-    pub fn as_value_ref(&self) -> ValueRef {
+    pub fn as_value_ref(&self) -> ValueRef<S> {
         match self {
             Value::Byte(v) => ValueRef::Byte(v),
             Value::Short(v) => ValueRef::Short(v),
@@ -199,7 +219,7 @@ impl Value {
             Value::Float(v) => ValueRef::Float(v),
             Value::Double(v) => ValueRef::Double(v),
             Value::ByteArray(v) => ValueRef::ByteArray(&v[..]),
-            Value::String(v) => ValueRef::String(&v[..]),
+            Value::String(v) => ValueRef::String(v),
             Value::List(v) => ValueRef::List(v),
             Value::Compound(v) => ValueRef::Compound(v),
             Value::IntArray(v) => ValueRef::IntArray(&v[..]),
@@ -208,7 +228,7 @@ impl Value {
     }
 
     /// Converts a mutable reference to a value to a [ValueMut].
-    pub fn as_value_mut(&mut self) -> ValueMut {
+    pub fn as_value_mut(&mut self) -> ValueMut<S> {
         match self {
             Value::Byte(v) => ValueMut::Byte(v),
             Value::Short(v) => ValueMut::Short(v),
@@ -226,9 +246,12 @@ impl Value {
     }
 }
 
-impl ValueRef<'_> {
+impl<S> ValueRef<'_, S>
+where
+    S: Clone,
+{
     /// Clones this value reference to a new owned [Value].
-    pub fn to_value(&self) -> Value {
+    pub fn to_value(&self) -> Value<S> {
         match *self {
             ValueRef::Byte(v) => Value::Byte(*v),
             ValueRef::Short(v) => Value::Short(*v),
@@ -246,9 +269,12 @@ impl ValueRef<'_> {
     }
 }
 
-impl<'a> ValueMut<'a> {
+impl<S> ValueMut<'_, S>
+where
+    S: Clone,
+{
     /// Clones this mutable value reference to a new owned [Value].
-    pub fn to_value(&self) -> Value {
+    pub fn to_value(&self) -> Value<S> {
         match self {
             ValueMut::Byte(v) => Value::Byte(**v),
             ValueMut::Short(v) => Value::Short(**v),
@@ -264,9 +290,11 @@ impl<'a> ValueMut<'a> {
             ValueMut::LongArray(v) => Value::LongArray((*v).clone()),
         }
     }
+}
 
+impl<'a, S> ValueMut<'a, S> {
     /// Downgrades this mutable value reference into an immutable [ValueRef].
-    pub fn into_value_ref(self) -> ValueRef<'a> {
+    pub fn into_value_ref(self) -> ValueRef<'a, S> {
         match self {
             ValueMut::Byte(v) => ValueRef::Byte(v),
             ValueMut::Short(v) => ValueRef::Short(v),
@@ -275,7 +303,7 @@ impl<'a> ValueMut<'a> {
             ValueMut::Float(v) => ValueRef::Float(v),
             ValueMut::Double(v) => ValueRef::Double(v),
             ValueMut::ByteArray(v) => ValueRef::ByteArray(&v[..]),
-            ValueMut::String(v) => ValueRef::String(&v[..]),
+            ValueMut::String(v) => ValueRef::String(v),
             ValueMut::List(v) => ValueRef::List(v),
             ValueMut::Compound(v) => ValueRef::Compound(v),
             ValueMut::IntArray(v) => ValueRef::IntArray(&v[..]),
@@ -285,80 +313,92 @@ impl<'a> ValueMut<'a> {
 }
 
 /// Bools are usually represented as `0` or `1` bytes in NBT.
-impl From<bool> for Value {
+impl<S> From<bool> for Value<S> {
     fn from(b: bool) -> Self {
         Value::Byte(b as _)
     }
 }
 
-impl From<Vec<i8>> for Value {
+impl<S> From<Vec<i8>> for Value<S> {
     fn from(v: Vec<i8>) -> Self {
         Self::ByteArray(v)
     }
 }
 
-impl From<String> for Value {
+impl From<String> for Value<String> {
     fn from(v: String) -> Self {
         Self::String(v)
     }
 }
 
-impl From<&String> for Value {
+impl From<&String> for Value<String> {
     fn from(value: &String) -> Self {
         Self::String(value.clone())
     }
 }
 
-impl<'a> From<&'a str> for Value {
+impl<'a> From<&'a str> for Value<String> {
     fn from(v: &'a str) -> Self {
         Self::String(v.to_owned())
     }
 }
 
-impl<'a> From<Cow<'a, str>> for Value {
+impl<'a> From<Cow<'a, str>> for Value<String> {
     fn from(v: Cow<'a, str>) -> Self {
         Self::String(v.into_owned())
     }
 }
 
-impl From<Vec<i32>> for Value {
+impl<S> From<Vec<i32>> for Value<S> {
     fn from(v: Vec<i32>) -> Self {
         Self::IntArray(v)
     }
 }
 
-impl From<Vec<i64>> for Value {
+impl<S> From<Vec<i64>> for Value<S> {
     fn from(v: Vec<i64>) -> Self {
         Self::LongArray(v)
     }
 }
 
-impl From<ValueRef<'_>> for Value {
-    fn from(v: ValueRef) -> Self {
+impl<S> From<ValueRef<'_, S>> for Value<S>
+where
+    S: Clone,
+{
+    fn from(v: ValueRef<S>) -> Self {
         v.to_value()
     }
 }
 
-impl From<&ValueRef<'_>> for Value {
-    fn from(v: &ValueRef) -> Self {
+impl<S> From<&ValueRef<'_, S>> for Value<S>
+where
+    S: Clone,
+{
+    fn from(v: &ValueRef<S>) -> Self {
         v.to_value()
     }
 }
 
-impl From<ValueMut<'_>> for Value {
-    fn from(v: ValueMut) -> Self {
+impl<S> From<ValueMut<'_, S>> for Value<S>
+where
+    S: Clone,
+{
+    fn from(v: ValueMut<S>) -> Self {
         v.to_value()
     }
 }
 
-impl From<&ValueMut<'_>> for Value {
-    fn from(v: &ValueMut) -> Self {
+impl<S> From<&ValueMut<'_, S>> for Value<S>
+where
+    S: Clone,
+{
+    fn from(v: &ValueMut<S>) -> Self {
         v.to_value()
     }
 }
 
 #[cfg(feature = "uuid")]
-impl From<uuid::Uuid> for Value {
+impl<S> From<uuid::Uuid> for Value<S> {
     fn from(value: uuid::Uuid) -> Self {
         let (most, least) = value.as_u64_pair();
 
@@ -372,11 +412,11 @@ impl From<uuid::Uuid> for Value {
 }
 
 #[cfg(feature = "valence_ident")]
-impl<S> From<valence_ident::Ident<S>> for Value
+impl<I, S> From<valence_ident::Ident<I>> for Value<S>
 where
-    S: Into<Value>,
+    I: Into<Value<S>>,
 {
-    fn from(value: valence_ident::Ident<S>) -> Self {
+    fn from(value: valence_ident::Ident<I>) -> Self {
         value.into_inner().into()
     }
 }
@@ -387,78 +427,69 @@ impl<'a> From<&'a [i8]> for ValueRef<'a> {
     }
 }
 
-impl<'a> From<&'a str> for ValueRef<'a> {
-    fn from(v: &'a str) -> ValueRef<'a> {
+impl<'a> From<&'a String> for ValueRef<'a, String> {
+    fn from(v: &'a String) -> ValueRef<'a> {
         Self::String(v)
     }
 }
 
-impl<'a> From<&'a Cow<'_, str>> for ValueRef<'a> {
-    fn from(v: &'a Cow<'_, str>) -> Self {
-        Self::String(v.as_ref())
-    }
-}
-
-impl<'a> From<&'a [i32]> for ValueRef<'a> {
+impl<'a, S> From<&'a [i32]> for ValueRef<'a, S> {
     fn from(v: &'a [i32]) -> Self {
         Self::IntArray(v)
     }
 }
 
-impl<'a> From<&'a [i64]> for ValueRef<'a> {
+impl<'a, S> From<&'a [i64]> for ValueRef<'a, S> {
     fn from(v: &'a [i64]) -> Self {
         Self::LongArray(v)
     }
 }
 
-impl<'a> From<&'a Value> for ValueRef<'a> {
-    fn from(v: &'a Value) -> Self {
+impl<'a, S> From<&'a Value<S>> for ValueRef<'a, S> {
+    fn from(v: &'a Value<S>) -> Self {
         v.as_value_ref()
     }
 }
 
-impl<'a> From<ValueMut<'a>> for ValueRef<'a> {
-    fn from(v: ValueMut<'a>) -> Self {
+impl<'a, S> From<ValueMut<'a, S>> for ValueRef<'a, S> {
+    fn from(v: ValueMut<'a, S>) -> Self {
         v.into_value_ref()
     }
 }
 
 #[cfg(feature = "valence_ident")]
-impl<'a, S> From<&'a valence_ident::Ident<S>> for ValueRef<'a>
-where
-    S: AsRef<str>,
-{
-    fn from(v: &'a valence_ident::Ident<S>) -> Self {
+impl<'a> From<&'a valence_ident::Ident<String>> for ValueRef<'a, String> {
+    fn from(v: &'a valence_ident::Ident<String>) -> Self {
         Self::String(v.as_ref())
     }
 }
 
-impl<'a> From<&'a mut Vec<i8>> for ValueMut<'a> {
+impl<'a, S> From<&'a mut Vec<i8>> for ValueMut<'a, S> {
     fn from(v: &'a mut Vec<i8>) -> Self {
         Self::ByteArray(v)
     }
 }
 
-impl<'a> From<&'a mut String> for ValueMut<'a> {
+impl<'a> From<&'a mut String> for ValueMut<'a, String> {
     fn from(v: &'a mut String) -> Self {
         Self::String(v)
     }
 }
 
-impl<'a> From<&'a mut Vec<i32>> for ValueMut<'a> {
+impl<'a, S> From<&'a mut Vec<i32>> for ValueMut<'a, S> {
     fn from(v: &'a mut Vec<i32>) -> Self {
         Self::IntArray(v)
     }
 }
 
-impl<'a> From<&'a mut Vec<i64>> for ValueMut<'a> {
+impl<'a, S> From<&'a mut Vec<i64>> for ValueMut<'a, S> {
     fn from(v: &'a mut Vec<i64>) -> Self {
         Self::LongArray(v)
     }
 }
 
-impl<'a> From<&'a mut Value> for ValueMut<'a> {
-    fn from(v: &'a mut Value) -> Self {
+impl<'a, S> From<&'a mut Value<S>> for ValueMut<'a, S> {
+    fn from(v: &'a mut Value<S>) -> Self {
         v.as_value_mut()
     }
 }

--- a/crates/valence_protocol/src/impls/other.rs
+++ b/crates/valence_protocol/src/impls/other.rs
@@ -44,7 +44,7 @@ impl<'a> Decode<'a> for Uuid {
 
 impl Encode for Compound {
     fn encode(&self, w: impl Write) -> anyhow::Result<()> {
-        Ok(valence_nbt::to_binary(self, w, "")?)
+        Ok(valence_nbt::to_binary(self, w, &String::new())?)
     }
 }
 

--- a/crates/valence_protocol/src/impls/other.rs
+++ b/crates/valence_protocol/src/impls/other.rs
@@ -44,7 +44,7 @@ impl<'a> Decode<'a> for Uuid {
 
 impl Encode for Compound {
     fn encode(&self, w: impl Write) -> anyhow::Result<()> {
-        Ok(valence_nbt::to_binary(self, w, &String::new())?)
+        Ok(valence_nbt::to_binary(self, w, "")?)
     }
 }
 


### PR DESCRIPTION
# Objective

- Generify `valence_nbt` to allow other types of `String`, such as `JavaString`.
- A side effect of this is that NBT using `Cow<str>` is now also possible.

# Solution

- `valence_nbt::Compound`, `valence_nbt::List` and `valence_nbt::Value` all now have a generic `S` parameter for the string type, which defaults to `String`.
- Extra `From` implementations for `Cow` strings have been added.
- Support for `JavaString` in `valence_nbt` has been added behind the `java_string` feature flag.
   - Added an `AsBorrowed` trait to query a compound, to allow `Compound<JavaString>` to be queried by `&str`.
- Added `FromModifiedUtf8` and `ToModifiedUtf8` traits to support decoding and encoding custom strings, respectively.
- `valence_anvil` has been adapted to allow custom string types in compounds in anvil files.
- The following breaking changes have been introduced:
   - `decode::from_binary` and `valence_anvil::RegionFolder::get_chunk` now have a generic parameter for the string. This can usually be inferred but not necessarily. Existing code that breaks should be changed to use `from_binary::<String>(...)` or `get_chunk::<String>(...)` respectively.