### PR TITLE
Add player slots constants

### DIFF
--- a/crates/valence_inventory/src/lib.rs
+++ b/crates/valence_inventory/src/lib.rs
@@ -83,6 +83,23 @@ impl Plugin for InventoryPlugin {
 /// plus the hotbar.
 pub const PLAYER_INVENTORY_MAIN_SLOTS_COUNT: u16 = 36;
 
+pub mod slots {
+    pub const CRAFTING_RESULT: u16 = 0;
+    pub const CRAFTING_TOP_LEFT: u16 = 1;
+    pub const CRAFTING_TOP_RIGHT: u16 = 2;
+    pub const CRAFTING_BOTTOM_LEFT: u16 = 3;
+    pub const CRAFTING_BOTTOM_RIGHT: u16 = 4;
+    pub const HELMET: u16 = 5;
+    pub const CHESTPLATE: u16 = 6;
+    pub const LEGGINGS: u16 = 7;
+    pub const BOOTS: u16 = 8;
+    pub const FIRST_ROW_START: u16 = 9;
+    pub const SECOND_ROW_START: u16 = 18;
+    pub const THIRD_ROW_START: u16 = 27;
+    pub const HOTBAR_START: u16 = 36;
+    pub const OFFHAND: u16 = 45;
+}
+
 #[derive(Debug, Clone, Component)]
 pub struct Inventory {
     title: Text,


### PR DESCRIPTION
# Objective

Add player inventory slots constants, so developers would not need to lookup them themselves

# Solution

Added constant slots into `slots` module

Based on this image (notice that index on image starts from 1, not 0)
![image](https://github.com/valence-rs/valence/assets/14099557/682fe675-1f25-474e-90bb-74e38d54fb9b)

Generated with this code:
```rust
fn debug_inventory(inv: &mut Inventory) {
    for slot in 0..inv.slot_count() {
        inv.set_slot(
            slot,
            ItemStack::new(ItemKind::Cobblestone, (slot + 1) as i8, None),
        );
    }
}
```