### PR TITLE
nix: add aarch64 support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
 
   outputs = { self, nixpkgs, flake-utils, rust-overlay, ... }:
   flake-utils.lib.eachSystem
-    [ "x86_64-linux" ]
+    [ "x86_64-linux" "aarch64-linux" ]
     (system:
     let
       overlays = [ (import rust-overlay) ];


### PR DESCRIPTION
# Objective

- Added support for aarch64 platform for NixOS

# Solution

- Just add the `aarch64-linux` field in `flake.nix`
