### PR TITLE
Default to IPv6 bind address

### DIFF
--- a/crates/valence_network/src/lib.rs
+++ b/crates/valence_network/src/lib.rs
@@ -23,7 +23,7 @@ mod legacy_ping;
 mod packet_io;
 
 use std::borrow::Cow;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::net::{IpAddr, Ipv6Addr, SocketAddr, SocketAddrV4};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -283,7 +283,7 @@ impl Default for NetworkSettings {
             tokio_handle: None,
             max_connections: 1024,
             max_players: 20,
-            address: SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 25565).into(),
+            address: SocketAddrV4::new(Ipv6Addr::UNSPECIFIED, 25565).into(),
             connection_mode: ConnectionMode::Online {
                 prevent_proxy_connections: false,
             },


### PR DESCRIPTION
# Default to IPv6 bind address

- By default applications should listen to the ipv6 wildcard address as this also includes IPv4 addresses and enables IPv6 support

# Solution

- The default bind ip address was set to the UNSPECIFIED constant of IPv6Adress
