### PR TITLE
fix indexmap deprication warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,7 @@ glam = "0.25.0"
 heck = "0.5.0-rc.1"
 hmac = "0.12.1"
 image = "0.24.6"
-indexmap = "2.0.0"
+indexmap = "2.2.1"
 itertools = "0.12.0"
 java_string = { path = "crates/java_string", version = "0.1.2" }
 lru = "0.12.0"

--- a/crates/valence_entity/src/active_status_effects.rs
+++ b/crates/valence_entity/src/active_status_effects.rs
@@ -212,7 +212,7 @@ impl ActiveStatusEffects {
 
     /// Removes an effect.
     fn remove_effect(&mut self, effect: StatusEffect) {
-        self.current_effects.remove(&effect);
+        self.current_effects.swap_remove(&effect);
     }
 
     /// Removes all effects.

--- a/crates/valence_entity/src/attributes.rs
+++ b/crates/valence_entity/src/attributes.rs
@@ -133,9 +133,9 @@ impl EntityAttributeInstance {
 
     /// Removes a modifier.
     pub fn remove_modifier(&mut self, uuid: Uuid) {
-        self.add_modifiers.remove(&uuid);
-        self.multiply_base_modifiers.remove(&uuid);
-        self.multiply_total_modifiers.remove(&uuid);
+        self.add_modifiers.swap_remove(&uuid);
+        self.multiply_base_modifiers.swap_remove(&uuid);
+        self.multiply_total_modifiers.swap_remove(&uuid);
     }
 
     /// Clears all modifiers.

--- a/crates/valence_nbt/src/compound.rs
+++ b/crates/valence_nbt/src/compound.rs
@@ -137,13 +137,39 @@ where
         self.map.insert(k.into(), v.into())
     }
 
+    #[inline]
     pub fn remove<Q>(&mut self, k: &Q) -> Option<Value<S>>
     where
         Q: ?Sized + AsBorrowed<S>,
         <Q as AsBorrowed<S>>::Borrowed: Hash + Ord,
         S: Borrow<<Q as AsBorrowed<S>>::Borrowed>,
     {
-        self.map.remove(k.as_borrowed())
+        #[cfg(feature = "preserve_order")]
+        return self.swap_remove(k);
+        #[cfg(not(feature = "preserve_order"))]
+        return self.map.remove(k.as_borrowed());
+    }
+
+    #[cfg(feature = "preserve_order")]
+    #[inline]
+    pub fn swap_remove<Q>(&mut self, k: &Q) -> Option<Value<S>>
+    where
+        Q: ?Sized + AsBorrowed<S>,
+        <Q as AsBorrowed<S>>::Borrowed: Hash + Ord,
+        S: Borrow<<Q as AsBorrowed<S>>::Borrowed>,
+    {
+        self.map.swap_remove(k.as_borrowed())
+    }
+
+    #[cfg(feature = "preserve_order")]
+    #[inline]
+    pub fn shift_remove<Q>(&mut self, k: &Q) -> Option<Value<S>>
+    where
+        Q: ?Sized + AsBorrowed<S>,
+        <Q as AsBorrowed<S>>::Borrowed: Hash + Ord,
+        S: Borrow<<Q as AsBorrowed<S>>::Borrowed>,
+    {
+        self.map.shift_remove(k.as_borrowed())
     }
 
     pub fn remove_entry<Q>(&mut self, k: &Q) -> Option<(S, Value<S>)>
@@ -151,7 +177,28 @@ where
         S: Borrow<Q>,
         Q: ?Sized + Ord + Hash,
     {
-        self.map.remove_entry(k)
+        #[cfg(feature = "preserve_order")]
+        return self.swap_remove_entry(k);
+        #[cfg(not(feature = "preserve_order"))]
+        return self.map.remove_entry(k);
+    }
+
+    #[cfg(feature = "preserve_order")]
+    pub fn swap_remove_entry<Q>(&mut self, k: &Q) -> Option<(S, Value<S>)>
+    where
+        S: Borrow<Q>,
+        Q: ?Sized + Ord + Hash,
+    {
+        self.map.swap_remove_entry(k)
+    }
+
+    #[cfg(feature = "preserve_order")]
+    pub fn shift_remove_entry<Q>(&mut self, k: &Q) -> Option<(S, Value<S>)>
+    where
+        S: Borrow<Q>,
+        Q: ?Sized + Ord + Hash,
+    {
+        self.map.shift_remove_entry(k)
     }
 
     pub fn append(&mut self, other: &mut Self) {
@@ -461,7 +508,20 @@ where
     }
 
     pub fn remove(self) -> Value<S> {
-        self.oe.remove()
+        #[cfg(feature = "preserve_order")]
+        return self.swap_remove();
+        #[cfg(not(feature = "preserve_order"))]
+        return self.oe.remove();
+    }
+
+    #[cfg(feature = "preserve_order")]
+    pub fn swap_remove(self) -> Value<S> {
+        self.oe.swap_remove()
+    }
+
+    #[cfg(feature = "preserve_order")]
+    pub fn shift_remove(self) -> Value<S> {
+        self.oe.shift_remove()
     }
 }
 

--- a/crates/valence_nbt/src/compound.rs
+++ b/crates/valence_nbt/src/compound.rs
@@ -137,7 +137,6 @@ where
         self.map.insert(k.into(), v.into())
     }
 
-    #[inline]
     pub fn remove<Q>(&mut self, k: &Q) -> Option<Value<S>>
     where
         Q: ?Sized + AsBorrowed<S>,
@@ -151,7 +150,6 @@ where
     }
 
     #[cfg(feature = "preserve_order")]
-    #[inline]
     pub fn swap_remove<Q>(&mut self, k: &Q) -> Option<Value<S>>
     where
         Q: ?Sized + AsBorrowed<S>,
@@ -162,7 +160,6 @@ where
     }
 
     #[cfg(feature = "preserve_order")]
-    #[inline]
     pub fn shift_remove<Q>(&mut self, k: &Q) -> Option<Value<S>>
     where
         Q: ?Sized + AsBorrowed<S>,
@@ -172,7 +169,6 @@ where
         self.map.shift_remove(k.as_borrowed())
     }
 
-    #[inline]
     pub fn remove_entry<Q>(&mut self, k: &Q) -> Option<(S, Value<S>)>
     where
         S: Borrow<Q>,
@@ -185,7 +181,6 @@ where
     }
 
     #[cfg(feature = "preserve_order")]
-    #[inline]
     pub fn swap_remove_entry<Q>(&mut self, k: &Q) -> Option<(S, Value<S>)>
     where
         S: Borrow<Q>,
@@ -195,7 +190,6 @@ where
     }
 
     #[cfg(feature = "preserve_order")]
-    #[inline]
     pub fn shift_remove_entry<Q>(&mut self, k: &Q) -> Option<(S, Value<S>)>
     where
         S: Borrow<Q>,
@@ -510,7 +504,6 @@ where
         self.oe.insert(v.into())
     }
 
-    #[inline]
     pub fn remove(self) -> Value<S> {
         #[cfg(feature = "preserve_order")]
         return self.swap_remove();
@@ -519,13 +512,11 @@ where
     }
 
     #[cfg(feature = "preserve_order")]
-    #[inline]
     pub fn swap_remove(self) -> Value<S> {
         self.oe.swap_remove()
     }
 
     #[cfg(feature = "preserve_order")]
-    #[inline]
     pub fn shift_remove(self) -> Value<S> {
         self.oe.shift_remove()
     }

--- a/crates/valence_nbt/src/compound.rs
+++ b/crates/valence_nbt/src/compound.rs
@@ -172,6 +172,7 @@ where
         self.map.shift_remove(k.as_borrowed())
     }
 
+    #[inline]
     pub fn remove_entry<Q>(&mut self, k: &Q) -> Option<(S, Value<S>)>
     where
         S: Borrow<Q>,
@@ -184,6 +185,7 @@ where
     }
 
     #[cfg(feature = "preserve_order")]
+    #[inline]
     pub fn swap_remove_entry<Q>(&mut self, k: &Q) -> Option<(S, Value<S>)>
     where
         S: Borrow<Q>,
@@ -193,6 +195,7 @@ where
     }
 
     #[cfg(feature = "preserve_order")]
+    #[inline]
     pub fn shift_remove_entry<Q>(&mut self, k: &Q) -> Option<(S, Value<S>)>
     where
         S: Borrow<Q>,
@@ -507,6 +510,7 @@ where
         self.oe.insert(v.into())
     }
 
+    #[inline]
     pub fn remove(self) -> Value<S> {
         #[cfg(feature = "preserve_order")]
         return self.swap_remove();
@@ -515,11 +519,13 @@ where
     }
 
     #[cfg(feature = "preserve_order")]
+    #[inline]
     pub fn swap_remove(self) -> Value<S> {
         self.oe.swap_remove()
     }
 
     #[cfg(feature = "preserve_order")]
+    #[inline]
     pub fn shift_remove(self) -> Value<S> {
         self.oe.shift_remove()
     }


### PR DESCRIPTION
# Objective

IndexMap remove methods are deprecated in favor of [swap|shift]_remove

# Solution

match serde_json's implementation of swap and shift remove
