### PR TITLE
Simplify website.yml

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -26,16 +26,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - name: Cache
-        uses: Swatinem/rust-cache@v2
-        id: cache
-        with:
-          prefix-key: "website"
-      - name: Install rust toolchain
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf -y | sh
-          rustup update
+      - name: Setup Rust toolchain and cache
+        uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
       - name: Install latest mdbook
         run: |
           tag=$(curl 'https://api.github.com/repos/rust-lang/mdbook/releases/latest' | jq -r '.tag_name')


### PR DESCRIPTION
# Objective

- Make "setup Rust toolchain" step consistent with ci.yml.
- Stop website.yml from failing due to outdated Rust toolchain (caching issue?)

# Solution

- Use `actions-rust-lang/setup-rust-toolchain@v1.5.0`
