### PR TITLE
fix digging stopping on start

### DIFF
--- a/crates/valence_server/src/action.rs
+++ b/crates/valence_server/src/action.rs
@@ -69,7 +69,7 @@ fn handle_player_action(
                         client: packet.client,
                         position: pkt.position,
                         direction: pkt.direction,
-                        state: DiggingState::Stop,
+                        state: DiggingState::Start,
                     });
                 }
                 PlayerAction::AbortDestroyBlock => {


### PR DESCRIPTION
For some silly reason when I updated to bevy 0.14 I copy pasted some code and forgot to change it. This fixes that.