### PR TITLE
feat: make more fields pub

### DIFF
--- a/crates/valence_server/src/layer/chunk.rs
+++ b/crates/valence_server/src/layer/chunk.rs
@@ -64,7 +64,7 @@ impl fmt::Debug for ChunkLayerInfo {
 type ChunkLayerMessages = Messages<GlobalMsg, LocalMsg>;
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
-pub(crate) enum GlobalMsg {
+pub enum GlobalMsg {
     /// Send packet data to all clients viewing the layer.
     Packet,
     /// Send packet data to all clients viewing the layer, except the client
@@ -73,7 +73,7 @@ pub(crate) enum GlobalMsg {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
-pub(crate) enum LocalMsg {
+pub enum LocalMsg {
     /// Send packet data to all clients viewing the layer in view of `pos`.
     PacketAt {
         pos: ChunkPos,
@@ -371,7 +371,7 @@ impl ChunkLayer {
         &self.info
     }
 
-    pub(crate) fn messages(&self) -> &ChunkLayerMessages {
+    pub fn messages(&self) -> &ChunkLayerMessages {
         &self.messages
     }
 

--- a/crates/valence_server/src/layer/chunk/loaded.rs
+++ b/crates/valence_server/src/layer/chunk/loaded.rs
@@ -373,7 +373,7 @@ impl LoadedChunk {
     }
 
     /// Writes the packet data needed to initialize this chunk.
-    pub(crate) fn write_init_packets(
+    pub fn write_init_packets(
         &self,
         mut writer: impl WritePacket,
         pos: ChunkPos,

--- a/crates/valence_server_common/src/lib.rs
+++ b/crates/valence_server_common/src/lib.rs
@@ -110,9 +110,9 @@ impl Plugin for ServerPlugin {
 #[derive(Resource)]
 pub struct Server {
     /// Incremented on every tick.
-    current_tick: i64,
-    threshold: CompressionThreshold,
-    tick_rate: NonZeroU32,
+    pub current_tick: i64,
+    pub threshold: CompressionThreshold,
+    pub tick_rate: NonZeroU32,
 }
 
 impl Server {


### PR DESCRIPTION
# Objective

Allows creation of `Server` outside of bevy. This is required for `ChunkLayer`

https://github.com/valence-rs/valence/blob/8d9364d9e140d07e6dfa6dcce1cdf12cdfb6bf0d/crates/valence_server/src/layer/chunk.rs#L129-L134

# Solution

Make `Server` fields public.
