### PR TITLE
Fix command tree & small improvements

### DIFF
--- a/crates/valence_command/src/graph.rs
+++ b/crates/valence_command/src/graph.rs
@@ -194,7 +194,7 @@ impl From<CommandGraph> for CommandTreeS2c {
 
 /// Ergonomic builder pattern for adding executables, literals and arguments to
 /// a command graph. See the derive macro for a more ergonomic way of doing this
-/// for a basic command with an enum.
+/// for a basic command with an enum or struct.
 ///
 /// # Type Parameters
 /// * `T` - the type that should be constructed by an executable when the
@@ -226,7 +226,7 @@ impl From<CommandGraph> for CommandTreeS2c {
 ///    .literal("test") // add a literal node then transition to it
 ///    .argument("test")
 ///    // a player needs one of these scopes to execute the command
-///    //(note: if you want an admin scope you should use the link method on the scope registry.)
+///    // (note: if you want an admin scope you should use the link method on the scope registry.)
 ///    .with_scopes(vec!["test:admin", "command:test"])
 ///    .with_parser::<i32>()
 ///    // it is reasonably safe to unwrap here because we know that the argument is an integer

--- a/crates/valence_command/src/manager.rs
+++ b/crates/valence_command/src/manager.rs
@@ -151,10 +151,10 @@ fn update_client_command_tree(
         let mut new_root = None;
 
         while let Some((parent, node)) = to_visit.pop() {
-            if already_visited.contains(&(parent.map(|(_, edge)| edge), node)) {
+            if already_visited.contains(&(parent.map(|(node_id, _)| node_id), node)) {
                 continue;
             }
-            already_visited.insert((parent.map(|(_, edge)| edge), node));
+            already_visited.insert((parent.map(|(node_id, _)| node_id), node));
             let node_scopes = &old_graph.graph[node].scopes;
             if !node_scopes.is_empty() {
                 let mut has_scope = false;

--- a/crates/valence_command/src/manager.rs
+++ b/crates/valence_command/src/manager.rs
@@ -259,7 +259,6 @@ fn parse_incoming_commands(
             command_registry.modifiers[&node](modifier, &mut modifiers);
         }
 
-
         for node in to_be_executed {
             trace!("executing node: {node:?}");
             event_writer.send(CommandProcessedEvent {
@@ -269,9 +268,11 @@ fn parse_incoming_commands(
                 node,
             });
         }
-        info!("Command dispatched: /{} (debug logs for more data)", command_event.command);
+        info!(
+            "Command dispatched: /{} (debug logs for more data)",
+            command_event.command
+        );
         debug!("Command modifiers: {:?}", modifiers);
-        
     }
 }
 

--- a/crates/valence_command/src/manager.rs
+++ b/crates/valence_command/src/manager.rs
@@ -9,7 +9,7 @@ use bevy_ecs::prelude::{
 use petgraph::graph::NodeIndex;
 use petgraph::prelude::EdgeRef;
 use petgraph::{Direction, Graph};
-use tracing::{debug, warn};
+use tracing::{debug, info, trace, warn};
 use valence_server::client::{Client, SpawnClientsSet};
 use valence_server::event_loop::PacketEvent;
 use valence_server::protocol::packets::play::command_tree_s2c::NodeData;
@@ -259,10 +259,9 @@ fn parse_incoming_commands(
             command_registry.modifiers[&node](modifier, &mut modifiers);
         }
 
-        debug!("Command processed: /{}", command_event.command);
 
         for node in to_be_executed {
-            println!("executing node: {node:?}");
+            trace!("executing node: {node:?}");
             event_writer.send(CommandProcessedEvent {
                 command: args.join(" "),
                 executor,
@@ -270,6 +269,9 @@ fn parse_incoming_commands(
                 node,
             });
         }
+        info!("Command dispatched: /{} (debug logs for more data)", command_event.command);
+        debug!("Command modifiers: {:?}", modifiers);
+        
     }
 }
 


### PR DESCRIPTION
- The already visited map was using edge-type not the id of the parent and the node its pointing too this leads to a situation where if two nodes redirect to the same node only one path will be sent to the client while the other is ignored (this could even be non deterministic)
- The macro supports structs and enums now updated docs to reflect
- Added space in docs for readability
- added some debug and trace logging for commands (Is it a good idea to have the command dispatched message on info?)