### PR TITLE
Fix command argument parse error checking

### DIFF
--- a/crates/valence_command/src/manager.rs
+++ b/crates/valence_command/src/manager.rs
@@ -350,8 +350,9 @@ fn parse_command_args(
                 let pre_input = input.clone().into_inner();
                 let valid = parser(&mut input);
                 if valid {
+                    // If input.len() > pre_input.len() the parser replaced the input
                     let Some(arg) = pre_input
-                        .get(..input.len() - pre_input.len())
+                        .get(..pre_input.len().wrapping_sub(input.len()))
                         .map(|s| s.to_string())
                     else {
                         panic!(


### PR DESCRIPTION
# Objective

This pull request aims to fix an error when parsing commands with arguments.  This error can be recreated by running the command example and executing the command "/gamemode creative @a" or "/gamemode creative {username}" etc. in game.

# Solution

The order of subtraction between the pre-parse argument string and post-parse argument string was changed to hopefully accomplish the intended purpose. This fixes the error when running the command in the example.

Note: I'm not an expert on how command parsing works, maybe @JackCrumpLeys can verify the solution?
