### PR TITLE
Add missing AsRef impl

### DIFF
--- a/crates/java_string/src/slice.rs
+++ b/crates/java_string/src/slice.rs
@@ -1717,6 +1717,13 @@ impl AsRef<JavaStr> for String {
     }
 }
 
+impl AsRef<JavaStr> for JavaStr {
+    #[inline]
+    fn as_ref(&self) -> &JavaStr {
+        self
+    }
+}
+
 impl Clone for Box<JavaStr> {
     #[inline]
     fn clone(&self) -> Self {


### PR DESCRIPTION
# Objective

- Add missing `AsRef` impl for `JavaStr`.

# Solution

- `str` has the same thing.
