### PR TITLE
Use monospaced links where applicable

### DIFF
--- a/crates/java_string/src/char.rs
+++ b/crates/java_string/src/char.rs
@@ -50,7 +50,7 @@ impl JavaCodePoint {
     pub const REPLACEMENT_CHARACTER: JavaCodePoint =
         JavaCodePoint::from_char(char::REPLACEMENT_CHARACTER);
 
-    /// See [char::from_u32]
+    /// See [`char::from_u32`]
     ///
     /// ```
     /// # use java_string::JavaCodePoint;
@@ -136,7 +136,7 @@ impl JavaCodePoint {
         char::from_u32_unchecked(self.as_u32())
     }
 
-    /// See [char::encode_utf16]
+    /// See [`char::encode_utf16`]
     ///
     /// ```
     /// # use java_string::JavaCodePoint;
@@ -226,7 +226,7 @@ impl JavaCodePoint {
         &mut dst[..len]
     }
 
-    /// See [char::eq_ignore_ascii_case].
+    /// See [`char::eq_ignore_ascii_case`].
     #[inline]
     pub fn eq_ignore_ascii_case(&self, other: &JavaCodePoint) -> bool {
         match (self.as_char(), other.as_char()) {
@@ -236,7 +236,7 @@ impl JavaCodePoint {
         }
     }
 
-    /// See [char::escape_debug].
+    /// See [`char::escape_debug`].
     ///
     /// ```
     /// # use java_string::JavaCodePoint;
@@ -303,7 +303,7 @@ impl JavaCodePoint {
         char.escape_debug().next() != Some('\\')
     }
 
-    /// See [char::escape_default].
+    /// See [`char::escape_default`].
     ///
     /// ```
     /// # use java_string::JavaCodePoint;
@@ -348,7 +348,7 @@ impl JavaCodePoint {
         }
     }
 
-    /// See [char::escape_unicode].
+    /// See [`char::escape_unicode`].
     ///
     /// ```
     /// # use java_string::JavaCodePoint;
@@ -392,49 +392,49 @@ impl JavaCodePoint {
         }
     }
 
-    /// See [char::is_alphabetic].
+    /// See [`char::is_alphabetic`].
     #[inline]
     #[must_use]
     pub fn is_alphabetic(self) -> bool {
         self.as_char().is_some_and(|char| char.is_alphabetic())
     }
 
-    /// See [char::is_alphanumeric].
+    /// See [`char::is_alphanumeric`].
     #[inline]
     #[must_use]
     pub fn is_alphanumeric(self) -> bool {
         self.as_char().is_some_and(|char| char.is_alphanumeric())
     }
 
-    /// See [char::is_ascii].
+    /// See [`char::is_ascii`].
     #[inline]
     #[must_use]
     pub fn is_ascii(self) -> bool {
         self.as_u32() <= 0x7f
     }
 
-    /// See [char::is_ascii_alphabetic].
+    /// See [`char::is_ascii_alphabetic`].
     #[inline]
     #[must_use]
     pub const fn is_ascii_alphabetic(self) -> bool {
         self.is_ascii_lowercase() || self.is_ascii_uppercase()
     }
 
-    /// See [char::is_ascii_alphanumeric].
+    /// See [`char::is_ascii_alphanumeric`].
     #[inline]
     #[must_use]
     pub const fn is_ascii_alphanumeric(self) -> bool {
         self.is_ascii_alphabetic() || self.is_ascii_digit()
     }
 
-    /// See [char::is_ascii_control].
+    /// See [`char::is_ascii_control`].
     #[inline]
     #[must_use]
     pub const fn is_ascii_control(self) -> bool {
         matches!(self.as_u32(), 0..=0x1f | 0x7f)
     }
 
-    /// See [char::is_ascii_digit].
+    /// See [`char::is_ascii_digit`].
     #[inline]
     #[must_use]
     pub const fn is_ascii_digit(self) -> bool {
@@ -443,14 +443,14 @@ impl JavaCodePoint {
         matches!(self.as_u32(), ZERO..=NINE)
     }
 
-    /// See [char::is_ascii_graphic].
+    /// See [`char::is_ascii_graphic`].
     #[inline]
     #[must_use]
     pub const fn is_ascii_graphic(self) -> bool {
         matches!(self.as_u32(), 0x21..=0x7e)
     }
 
-    /// See [char::is_ascii_hexdigit].
+    /// See [`char::is_ascii_hexdigit`].
     #[inline]
     #[must_use]
     pub const fn is_ascii_hexdigit(self) -> bool {
@@ -461,7 +461,7 @@ impl JavaCodePoint {
         self.is_ascii_digit() || matches!(self.as_u32(), (LOWER_A..=LOWER_F) | (UPPER_A..=UPPER_F))
     }
 
-    /// See [char::is_ascii_lowercase].
+    /// See [`char::is_ascii_lowercase`].
     #[inline]
     #[must_use]
     pub const fn is_ascii_lowercase(self) -> bool {
@@ -470,7 +470,7 @@ impl JavaCodePoint {
         matches!(self.as_u32(), A..=Z)
     }
 
-    /// See [char::is_ascii_octdigit].
+    /// See [`char::is_ascii_octdigit`].
     #[inline]
     #[must_use]
     pub const fn is_ascii_octdigit(self) -> bool {
@@ -479,7 +479,7 @@ impl JavaCodePoint {
         matches!(self.as_u32(), ZERO..=SEVEN)
     }
 
-    /// See [char::is_ascii_punctuation].
+    /// See [`char::is_ascii_punctuation`].
     #[inline]
     #[must_use]
     pub const fn is_ascii_punctuation(self) -> bool {
@@ -489,7 +489,7 @@ impl JavaCodePoint {
         )
     }
 
-    /// See [char::is_ascii_uppercase].
+    /// See [`char::is_ascii_uppercase`].
     #[inline]
     #[must_use]
     pub const fn is_ascii_uppercase(self) -> bool {
@@ -498,7 +498,7 @@ impl JavaCodePoint {
         matches!(self.as_u32(), A..=Z)
     }
 
-    /// See [char::is_ascii_whitespace].
+    /// See [`char::is_ascii_whitespace`].
     #[inline]
     #[must_use]
     pub const fn is_ascii_whitespace(self) -> bool {
@@ -513,49 +513,49 @@ impl JavaCodePoint {
         )
     }
 
-    /// See [char::is_control].
+    /// See [`char::is_control`].
     #[inline]
     #[must_use]
     pub fn is_control(self) -> bool {
         self.as_char().is_some_and(|char| char.is_control())
     }
 
-    /// See [char::is_digit].
+    /// See [`char::is_digit`].
     #[inline]
     #[must_use]
     pub fn is_digit(self, radix: u32) -> bool {
         self.to_digit(radix).is_some()
     }
 
-    /// See [char::is_lowercase].
+    /// See [`char::is_lowercase`].
     #[inline]
     #[must_use]
     pub fn is_lowercase(self) -> bool {
         self.as_char().is_some_and(|char| char.is_lowercase())
     }
 
-    /// See [char::is_numeric].
+    /// See [`char::is_numeric`].
     #[inline]
     #[must_use]
     pub fn is_numeric(self) -> bool {
         self.as_char().is_some_and(|char| char.is_numeric())
     }
 
-    /// See [char::is_uppercase].
+    /// See [`char::is_uppercase`].
     #[inline]
     #[must_use]
     pub fn is_uppercase(self) -> bool {
         self.as_char().is_some_and(|char| char.is_uppercase())
     }
 
-    /// See [char::is_whitespace].
+    /// See [`char::is_whitespace`].
     #[inline]
     #[must_use]
     pub fn is_whitespace(self) -> bool {
         self.as_char().is_some_and(|char| char.is_whitespace())
     }
 
-    /// See [char::len_utf16]. Surrogate code points return 1.
+    /// See [`char::len_utf16`]. Surrogate code points return 1.
     ///
     /// ```
     /// # use java_string::JavaCodePoint;
@@ -578,7 +578,7 @@ impl JavaCodePoint {
         }
     }
 
-    /// See [char::len_utf8]. Surrogate code points return 3.
+    /// See [`char::len_utf8`]. Surrogate code points return 3.
     ///
     /// ```
     /// # use java_string::JavaCodePoint;
@@ -608,19 +608,19 @@ impl JavaCodePoint {
         }
     }
 
-    /// See [char::make_ascii_lowercase].
+    /// See [`char::make_ascii_lowercase`].
     #[inline]
     pub fn make_ascii_lowercase(&mut self) {
         *self = self.to_ascii_lowercase();
     }
 
-    /// See [char::make_ascii_uppercase].
+    /// See [`char::make_ascii_uppercase`].
     #[inline]
     pub fn make_ascii_uppercase(&mut self) {
         *self = self.to_ascii_uppercase();
     }
 
-    /// See [char::to_ascii_lowercase].
+    /// See [`char::to_ascii_lowercase`].
     ///
     /// ```
     /// # use java_string::JavaCodePoint;
@@ -644,7 +644,7 @@ impl JavaCodePoint {
         }
     }
 
-    /// See [char::to_ascii_uppercase].
+    /// See [`char::to_ascii_uppercase`].
     ///
     /// ```
     /// # use java_string::JavaCodePoint;
@@ -668,7 +668,7 @@ impl JavaCodePoint {
         }
     }
 
-    /// See [char::to_digit].
+    /// See [`char::to_digit`].
     #[inline]
     #[must_use]
     pub const fn to_digit(self, radix: u32) -> Option<u32> {
@@ -679,7 +679,7 @@ impl JavaCodePoint {
         }
     }
 
-    /// See [char::to_lowercase].
+    /// See [`char::to_lowercase`].
     #[inline]
     #[must_use]
     pub fn to_lowercase(self) -> ToLowercase {
@@ -689,7 +689,7 @@ impl JavaCodePoint {
         }
     }
 
-    /// See [char::to_uppercase].
+    /// See [`char::to_uppercase`].
     #[inline]
     #[must_use]
     pub fn to_uppercase(self) -> ToUppercase {

--- a/crates/java_string/src/owned.rs
+++ b/crates/java_string/src/owned.rs
@@ -39,7 +39,7 @@ impl JavaString {
     }
 
     /// Converts `vec` to a `JavaString` if it is fully-valid UTF-8, i.e. UTF-8
-    /// without surrogate code points. See [String::from_utf8].
+    /// without surrogate code points. See [`String::from_utf8`].
     #[inline]
     pub fn from_full_utf8(vec: Vec<u8>) -> Result<JavaString, FromUtf8Error> {
         match std::str::from_utf8(&vec) {
@@ -152,14 +152,14 @@ impl JavaString {
         JavaString { vec: bytes }
     }
 
-    /// See [String::into_bytes].
+    /// See [`String::into_bytes`].
     #[inline]
     #[must_use]
     pub fn into_bytes(self) -> Vec<u8> {
         self.vec
     }
 
-    /// See [String::as_str].
+    /// See [`String::as_str`].
     #[inline]
     #[must_use]
     pub fn as_java_str(&self) -> &JavaStr {
@@ -169,7 +169,7 @@ impl JavaString {
         }
     }
 
-    /// See [String::as_mut_str].
+    /// See [`String::as_mut_str`].
     #[inline]
     #[must_use]
     pub fn as_mut_java_str(&mut self) -> &mut JavaStr {
@@ -216,62 +216,62 @@ impl JavaString {
         String::from_utf8_unchecked(self.vec)
     }
 
-    /// See [String::push_str].
+    /// See [`String::push_str`].
     #[inline]
     pub fn push_java_str(&mut self, string: &JavaStr) {
         self.vec.extend_from_slice(string.as_bytes())
     }
 
-    /// See [String::push_str].
+    /// See [`String::push_str`].
     #[inline]
     pub fn push_str(&mut self, string: &str) {
         self.vec.extend_from_slice(string.as_bytes())
     }
 
-    /// See [String::capacity].
+    /// See [`String::capacity`].
     #[inline]
     #[must_use]
     pub fn capacity(&self) -> usize {
         self.vec.capacity()
     }
 
-    /// See [String::reserve].
+    /// See [`String::reserve`].
     #[inline]
     pub fn reserve(&mut self, additional: usize) {
         self.vec.reserve(additional)
     }
 
-    /// See [String::reserve_exact].
+    /// See [`String::reserve_exact`].
     #[inline]
     pub fn reserve_exact(&mut self, additional: usize) {
         self.vec.reserve_exact(additional)
     }
 
-    /// See [String::try_reserve].
+    /// See [`String::try_reserve`].
     #[inline]
     pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
         self.vec.try_reserve(additional)
     }
 
-    /// See [String::try_reserve_exact].
+    /// See [`String::try_reserve_exact`].
     #[inline]
     pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), TryReserveError> {
         self.vec.try_reserve_exact(additional)
     }
 
-    /// See [String::shrink_to_fit].
+    /// See [`String::shrink_to_fit`].
     #[inline]
     pub fn shrink_to_fit(&mut self) {
         self.vec.shrink_to_fit()
     }
 
-    /// See [String::shrink_to].
+    /// See [`String::shrink_to`].
     #[inline]
     pub fn shrink_to(&mut self, min_capacity: usize) {
         self.vec.shrink_to(min_capacity)
     }
 
-    /// See [String::push].
+    /// See [`String::push`].
     #[inline]
     pub fn push(&mut self, ch: char) {
         match ch.len_utf8() {
@@ -282,7 +282,7 @@ impl JavaString {
         }
     }
 
-    /// See [String::push].
+    /// See [`String::push`].
     #[inline]
     pub fn push_java(&mut self, ch: JavaCodePoint) {
         match ch.len_utf8() {
@@ -291,14 +291,14 @@ impl JavaString {
         }
     }
 
-    /// See [String::as_bytes].
+    /// See [`String::as_bytes`].
     #[inline]
     #[must_use]
     pub fn as_bytes(&self) -> &[u8] {
         &self.vec
     }
 
-    /// See [String::truncate].
+    /// See [`String::truncate`].
     #[inline]
     pub fn truncate(&mut self, new_len: usize) {
         if new_len <= self.len() {
@@ -307,7 +307,7 @@ impl JavaString {
         }
     }
 
-    /// See [String::pop].
+    /// See [`String::pop`].
     ///
     /// ```
     /// # use java_string::JavaString;
@@ -332,7 +332,7 @@ impl JavaString {
         Some(ch)
     }
 
-    /// See [String::remove].
+    /// See [`String::remove`].
     ///
     /// ```
     /// # use java_string::JavaString;
@@ -375,7 +375,7 @@ impl JavaString {
         ch
     }
 
-    /// See [String::retain].
+    /// See [`String::retain`].
     ///
     /// ```
     /// # use java_string::{JavaCodePoint, JavaString};
@@ -452,7 +452,7 @@ impl JavaString {
         drop(guard);
     }
 
-    /// See [String::insert].
+    /// See [`String::insert`].
     ///
     /// ```
     /// # use java_string::JavaString;
@@ -473,7 +473,7 @@ impl JavaString {
         }
     }
 
-    /// See [String::insert].
+    /// See [`String::insert`].
     #[inline]
     pub fn insert_java(&mut self, idx: usize, ch: JavaCodePoint) {
         assert!(self.is_char_boundary(idx));
@@ -502,7 +502,7 @@ impl JavaString {
         }
     }
 
-    /// See [String::insert_str].
+    /// See [`String::insert_str`].
     ///
     /// ```
     /// # use java_string::JavaString;
@@ -519,7 +519,7 @@ impl JavaString {
         }
     }
 
-    /// See [String::insert_str].
+    /// See [`String::insert_str`].
     pub fn insert_java_str(&mut self, idx: usize, string: &JavaStr) {
         assert!(self.is_char_boundary(idx));
 
@@ -528,7 +528,7 @@ impl JavaString {
         }
     }
 
-    /// See [String::as_mut_vec].
+    /// See [`String::as_mut_vec`].
     ///
     /// # Safety
     ///
@@ -539,21 +539,21 @@ impl JavaString {
         &mut self.vec
     }
 
-    /// See [String::len].
+    /// See [`String::len`].
     #[inline]
     #[must_use]
     pub fn len(&self) -> usize {
         self.vec.len()
     }
 
-    /// See [String::is_empty].
+    /// See [`String::is_empty`].
     #[inline]
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
-    /// See [String::split_off].
+    /// See [`String::split_off`].
     ///
     /// ```
     /// # use java_string::JavaString;
@@ -576,13 +576,13 @@ impl JavaString {
         unsafe { JavaString::from_semi_utf8_unchecked(other) }
     }
 
-    /// See [String::clear].
+    /// See [`String::clear`].
     #[inline]
     pub fn clear(&mut self) {
         self.vec.clear();
     }
 
-    /// See [String::drain].
+    /// See [`String::drain`].
     ///
     /// ```
     /// # use java_string::JavaString;
@@ -624,7 +624,7 @@ impl JavaString {
         }
     }
 
-    /// See [String::replace_range].
+    /// See [`String::replace_range`].
     ///
     /// ```
     /// # use java_string::JavaString;
@@ -649,7 +649,7 @@ impl JavaString {
         self.replace_range_java(range, JavaStr::from_str(replace_with))
     }
 
-    /// See [String::replace_range].
+    /// See [`String::replace_range`].
     pub fn replace_range_java<R>(&mut self, range: R, replace_with: &JavaStr)
     where
         R: RangeBounds<usize>,
@@ -670,7 +670,7 @@ impl JavaString {
         unsafe { self.as_mut_vec() }.splice((start, end), replace_with.bytes());
     }
 
-    /// See [String::into_boxed_str].
+    /// See [`String::into_boxed_str`].
     #[inline]
     #[must_use]
     pub fn into_boxed_str(self) -> Box<JavaStr> {
@@ -678,7 +678,7 @@ impl JavaString {
         unsafe { JavaStr::from_boxed_semi_utf8_unchecked(slice) }
     }
 
-    /// See [String::leak].
+    /// See [`String::leak`].
     #[inline]
     pub fn leak<'a>(self) -> &'a mut JavaStr {
         let slice = self.vec.leak();

--- a/crates/java_string/src/slice.rs
+++ b/crates/java_string/src/slice.rs
@@ -31,7 +31,7 @@ pub struct JavaStr {
 
 impl JavaStr {
     /// Converts `v` to a `&JavaStr` if it is fully-valid UTF-8, i.e. UTF-8
-    /// without surrogate code points. See [std::str::from_utf8].
+    /// without surrogate code points. See [`std::str::from_utf8`].
     #[inline]
     pub const fn from_full_utf8(v: &[u8]) -> Result<&JavaStr, Utf8Error> {
         match std::str::from_utf8(v) {
@@ -41,7 +41,7 @@ impl JavaStr {
     }
 
     /// Converts `v` to a `&mut JavaStr` if it is fully-valid UTF-8, i.e. UTF-8
-    /// without surrogate code points. See [std::str::from_utf8_mut].
+    /// without surrogate code points. See [`std::str::from_utf8_mut`].
     #[inline]
     pub fn from_full_utf8_mut(v: &mut [u8]) -> Result<&mut JavaStr, Utf8Error> {
         match std::str::from_utf8_mut(v) {
@@ -126,14 +126,14 @@ impl JavaStr {
         unsafe { Box::from_raw(Box::into_raw(v) as *mut JavaStr) }
     }
 
-    /// See [str::as_bytes].
+    /// See [`str::as_bytes`].
     #[inline]
     #[must_use]
     pub const fn as_bytes(&self) -> &[u8] {
         &self.inner
     }
 
-    /// See [str::as_bytes_mut].
+    /// See [`str::as_bytes_mut`].
     ///
     /// # Safety
     ///
@@ -145,14 +145,14 @@ impl JavaStr {
         &mut self.inner
     }
 
-    /// See [str::as_mut_ptr].
+    /// See [`str::as_mut_ptr`].
     #[inline]
     #[must_use]
     pub fn as_mut_ptr(&mut self) -> *mut u8 {
         self.inner.as_mut_ptr()
     }
 
-    /// See [str::as_ptr].
+    /// See [`str::as_ptr`].
     #[inline]
     #[must_use]
     pub const fn as_ptr(&self) -> *const u8 {
@@ -219,7 +219,7 @@ impl JavaStr {
         }
     }
 
-    /// See [str::bytes].
+    /// See [`str::bytes`].
     #[inline]
     pub fn bytes(&self) -> Bytes<'_> {
         Bytes {
@@ -227,7 +227,7 @@ impl JavaStr {
         }
     }
 
-    /// See [str::char_indices].
+    /// See [`str::char_indices`].
     #[inline]
     pub fn char_indices(&self) -> CharIndices<'_> {
         CharIndices {
@@ -236,7 +236,7 @@ impl JavaStr {
         }
     }
 
-    /// See [str::chars].
+    /// See [`str::chars`].
     #[inline]
     pub fn chars(&self) -> Chars<'_> {
         Chars {
@@ -244,7 +244,7 @@ impl JavaStr {
         }
     }
 
-    /// See [str::contains].
+    /// See [`str::contains`].
     ///
     /// ```
     /// # use java_string::JavaStr;
@@ -262,7 +262,7 @@ impl JavaStr {
         pat.find_in(self).is_some()
     }
 
-    /// See [str::ends_with].
+    /// See [`str::ends_with`].
     ///
     /// ```
     /// # use java_string::JavaStr;
@@ -280,21 +280,21 @@ impl JavaStr {
         pat.suffix_len_in(self).is_some()
     }
 
-    /// See [str::eq_ignore_ascii_case].
+    /// See [`str::eq_ignore_ascii_case`].
     #[inline]
     #[must_use]
     pub fn eq_ignore_ascii_case(&self, other: &str) -> bool {
         self.as_bytes().eq_ignore_ascii_case(other.as_bytes())
     }
 
-    /// See [str::eq_ignore_ascii_case].
+    /// See [`str::eq_ignore_ascii_case`].
     #[inline]
     #[must_use]
     pub fn eq_java_ignore_ascii_case(&self, other: &JavaStr) -> bool {
         self.as_bytes().eq_ignore_ascii_case(other.as_bytes())
     }
 
-    /// See [str::escape_debug].
+    /// See [`str::escape_debug`].
     ///
     /// ```
     /// # use java_string::JavaStr;
@@ -328,7 +328,7 @@ impl JavaStr {
         }
     }
 
-    /// See [str::escape_default].
+    /// See [`str::escape_default`].
     ///
     /// ```
     /// # use java_string::JavaStr;
@@ -344,7 +344,7 @@ impl JavaStr {
         }
     }
 
-    /// See [str::escape_unicode].
+    /// See [`str::escape_unicode`].
     ///
     /// ```
     /// # use java_string::JavaStr;
@@ -360,7 +360,7 @@ impl JavaStr {
         }
     }
 
-    /// See [str::find].
+    /// See [`str::find`].
     ///
     /// ```
     /// let s = "Löwe 老虎 Léopard Gepardi";
@@ -381,7 +381,7 @@ impl JavaStr {
         pat.find_in(self).map(|(index, _)| index)
     }
 
-    /// See [str::get].
+    /// See [`str::get`].
     ///
     /// ```
     /// # use java_string::{JavaStr, JavaString};
@@ -405,7 +405,7 @@ impl JavaStr {
         i.get(self)
     }
 
-    /// See [str::get_mut].
+    /// See [`str::get_mut`].
     #[inline]
     #[must_use]
     pub fn get_mut<I>(&mut self, i: I) -> Option<&mut JavaStr>
@@ -415,7 +415,7 @@ impl JavaStr {
         i.get_mut(self)
     }
 
-    /// See [str::get_unchecked].
+    /// See [`str::get_unchecked`].
     ///
     /// # Safety
     ///
@@ -431,7 +431,7 @@ impl JavaStr {
         unsafe { &*i.get_unchecked(self) }
     }
 
-    /// See [str::get_unchecked_mut].
+    /// See [`str::get_unchecked_mut`].
     ///
     /// # Safety
     ///
@@ -447,14 +447,14 @@ impl JavaStr {
         unsafe { &mut *i.get_unchecked_mut(self) }
     }
 
-    /// See [str::into_boxed_bytes].
+    /// See [`str::into_boxed_bytes`].
     #[inline]
     #[must_use]
     pub fn into_boxed_bytes(self: Box<JavaStr>) -> Box<[u8]> {
         unsafe { Box::from_raw(Box::into_raw(self) as *mut [u8]) }
     }
 
-    /// See [str::into_string].
+    /// See [`str::into_string`].
     #[inline]
     #[must_use]
     pub fn into_string(self: Box<JavaStr>) -> JavaString {
@@ -462,14 +462,14 @@ impl JavaStr {
         unsafe { JavaString::from_semi_utf8_unchecked(slice.into_vec()) }
     }
 
-    /// See [str::is_ascii].
+    /// See [`str::is_ascii`].
     #[inline]
     #[must_use]
     pub fn is_ascii(&self) -> bool {
         self.as_bytes().is_ascii()
     }
 
-    /// See [str::is_char_boundary].
+    /// See [`str::is_char_boundary`].
     #[inline]
     #[must_use]
     pub fn is_char_boundary(&self, index: usize) -> bool {
@@ -513,21 +513,21 @@ impl JavaStr {
         }
     }
 
-    /// See [str::is_empty].
+    /// See [`str::is_empty`].
     #[inline]
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
-    /// See [str::len].
+    /// See [`str::len`].
     #[inline]
     #[must_use]
     pub fn len(&self) -> usize {
         self.inner.len()
     }
 
-    /// See [str::lines].
+    /// See [`str::lines`].
     #[inline]
     pub fn lines(&self) -> Lines<'_> {
         Lines {
@@ -543,7 +543,7 @@ impl JavaStr {
         }
     }
 
-    /// See [str::make_ascii_lowercase].
+    /// See [`str::make_ascii_lowercase`].
     #[inline]
     pub fn make_ascii_lowercase(&mut self) {
         // SAFETY: changing ASCII letters only does not invalidate UTF-8.
@@ -551,7 +551,7 @@ impl JavaStr {
         me.make_ascii_lowercase()
     }
 
-    /// See [str::make_ascii_uppercase].
+    /// See [`str::make_ascii_uppercase`].
     #[inline]
     pub fn make_ascii_uppercase(&mut self) {
         // SAFETY: changing ASCII letters only does not invalidate UTF-8.
@@ -559,7 +559,7 @@ impl JavaStr {
         me.make_ascii_uppercase()
     }
 
-    /// See [str::match_indices].
+    /// See [`str::match_indices`].
     ///
     /// ```
     /// # use java_string::JavaStr;
@@ -596,7 +596,7 @@ impl JavaStr {
         }
     }
 
-    /// See [str::matches].
+    /// See [`str::matches`].
     ///
     /// ```
     /// # use java_string::{JavaCodePoint, JavaStr};
@@ -632,7 +632,7 @@ impl JavaStr {
         Matches { str: self, pat }
     }
 
-    /// See [str::parse].
+    /// See [`str::parse`].
     #[inline]
     pub fn parse<F>(&self) -> Result<F, ParseError<<F as FromStr>::Err>>
     where
@@ -644,14 +644,14 @@ impl JavaStr {
         }
     }
 
-    /// See [str::repeat].
+    /// See [`str::repeat`].
     #[inline]
     #[must_use]
     pub fn repeat(&self, n: usize) -> JavaString {
         unsafe { JavaString::from_semi_utf8_unchecked(self.as_bytes().repeat(n)) }
     }
 
-    /// See [str::replace].
+    /// See [`str::replace`].
     ///
     /// ```
     /// # use java_string::JavaStr;
@@ -669,7 +669,7 @@ impl JavaStr {
         self.replace_java(from, JavaStr::from_str(to))
     }
 
-    /// See [str::replace].
+    /// See [`str::replace`].
     #[inline]
     #[must_use]
     pub fn replace_java<P>(&self, from: P, to: &JavaStr) -> JavaString
@@ -687,7 +687,7 @@ impl JavaStr {
         result
     }
 
-    /// See [str::replacen].
+    /// See [`str::replacen`].
     ///
     /// ```
     /// # use java_string::{JavaCodePoint, JavaStr};
@@ -708,7 +708,7 @@ impl JavaStr {
         self.replacen_java(from, JavaStr::from_str(to), count)
     }
 
-    /// See [str::replacen].
+    /// See [`str::replacen`].
     #[inline]
     #[must_use]
     pub fn replacen_java<P>(&self, from: P, to: &JavaStr, count: usize) -> JavaString
@@ -727,7 +727,7 @@ impl JavaStr {
         result
     }
 
-    /// See [str::rfind].
+    /// See [`str::rfind`].
     ///
     /// ```
     /// # use java_string::JavaStr;
@@ -749,7 +749,7 @@ impl JavaStr {
         pat.rfind_in(self).map(|(index, _)| index)
     }
 
-    /// See [str::rmatch_indices].
+    /// See [`str::rmatch_indices`].
     ///
     /// ```
     /// # use java_string::JavaStr;
@@ -786,7 +786,7 @@ impl JavaStr {
         }
     }
 
-    /// See [str::rmatches].
+    /// See [`str::rmatches`].
     ///
     /// ```
     /// # use java_string::{JavaCodePoint, JavaStr};
@@ -824,7 +824,7 @@ impl JavaStr {
         }
     }
 
-    /// See [str::rsplit].
+    /// See [`str::rsplit`].
     ///
     /// ```
     /// # use java_string::JavaStr;
@@ -878,7 +878,7 @@ impl JavaStr {
         RSplit::new(self, pat)
     }
 
-    /// See [str::rsplit_once].
+    /// See [`str::rsplit_once`].
     ///
     /// ```
     /// # use java_string::JavaStr;
@@ -908,7 +908,7 @@ impl JavaStr {
         }
     }
 
-    /// See [str::rsplit_terminator].
+    /// See [`str::rsplit_terminator`].
     ///
     /// ```
     /// # use java_string::JavaStr;
@@ -947,7 +947,7 @@ impl JavaStr {
         RSplitTerminator::new(self, pat)
     }
 
-    /// See [str::rsplitn].
+    /// See [`str::rsplitn`].
     ///
     /// ```
     /// # use java_string::JavaStr;
@@ -994,7 +994,7 @@ impl JavaStr {
         RSplitN::new(self, pat, n)
     }
 
-    /// See [str::split].
+    /// See [`str::split`].
     ///
     /// ```
     /// # use java_string::{JavaCodePoint, JavaStr};
@@ -1072,7 +1072,7 @@ impl JavaStr {
         Split::new(self, pat)
     }
 
-    /// See [str::split_ascii_whitespace].
+    /// See [`str::split_ascii_whitespace`].
     ///
     /// ```
     /// # use java_string::JavaStr;
@@ -1101,7 +1101,7 @@ impl JavaStr {
         }
     }
 
-    /// See [str::split_at].
+    /// See [`str::split_at`].
     ///
     /// ```
     /// # use java_string::JavaStr;
@@ -1135,7 +1135,7 @@ impl JavaStr {
         }
     }
 
-    /// See [str::split_at_mut].
+    /// See [`str::split_at_mut`].
     ///
     /// ```
     /// # use java_string::{JavaStr, JavaString};
@@ -1176,7 +1176,7 @@ impl JavaStr {
         }
     }
 
-    /// See [str::split_inclusive].
+    /// See [`str::split_inclusive`].
     ///
     /// ```
     /// # use java_string::JavaStr;
@@ -1200,7 +1200,7 @@ impl JavaStr {
         SplitInclusive::new(self, pat)
     }
 
-    /// See [str::split_once].
+    /// See [`str::split_once`].
     ///
     /// ```
     /// # use java_string::JavaStr;
@@ -1234,7 +1234,7 @@ impl JavaStr {
         }
     }
 
-    /// See [str::split_terminator].
+    /// See [`str::split_terminator`].
     ///
     /// ```
     /// # use java_string::JavaStr;
@@ -1273,7 +1273,7 @@ impl JavaStr {
         SplitTerminator::new(self, pat)
     }
 
-    /// See [str::split_whitespace].
+    /// See [`str::split_whitespace`].
     #[inline]
     pub fn split_whitespace(&self) -> SplitWhitespace<'_> {
         SplitWhitespace {
@@ -1283,7 +1283,7 @@ impl JavaStr {
         }
     }
 
-    /// See [str::splitn].
+    /// See [`str::splitn`].
     ///
     /// ```
     /// # use java_string::JavaStr;
@@ -1325,7 +1325,7 @@ impl JavaStr {
         SplitN::new(self, pat, n)
     }
 
-    /// See [str::starts_with].
+    /// See [`str::starts_with`].
     ///
     /// ```
     /// # use java_string::JavaStr;
@@ -1343,7 +1343,7 @@ impl JavaStr {
         pat.prefix_len_in(self).is_some()
     }
 
-    /// See [str::strip_prefix].
+    /// See [`str::strip_prefix`].
     ///
     /// ```
     /// # use java_string::JavaStr;
@@ -1368,7 +1368,7 @@ impl JavaStr {
         unsafe { Some(self.get_unchecked(len..)) }
     }
 
-    /// See [str::strip_suffix].
+    /// See [`str::strip_suffix`].
     ///
     /// ```
     /// # use java_string::JavaStr;
@@ -1393,7 +1393,7 @@ impl JavaStr {
         unsafe { Some(self.get_unchecked(..self.len() - len)) }
     }
 
-    /// See [str::to_ascii_lowercase].
+    /// See [`str::to_ascii_lowercase`].
     #[inline]
     #[must_use]
     pub fn to_ascii_lowercase(&self) -> JavaString {
@@ -1402,7 +1402,7 @@ impl JavaStr {
         s
     }
 
-    /// See [str::to_ascii_uppercase].
+    /// See [`str::to_ascii_uppercase`].
     #[inline]
     #[must_use]
     pub fn to_ascii_uppercase(&self) -> JavaString {
@@ -1411,7 +1411,7 @@ impl JavaStr {
         s
     }
 
-    /// See [str::to_lowercase].
+    /// See [`str::to_lowercase`].
     ///
     /// ```
     /// # use java_string::{JavaCodePoint, JavaStr, JavaString};

--- a/crates/valence_nbt/src/list.rs
+++ b/crates/valence_nbt/src/list.rs
@@ -462,7 +462,7 @@ impl<S> List<S> {
         }
     }
 
-    /// Returns an iterator over this list. This iterator yields [ValueRef]s.
+    /// Returns an iterator over this list. This iterator yields [`ValueRef`]s.
     pub fn iter(&self) -> Iter<S> {
         Iter {
             inner: match self {
@@ -484,7 +484,7 @@ impl<S> List<S> {
     }
 
     /// Returns a mutable iterator over this list. This iterator yields
-    /// [ValueMut]s.
+    /// [`ValueMut`]s.
     pub fn iter_mut(&mut self) -> IterMut<S> {
         IterMut {
             inner: match self {
@@ -661,7 +661,7 @@ impl<'a, S> IntoIterator for &'a mut List<S> {
     }
 }
 
-/// The owned iterator type for [List].
+/// The owned iterator type for [`List`].
 pub struct IntoIter<S = String> {
     inner: IntoIterInner<S>,
 }
@@ -764,7 +764,7 @@ impl<S> ExactSizeIterator for IntoIter<S> {
 
 impl<S> FusedIterator for IntoIter<S> {}
 
-/// The borrowing iterator type for [List].
+/// The borrowing iterator type for [`List`].
 pub struct Iter<'a, S = String> {
     inner: IterInner<'a, S>,
 }
@@ -871,7 +871,7 @@ impl<S> ExactSizeIterator for Iter<'_, S> {
 
 impl<S> FusedIterator for Iter<'_, S> {}
 
-/// The mutable borrowing iterator type for [List].
+/// The mutable borrowing iterator type for [`List`].
 pub struct IterMut<'a, S = String> {
     inner: IterMutInner<'a, S>,
 }

--- a/crates/valence_nbt/src/snbt.rs
+++ b/crates/valence_nbt/src/snbt.rs
@@ -429,7 +429,7 @@ impl<'a> SnbtReader<'a> {
 /// Parse a string in SNBT format into a `Value`.
 /// Assert that the string has no trailing data.
 /// SNBT is quite similar to JSON, but with some differences.
-/// See [the wiki](https://minecraft.gamepedia.com/NBT_format#SNBT_format) for more information.
+/// See [the wiki](https://minecraft.wiki/w/NBT_format#SNBT_format) for more information.
 ///
 /// # Example
 ///

--- a/crates/valence_nbt/src/value.rs
+++ b/crates/valence_nbt/src/value.rs
@@ -209,7 +209,7 @@ impl_value!(ValueRef, 'a, (**), &'a);
 impl_value!(ValueMut, 'a, (**), &'a mut);
 
 impl<S> Value<S> {
-    /// Converts a reference to a value to a [ValueRef].
+    /// Converts a reference to a value to a [`ValueRef`].
     pub fn as_value_ref(&self) -> ValueRef<S> {
         match self {
             Value::Byte(v) => ValueRef::Byte(v),
@@ -227,7 +227,7 @@ impl<S> Value<S> {
         }
     }
 
-    /// Converts a mutable reference to a value to a [ValueMut].
+    /// Converts a mutable reference to a value to a [`ValueMut`].
     pub fn as_value_mut(&mut self) -> ValueMut<S> {
         match self {
             Value::Byte(v) => ValueMut::Byte(v),
@@ -250,7 +250,7 @@ impl<S> ValueRef<'_, S>
 where
     S: Clone,
 {
-    /// Clones this value reference to a new owned [Value].
+    /// Clones this value reference to a new owned [`Value`].
     pub fn to_value(&self) -> Value<S> {
         match *self {
             ValueRef::Byte(v) => Value::Byte(*v),
@@ -273,7 +273,7 @@ impl<S> ValueMut<'_, S>
 where
     S: Clone,
 {
-    /// Clones this mutable value reference to a new owned [Value].
+    /// Clones this mutable value reference to a new owned [`Value`].
     pub fn to_value(&self) -> Value<S> {
         match self {
             ValueMut::Byte(v) => Value::Byte(**v),
@@ -293,7 +293,7 @@ where
 }
 
 impl<'a, S> ValueMut<'a, S> {
-    /// Downgrades this mutable value reference into an immutable [ValueRef].
+    /// Downgrades this mutable value reference into an immutable [`ValueRef`].
     pub fn into_value_ref(self) -> ValueRef<'a, S> {
         match self {
             ValueMut::Byte(v) => ValueRef::Byte(v),

--- a/crates/valence_network/src/lib.rs
+++ b/crates/valence_network/src/lib.rs
@@ -408,8 +408,8 @@ pub trait NetworkCallbacks: Send + Sync + 'static {
     ///
     /// # Default Implementation
     ///
-    /// The default implementation returns [BroadcastToLan::Disabled], disabling
-    /// LAN discovery.
+    /// The default implementation returns [`BroadcastToLan::Disabled`],
+    /// disabling LAN discovery.
     async fn broadcast_to_lan(&self, shared: &SharedNetworkState) -> BroadcastToLan {
         #![allow(unused_variables)]
 

--- a/crates/valence_server/src/layer/chunk/loaded.rs
+++ b/crates/valence_server/src/layer/chunk/loaded.rs
@@ -299,14 +299,15 @@ impl LoadedChunk {
     /// through the void and there will be no rain particles.
     ///
     /// A value of 1 means that rain particles will appear at the lowest
-    /// possible height given by
-    /// [valence_registry::dimension_type::DimensionType::min_y]. Note that
+    /// possible height given by [`DimensionType::min_y`]. Note that
     /// blocks cannot be placed at `min_y - 1`.
     ///
     /// We take these two special cases into account by adding a value of 2 to
     /// our heightmap if we find a motion-blocking block, since
     /// `self.block_state(x, 0, z)` corresponds to the block at (x, min_y, z)
     /// ingame.
+    ///
+    /// [`DimensionType::min_y`]: valence_registry::dimension_type::DimensionType::min_y
     #[allow(clippy::needless_range_loop)]
     fn motion_blocking(&self) -> Vec<Vec<u32>> {
         let mut heightmap: Vec<Vec<u32>> = vec![vec![0; 16]; 16];


### PR DESCRIPTION
# Objective

- Follow up on https://github.com/valence-rs/valence/pull/546#discussion_r1349688466

# Solution

- Use monospace links where applicable.
- I also found a reference to the old wiki which I replaced with the new one.
