### PR TITLE
Fixed Hex Viewer writing white text on white background when in light mode

### DIFF
--- a/tools/packet_inspector/src/app/filter.rs
+++ b/tools/packet_inspector/src/app/filter.rs
@@ -1,4 +1,4 @@
-use egui::{RichText, Ui, Widget};
+use egui::{RichText, TextEdit, Ui, Widget};
 use itertools::Itertools;
 use valence_protocol::PacketState;
 
@@ -24,7 +24,9 @@ impl View for Filter {
             if ui.button("x").clicked() {
                 state.packet_search.clear();
             }
-            ui.text_edit_singleline(&mut state.packet_search);
+            TextEdit::singleline(&mut state.packet_search)
+                .hint_text("Filter shown packets, e.g \"0x00\" or \"S2c\"")
+                .ui(ui);
         });
 
         egui::ScrollArea::vertical()

--- a/tools/packet_inspector/src/app/hex_viewer.rs
+++ b/tools/packet_inspector/src/app/hex_viewer.rs
@@ -44,8 +44,13 @@ impl View for HexView {
                     }
 
                     ui.label(format!("{:08X}", count));
+                    let text_color = if ui.style().visuals.dark_mode {
+                        egui::Color32::from_gray(255)
+                    } else {
+                        egui::Color32::from_gray(0)
+                    };
                     for b in buf.iter().take(bytes_read) {
-                        ui.label(format!("{:02X}", b));
+                        ui.colored_label(text_color, format!("{:02X}", b));
                     }
                     for _ in 0..16 - bytes_read {
                         ui.label(" ");

--- a/tools/packet_inspector/src/app/hex_viewer.rs
+++ b/tools/packet_inspector/src/app/hex_viewer.rs
@@ -1,7 +1,5 @@
 use std::io::Read;
 
-use egui::Color32;
-
 use super::{SharedState, Tab, View};
 
 pub struct HexView {}
@@ -47,7 +45,7 @@ impl View for HexView {
 
                     ui.label(format!("{:08X}", count));
                     for b in buf.iter().take(bytes_read) {
-                        ui.colored_label(Color32::from_rgb(255, 255, 255), format!("{:02X}", b));
+                        ui.label(format!("{:02X}", b));
                     }
                     for _ in 0..16 - bytes_read {
                         ui.label(" ");

--- a/tools/packet_inspector/src/app/packet_list.rs
+++ b/tools/packet_inspector/src/app/packet_list.rs
@@ -136,7 +136,7 @@ fn draw_packet_widget(ui: &mut Ui, packet: &Packet, selected: bool) -> Response 
     ); // this should give me a new rect inside the scroll area... no?
 
     let fill = match selected /*packet.selected*/ {
-        true => Rgba::from_rgba_premultiplied(0.3, 0.3, 0.3, 0.4),
+        true => Rgba::from_rgba_premultiplied(0.1, 0.1, 0.1, 0.5),
         false => Rgba::from_rgba_premultiplied(0.0, 0.0, 0.0, 0.0),
     };
 
@@ -168,13 +168,19 @@ fn draw_packet_widget(ui: &mut Ui, packet: &Packet, selected: bool) -> Response 
         let timestamp =
             timestamp.into_galley(ui, Some(false), rect.width() - 60.0, TextStyle::Button);
 
+        let id_and_timestamp_color = if selected {
+            text_color
+        } else {
+            ui.visuals().weak_text_color()
+        };
+
         identifier.paint_with_fallback_color(
             ui.painter(),
             Pos2 {
                 x: rect.left() + 21.0,
                 y: rect.top() + 6.0,
             },
-            ui.visuals().weak_text_color(),
+            id_and_timestamp_color,
         );
 
         rect.set_width(rect.width() - 5.0);
@@ -196,7 +202,7 @@ fn draw_packet_widget(ui: &mut Ui, packet: &Packet, selected: bool) -> Response 
                 x: rect.left() + label_width + 8.0,
                 y: rect.top() + 6.0,
             },
-            ui.visuals().weak_text_color(),
+            id_and_timestamp_color,
         );
     }
 


### PR DESCRIPTION
# Objective
The Hex Viewer would write the raw data in white, on white background, when in light mode. This fixes that.

# Solution
The Color of the text is now not hardcoded anymore, but inferred.