### PR TITLE
Set brand

### DIFF
--- a/crates/valence_server/src/brand.rs
+++ b/crates/valence_server/src/brand.rs
@@ -1,0 +1,23 @@
+use valence_protocol::{WritePacket, ident, Bounded};
+use valence_protocol::packets::play::CustomPayloadS2c;
+
+pub trait SetBrand {
+    /// Sets the brand of the server.
+    ///
+    /// The Brand is displayed to the client in the F3 screen
+    /// and is often used to display the server name.
+    fn set_brand(&mut self, brand: &str);
+}
+
+impl<T: WritePacket> SetBrand for T {
+    fn set_brand(&mut self, brand: &str) {
+        // The data is a &[u8], where the first byte is the length of the string.
+        // It is also UTF-8 encoded, so any valid &str can be used.
+        let vec_data = [brand.len() as u8].iter().chain(brand.as_bytes().iter()).copied().collect::<Vec<_>>();
+        let data = vec_data.as_slice();
+        self.write_packet(&CustomPayloadS2c {
+            channel: ident!("minecraft:brand").into(),
+            data: Bounded(data.into()),
+        });
+    }
+}

--- a/crates/valence_server/src/brand.rs
+++ b/crates/valence_server/src/brand.rs
@@ -1,11 +1,12 @@
-use valence_protocol::{WritePacket, ident, Bounded};
 use valence_protocol::packets::play::CustomPayloadS2c;
+use valence_protocol::{ident, Bounded, WritePacket};
 
 pub trait SetBrand {
     /// Sets the brand of the server.
     ///
     /// The Brand is displayed to the client in the F3 screen
     /// and is often used to display the server name.
+    /// Any valid &str can be used.
     fn set_brand(&mut self, brand: &str);
 }
 
@@ -13,7 +14,11 @@ impl<T: WritePacket> SetBrand for T {
     fn set_brand(&mut self, brand: &str) {
         // The data is a &[u8], where the first byte is the length of the string.
         // It is also UTF-8 encoded, so any valid &str can be used.
-        let vec_data = [brand.len() as u8].iter().chain(brand.as_bytes().iter()).copied().collect::<Vec<_>>();
+        let vec_data = [brand.len() as u8]
+            .iter()
+            .chain(brand.as_bytes().iter())
+            .copied()
+            .collect::<Vec<_>>();
         let data = vec_data.as_slice();
         self.write_packet(&CustomPayloadS2c {
             channel: ident!("minecraft:brand").into(),

--- a/crates/valence_server/src/brand.rs
+++ b/crates/valence_server/src/brand.rs
@@ -1,5 +1,5 @@
 use valence_protocol::packets::play::CustomPayloadS2c;
-use valence_protocol::{ident, Bounded, WritePacket};
+use valence_protocol::{ident, Bounded, Encode, VarInt, WritePacket};
 
 pub trait SetBrand {
     /// Sets the brand of the server.
@@ -7,22 +7,22 @@ pub trait SetBrand {
     /// The Brand is displayed to the client in the F3 screen
     /// and is often used to display the server name.
     /// Any valid &str can be used.
+    ///
+    /// However, the legacy formatting codes are used,
+    /// which means that while color and other formatting can technically be
+    /// used, it needs to use the § character, which needs to be encoded as
+    /// 0xC2, 0xA7.
     fn set_brand(&mut self, brand: &str);
 }
 
 impl<T: WritePacket> SetBrand for T {
     fn set_brand(&mut self, brand: &str) {
-        // The data is a &[u8], where the first byte is the length of the string.
-        // It is also UTF-8 encoded, so any valid &str can be used.
-        let vec_data = [brand.len() as u8]
-            .iter()
-            .chain(brand.as_bytes().iter())
-            .copied()
-            .collect::<Vec<_>>();
-        let data = vec_data.as_slice();
+        let mut buf = vec![];
+        let _ = VarInt(brand.len() as _).encode(&mut buf);
+        buf.extend_from_slice(brand.as_bytes());
         self.write_packet(&CustomPayloadS2c {
             channel: ident!("minecraft:brand").into(),
-            data: Bounded(data.into()),
+            data: Bounded(buf.as_slice().into()),
         });
     }
 }

--- a/crates/valence_server/src/lib.rs
+++ b/crates/valence_server/src/lib.rs
@@ -40,6 +40,7 @@ pub mod spawn;
 pub mod status;
 pub mod teleport;
 pub mod title;
+pub mod brand;
 
 pub use chunk_view::ChunkView;
 pub use event_loop::{EventLoopPostUpdate, EventLoopPreUpdate, EventLoopUpdate};

--- a/crates/valence_server/src/lib.rs
+++ b/crates/valence_server/src/lib.rs
@@ -20,6 +20,7 @@
 
 pub mod abilities;
 pub mod action;
+pub mod brand;
 mod chunk_view;
 pub mod client;
 pub mod client_command;
@@ -40,7 +41,6 @@ pub mod spawn;
 pub mod status;
 pub mod teleport;
 pub mod title;
-pub mod brand;
 
 pub use chunk_view::ChunkView;
 pub use event_loop::{EventLoopPostUpdate, EventLoopPreUpdate, EventLoopUpdate};


### PR DESCRIPTION
# Objective
Allows the setting of the brand/server name, visible on the F3 screen. Fixes #560 

# Solution
As recommended, uses an extension trait.