### PR TITLE
Add remaining is_method_name and as_method_name in NBT Value

### DIFF
--- a/crates/valence_nbt/src/value.rs
+++ b/crates/valence_nbt/src/value.rs
@@ -122,12 +122,68 @@ macro_rules! impl_value {
                 }
             }
 
+            /// Returns whether this value is a array, i.e. a byte array, int array or long array.
+            pub fn is_array(&self) -> bool {
+                match self {
+                    Self::ByteArray(_) | Self::IntArray(_) | Self::LongArray(_) => true,
+                    _ => false,
+                }
+            }
+
+            /// Returns whether this value is a string.
+            pub fn is_string(&self) -> bool {
+                match self {
+                    Self::String(_) => true,
+                    _ => false,
+                }
+            }
+
+            /// Returns whether this value is a list of values, i.e. a compound list, a string list and so on.
+            pub fn is_list(&self) -> bool {
+                match self {
+                    Self::List(_) => true,
+                    _ => false,
+                }
+            }
+
+            /// Returns whether this value is a compound.
+            pub fn is_compound(&self) -> bool {
+                match self {
+                    Self::Compound(_) => true,
+                    _ => false,
+                }
+            }
+
             as_number!(as_i8, i8, $($deref)*);
             as_number!(as_i16, i16, $($deref)*);
             as_number!(as_i32, i32, $($deref)*);
             as_number!(as_i64, i64, $($deref)*);
             as_number_float!(as_f32, f32, $($deref)*);
             as_number_float!(as_f64, f64, $($deref)*);
+
+            /// Returns the `String` representation of this value if it exists.
+            pub fn as_string(&$($lifetime)* self) -> Option<&$($lifetime)* S> {
+                match self {
+                    Self::String(v) => Some(v),
+                    _ => None,
+                }
+            }
+
+            /// Returns the `List` representation of this value if it exists.
+            pub fn as_list(&$($lifetime)* self) -> Option<&$($lifetime)* List<S>> {
+                match self {
+                    Self::List(v) => Some(v),
+                    _ => None,
+                }
+            }
+
+            /// Returns the `Compound` representation of this value if it exists.
+            pub fn as_compound(&$($lifetime)* self) -> Option<&$($lifetime)* Compound<S>> {
+                match self {
+                    Self::Compound(v) => Some(v),
+                    _ => None,
+                }
+            }
 
             /// If this value is a number, returns the `bool` representation of this value.
             pub fn as_bool(&self) -> Option<bool> {
@@ -209,6 +265,30 @@ impl_value!(ValueRef, 'a, (**), &'a);
 impl_value!(ValueMut, 'a, (**), &'a mut);
 
 impl<S> Value<S> {
+    /// Returns the `[i8]` representation of this value if it exists.
+    pub fn as_i8_array(&self) -> Option<&[i8]> {
+        match self {
+            Self::ByteArray(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Returns the `[i32]` representation of this value if it exists.
+    pub fn as_i32_array(&self) -> Option<&[i32]> {
+        match self {
+            Self::IntArray(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Returns the `[i64]` representation of this value if it exists.
+    pub fn as_i64_array(&self) -> Option<&[i64]> {
+        match self {
+            Self::LongArray(v) => Some(v),
+            _ => None,
+        }
+    }
+
     /// Converts a reference to a value to a [`ValueRef`].
     pub fn as_value_ref(&self) -> ValueRef<S> {
         match self {
@@ -250,6 +330,30 @@ impl<S> ValueRef<'_, S>
 where
     S: Clone,
 {
+    /// Returns the `[i8]` representation of this value if it exists.
+    pub fn as_i8_array(&self) -> Option<&[i8]> {
+        match self {
+            Self::ByteArray(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Returns the `[i32]` representation of this value if it exists.
+    pub fn as_i32_array(&self) -> Option<&[i32]> {
+        match self {
+            Self::IntArray(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Returns the `[i64]` representation of this value if it exists.
+    pub fn as_i64_array(&self) -> Option<&[i64]> {
+        match self {
+            Self::LongArray(v) => Some(v),
+            _ => None,
+        }
+    }
+
     /// Clones this value reference to a new owned [`Value`].
     pub fn to_value(&self) -> Value<S> {
         match *self {
@@ -273,6 +377,30 @@ impl<S> ValueMut<'_, S>
 where
     S: Clone,
 {
+    /// Returns the `[i8]` representation of this value if it exists.
+    pub fn as_i8_array(&mut self) -> Option<&mut Vec<i8>> {
+        match self {
+            Self::ByteArray(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Returns the `[i32]` representation of this value if it exists.
+    pub fn as_i32_array(&mut self) -> Option<&mut Vec<i32>> {
+        match self {
+            Self::IntArray(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Returns the `[i64]` representation of this value if it exists.
+    pub fn as_i64_array(&mut self) -> Option<&mut Vec<i64>> {
+        match self {
+            Self::LongArray(v) => Some(v),
+            _ => None,
+        }
+    }
+
     /// Clones this mutable value reference to a new owned [`Value`].
     pub fn to_value(&self) -> Value<S> {
         match self {

--- a/crates/valence_nbt/src/value.rs
+++ b/crates/valence_nbt/src/value.rs
@@ -161,6 +161,30 @@ macro_rules! impl_value {
             as_number_float!(as_f32, f32, $($deref)*);
             as_number_float!(as_f64, f64, $($deref)*);
 
+            /// Returns the `[i8]` representation of this value if it exists.
+            pub fn as_i8_array(&self) -> Option<&[i8]> {
+                match self {
+                    Self::ByteArray(v) => Some(v),
+                    _ => None,
+                }
+            }
+
+            /// Returns the `[i32]` representation of this value if it exists.
+            pub fn as_i32_array(&self) -> Option<&[i32]> {
+                match self {
+                    Self::IntArray(v) => Some(v),
+                    _ => None,
+                }
+            }
+
+            /// Returns the `[i64]` representation of this value if it exists.
+            pub fn as_i64_array(&self) -> Option<&[i64]> {
+                match self {
+                    Self::LongArray(v) => Some(v),
+                    _ => None,
+                }
+            }
+
             /// Returns the `String` representation of this value if it exists.
             pub fn as_string(&$($lifetime)* self) -> Option<&$($lifetime)* S> {
                 match self {
@@ -265,24 +289,26 @@ impl_value!(ValueRef, 'a, (**), &'a);
 impl_value!(ValueMut, 'a, (**), &'a mut);
 
 impl<S> Value<S> {
-    /// Returns the `[i8]` representation of this value if it exists.
-    pub fn as_i8_array(&self) -> Option<&[i8]> {
+    /// Returns the mutable `Vec<i8>` representation of this value if it exists.
+    pub fn as_i8_array_mut(&mut self) -> Option<&mut Vec<i8>> {
         match self {
             Self::ByteArray(v) => Some(v),
             _ => None,
         }
     }
 
-    /// Returns the `[i32]` representation of this value if it exists.
-    pub fn as_i32_array(&self) -> Option<&[i32]> {
+    /// Returns the mutable `Vec<i32>` representation of this value if it
+    /// exists.
+    pub fn as_i32_array_mut(&mut self) -> Option<&mut Vec<i32>> {
         match self {
             Self::IntArray(v) => Some(v),
             _ => None,
         }
     }
 
-    /// Returns the `[i64]` representation of this value if it exists.
-    pub fn as_i64_array(&self) -> Option<&[i64]> {
+    /// Returns the mutable `Vec<i64>` representation of this value if it
+    /// exists.
+    pub fn as_i64_array_mut(&mut self) -> Option<&mut Vec<i64>> {
         match self {
             Self::LongArray(v) => Some(v),
             _ => None,
@@ -330,30 +356,6 @@ impl<S> ValueRef<'_, S>
 where
     S: Clone,
 {
-    /// Returns the `[i8]` representation of this value if it exists.
-    pub fn as_i8_array(&self) -> Option<&[i8]> {
-        match self {
-            Self::ByteArray(v) => Some(v),
-            _ => None,
-        }
-    }
-
-    /// Returns the `[i32]` representation of this value if it exists.
-    pub fn as_i32_array(&self) -> Option<&[i32]> {
-        match self {
-            Self::IntArray(v) => Some(v),
-            _ => None,
-        }
-    }
-
-    /// Returns the `[i64]` representation of this value if it exists.
-    pub fn as_i64_array(&self) -> Option<&[i64]> {
-        match self {
-            Self::LongArray(v) => Some(v),
-            _ => None,
-        }
-    }
-
     /// Clones this value reference to a new owned [`Value`].
     pub fn to_value(&self) -> Value<S> {
         match *self {
@@ -377,24 +379,26 @@ impl<S> ValueMut<'_, S>
 where
     S: Clone,
 {
-    /// Returns the `[i8]` representation of this value if it exists.
-    pub fn as_i8_array(&mut self) -> Option<&mut Vec<i8>> {
+    /// Returns the mutable `Vec<i8>` representation of this value if it exists.
+    pub fn as_i8_array_mut(&mut self) -> Option<&mut Vec<i8>> {
         match self {
             Self::ByteArray(v) => Some(v),
             _ => None,
         }
     }
 
-    /// Returns the `[i32]` representation of this value if it exists.
-    pub fn as_i32_array(&mut self) -> Option<&mut Vec<i32>> {
+    /// Returns the mutable `Vec<i32>` representation of this value if it
+    /// exists.
+    pub fn as_i32_array_mut(&mut self) -> Option<&mut Vec<i32>> {
         match self {
             Self::IntArray(v) => Some(v),
             _ => None,
         }
     }
 
-    /// Returns the `[i64]` representation of this value if it exists.
-    pub fn as_i64_array(&mut self) -> Option<&mut Vec<i64>> {
+    /// Returns the mutable `Vec<i64>` representation of this value if it
+    /// exists.
+    pub fn as_i64_array_mut(&mut self) -> Option<&mut Vec<i64>> {
         match self {
             Self::LongArray(v) => Some(v),
             _ => None,


### PR DESCRIPTION
This adds the following methods in Value, ValueRef and ValueMut:

  - is_array
  - is_string
  - is_list
  - is_compound
  - as_i8_array
  - as_i32_array
  - as_i64_array
  - as_string
  - as_list
  - as_compound
  
And this other methods for Value and ValueMut:

  - as_i8_array_mut
  - as_i32_array_mut
  - as_i64_array_mut

# Objective

It is a quality change when dealing with NBT Values and friends, so this kind of code
```rs
let id = match value.get("some_key")? {
    Value::String(id) => Some(id),
    _ => None,
}?;
```
can be turned into
```rs
let id = value.get("some_key")?.as_string()?;
```
specially if there are several of those