### PR TITLE
Fix `DisconnectClient` disconnecting clients before kicking them with message

### DIFF
--- a/crates/valence_server/src/client.rs
+++ b/crates/valence_server/src/client.rs
@@ -385,7 +385,8 @@ impl Command for DisconnectClient {
                     reason: self.reason.into(),
                 });
 
-                // Despawned will be removed at the end of the tick, this way, the packets have time to be sent.
+                // Despawned will be removed at the end of the tick, this way, the packets have
+                // time to be sent.
                 entity.insert(Despawned);
             }
         }

--- a/crates/valence_server/src/client.rs
+++ b/crates/valence_server/src/client.rs
@@ -385,7 +385,8 @@ impl Command for DisconnectClient {
                     reason: self.reason.into(),
                 });
 
-                entity.remove::<Client>();
+                // Despawned will be removed at the end of the tick, this way, the packets have time to be sent.
+                entity.insert(Despawned);
             }
         }
     }


### PR DESCRIPTION
# Objective

There was a bug in the implementation of `DisconnectClient` where the client would be disconnected before receiving the kick message.

# Solution

Replace `entity.remove::<Client>();` with `entity.insert(Despawned);`. This way, the client will be removed at the end of the tick to give time for the packets to be sent.

> Note: Removing that line altogether also works with a vanilla client, however, it is trivial for a custom client to ignore the packet, and thus having an "anti-kick" exploit.

# Playground

```rs
use valence::client::{despawn_disconnected_clients, DisconnectClient};
use valence::log::LogPlugin;
use valence::network::ConnectionMode;
use valence::prelude::*;

#[allow(unused_imports)]
use crate::extras::*;

const SPAWN_Y: i32 = 64;

pub fn build_app(app: &mut App) {
    app.insert_resource(NetworkSettings {
        connection_mode: ConnectionMode::Offline,
        ..Default::default()
    })
    .add_plugins(DefaultPlugins.build().disable::<LogPlugin>())
    .add_systems(Startup, setup)
    .add_systems(EventLoopUpdate, kick_on_sneak)
    .add_systems(Update, (init_clients, despawn_disconnected_clients))
    .run();
}

fn setup(
    mut commands: Commands,
    server: Res<Server>,
    biomes: Res<BiomeRegistry>,
    dimensions: Res<DimensionTypeRegistry>,
) {
    let mut layer = LayerBundle::new(ident!("overworld"), &dimensions, &biomes, &server);

    for z in -5..5 {
        for x in -5..5 {
            layer.chunk.insert_chunk([x, z], UnloadedChunk::new());
        }
    }

    for z in -25..25 {
        for x in -25..25 {
            layer
                .chunk
                .set_block([x, SPAWN_Y, z], BlockState::GRASS_BLOCK);
        }
    }

    commands.spawn(layer);
}

fn init_clients(
    mut clients: Query<
        (
            &mut EntityLayerId,
            &mut VisibleChunkLayer,
            &mut VisibleEntityLayers,
            &mut Position,
            &mut GameMode,
        ),
        Added<Client>,
    >,
    layers: Query<Entity, (With<ChunkLayer>, With<EntityLayer>)>,
) {
    for (
        mut layer_id,
        mut visible_chunk_layer,
        mut visible_entity_layers,
        mut pos,
        mut game_mode,
    ) in &mut clients
    {
        let layer = layers.single();

        layer_id.0 = layer;
        visible_chunk_layer.0 = layer;
        visible_entity_layers.0.insert(layer);
        pos.set([0.0, SPAWN_Y as f64 + 1.0, 0.0]);
        *game_mode = GameMode::Creative;
    }
}

pub fn kick_on_sneak(
    mut commands: Commands,
    mut events: EventReader<SneakEvent>,
) {
    for event in events.iter() {
        if event.state == SneakState::Start {
            commands.add(DisconnectClient {
                client: event.client,
                reason: "You sneaked!".into(),
            });
        }
    }
}
```