### PR TITLE
fix ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
           </details>" > ./bad-depgraph/pr-comment.txt
 
       - name: Upload comment artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: ${{ failure() && github.event_name == 'pull_request' }}
         with:
           name: bad-depgraph

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Rust toolchain and cache
-        uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
+        uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
         with:
           toolchain: "nightly"
           components: "rustfmt"
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Rust toolchain and cache
-        uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
+        uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
 
       - name: Copy playground
         run: cp tools/playground/src/playground.template.rs tools/playground/src/playground.rs
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Rust toolchain and cache
-        uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
+        uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
         with:
           toolchain: "stable"
           components: "clippy"
@@ -99,7 +99,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Rust toolchain and cache
-        uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
+        uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
 
       - name: Copy playground
         run: cp tools/playground/src/playground.template.rs tools/playground/src/playground.rs
@@ -125,7 +125,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Rust toolchain and cache
-        uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
+        uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
         with:
           toolchain: "nightly"
           components: "miri"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,76 +107,76 @@ license = "MIT"
 
 [workspace.dependencies]
 aes = "0.8.4"
-anyhow = { version = "1.0.86", features = ["backtrace"] }
+anyhow = { version = "1.0.89", features = ["backtrace"] }
 approx = "0.5.1"
-arrayvec = "0.7.4"
-async-trait = "0.1.81"
+arrayvec = "0.7.6"
+async-trait = "0.1.82"
 atty = "0.2.14"
 base64 = "0.22.1"
-bevy_app = { version = "0.14.0", default-features = false }
-bevy_derive = "0.14.0"
-bevy_ecs = { version = "0.14.0", default-features = false, features = [
+bevy_app = { version = "0.14.2", default-features = false }
+bevy_derive = "0.14.2"
+bevy_ecs = { version = "0.14.2", default-features = false, features = [
     "multi_threaded",
 ] }
-bevy_hierarchy = { version = "0.14.0", default-features = false, features = ["bevy_app"] }
-bevy_log = { version = "0.14.0" }
-bevy_mod_debugdump = { version = "0.11.0" }
-bevy_utils = { version = "0.14.0" }
+bevy_hierarchy = { version = "0.14.2", default-features = false, features = ["bevy_app"] }
+bevy_log = { version = "0.14.2" }
+bevy_mod_debugdump = { version = "0.11.1" }
+bevy_utils = { version = "0.14.2" }
 bitfield-struct = "0.8.0"
 bitvec = "1.0.1"
 byteorder = "1.5.0"
-bytes = "1.6.1"
+bytes = "1.7.1"
 cesu8 = "1.1.0"
 cfb8 = "0.8.1"
-clap = { version = "4.5.11", features = ["derive"] }
-derive_more = "1.0.0-beta.6"
+clap = { version = "4.5.17", features = ["derive"] }
+derive_more = "1.0.0"
 directories = "5.0.1"
 divan = "0.1.14"
 eframe = { version = "0.28.1" }
 egui = "0.28.1"
 egui_dock = "0.13"
-flate2 = "1.0.30"
+flate2 = "1.0.33"
 flume = "0.11.0"
 fs_extra = "1.3.0"
-glam = "0.28.0"
+glam = "0.29.0"
 heck = "0.5.0"
 hmac = "0.12.1"
 image = "0.25.2"
-indexmap = "2.2.6"
+indexmap = "2.5.0"
 itertools = "0.13.0"
 java_string = { path = "crates/java_string", version = "0.1.2" }
-lru = "0.12.3"
+lru = "0.12.4"
 noise = "0.9.0"
 num = "0.4.3"
 num-bigint = "0.4.6"
-owo-colors = "4.0.0"
-ordered-float = "4.2.1"
+owo-colors = "4.1.0"
+ordered-float = "4.2.2"
 parking_lot = "0.12.3"
 paste = "1.0.15"
 petgraph = "0.6.5"
-pretty_assertions = "1.4.0"
+pretty_assertions = "1.4.1"
 proc-macro2 = "1.0.86"
-quote = "1.0.36"
+quote = "1.0.37"
 rand = "0.8.5"
 rayon = "1.10.0"
-regex = "1.10.5"
-reqwest = { version = "0.12.5", default-features = false }
+regex = "1.10.6"
+reqwest = { version = "0.12.7", default-features = false }
 rfd = "0.14.1"
 rsa = "0.9.6"
 rsa-der = "0.3.0"
 rustc-hash = "2.0.0"
-serde = "1.0.204"
+serde = "1.0.210"
 serde-value = "0.7.0"
-serde_json = "1.0.121"
+serde_json = "1.0.128"
 sha1 = "0.10.6"
 sha2 = "0.10.8"
-syn = "2.0.72"
+syn = "2.0.77"
 syntect = { version = "5.2.0", default-features = false }
-tempfile = "3.10.1"
+tempfile = "3.12.0"
 thiserror = "1.0.63"
 time = "0.3.36"
-tokio = { version = "1.39.2", features = ["full"] }
-toml = "0.8.16"
+tokio = { version = "1.40.0", features = ["full"] }
+toml = "0.8.19"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 url = { version = "2.5.2", features = ["serde"] }
@@ -209,7 +209,7 @@ valence_server_common = { path = "crates/valence_server_common", version = "0.2.
 valence_text = { path = "crates/valence_text", version = "0.2.0-alpha.1" }
 valence_weather = { path = "crates/valence_weather", version = "0.2.0-alpha.1" }
 valence_world_border = { path = "crates/valence_world_border", version = "0.2.0-alpha.1" }
-zip = "2.1.5"
+zip = "2.2.0"
 
 [workspace.lints.rust]
 # missing_debug_implementations = "warn" # TODO: enable me.`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,6 +209,7 @@ valence_server_common = { path = "crates/valence_server_common", version = "0.2.
 valence_text = { path = "crates/valence_text", version = "0.2.0-alpha.1" }
 valence_weather = { path = "crates/valence_weather", version = "0.2.0-alpha.1" }
 valence_world_border = { path = "crates/valence_world_border", version = "0.2.0-alpha.1" }
+vek = "0.17.1"
 zip = "2.2.0"
 
 [workspace.lints.rust]

--- a/crates/valence_spatial/Cargo.toml
+++ b/crates/valence_spatial/Cargo.toml
@@ -13,4 +13,4 @@ workspace = true
 [dependencies]
 approx.workspace = true
 rayon.workspace = true
-vek = "0.16.1" # TODO: remove this.
+vek.workspace = true


### PR DESCRIPTION
https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/:
> With the introduction of v4, we will be deprecating v1 and v2 of actions/upload-artifact, actions/download-artifact, and related npm packages on June 30, 2024. We strongly encourage customers to update their workflows to begin using v4 of the artifact actions.

EDIT: I have also updated deps to fix issues with CI