### PR TITLE
Readonly inventory

### DIFF
--- a/crates/valence_inventory/src/lib.rs
+++ b/crates/valence_inventory/src/lib.rs
@@ -1206,6 +1206,7 @@ fn handle_player_actions(
                                 slots: Cow::Borrowed(inv.slot_slice()),
                                 carried_item: Cow::Borrowed(&ItemStack::EMPTY),
                             });
+                            continue;
                         }
 
                         let stack = inv.replace_slot(held.slot(), ItemStack::EMPTY);

--- a/crates/valence_inventory/src/lib.rs
+++ b/crates/valence_inventory/src/lib.rs
@@ -73,7 +73,7 @@ pub struct Inventory {
     pub changed: u64,
     /// Makes a inventory read-only. This will prevent adding
     /// or removing items. If this is a player inventory
-    /// This will also make it impossible to drop items while not 
+    /// This will also make it impossible to drop items while not
     /// in the inventory (e.g. by pressing Q)
     pub readonly: bool,
 }
@@ -868,7 +868,7 @@ fn handle_click_slot(
 
         if pkt.slot_idx < 0 && pkt.mode == ClickMode::Click {
             // The client is dropping the cursor item by clicking outside the window.
-            
+
             let stack = std::mem::take(&mut cursor_item.0);
 
             if !stack.is_empty() {

--- a/crates/valence_inventory/src/lib.rs
+++ b/crates/valence_inventory/src/lib.rs
@@ -71,7 +71,7 @@ pub struct Inventory {
     /// Contains a set bit for each modified slot in `slots`.
     #[doc(hidden)]
     pub changed: u64,
-    /// Makes a inventory read-only. This will prevent adding
+    /// Makes an inventory read-only for clients. This will prevent adding
     /// or removing items. If this is a player inventory
     /// This will also make it impossible to drop items while not
     /// in the inventory (e.g. by pressing Q)

--- a/crates/valence_inventory/src/lib.rs
+++ b/crates/valence_inventory/src/lib.rs
@@ -1066,7 +1066,7 @@ fn handle_click_slot(
 
                     continue;
                 }
-              
+
                 let mut new_cursor = pkt.carried_item.clone();
 
                 for slot in pkt.slot_changes.iter() {
@@ -1101,7 +1101,7 @@ fn handle_click_slot(
                     }
                 }
 
-                cursor_item.set_if_neq(CursorItem(new_cursor));
+                cursor_item.set_if_neq(CursorItem(new_cursor.clone()));
                 inv_state.client_updated_cursor_item = Some(new_cursor);
 
                 if target_inventory.readonly || client_inv.readonly {
@@ -1161,9 +1161,9 @@ fn handle_click_slot(
                     }
                 }
 
-                cursor_item.set_if_neq(CursorItem(new_cursor));
+                cursor_item.set_if_neq(CursorItem(new_cursor.clone()));
                 inv_state.client_updated_cursor_item = Some(new_cursor);
-              
+
                 if client_inv.readonly {
                     // resync the client inventory
                     client.write_packet(&InventoryS2c {

--- a/src/tests/inventory.rs
+++ b/src/tests/inventory.rs
@@ -331,6 +331,79 @@ fn test_should_modify_open_inventory_click_slot() {
 }
 
 #[test]
+fn test_prevent_modify_open_inventory_click_slot_readonly_inventory() {
+    let ScenarioSingleClient {
+        mut app,
+        client,
+        mut helper,
+        ..
+    } = ScenarioSingleClient::new();
+
+    // The open inventory is readonly, the client can not interact with it.
+    let inventory_ent = set_up_open_inventory(&mut app, client);
+
+    let mut inventory = app
+        .world_mut()
+        .get_mut::<Inventory>(inventory_ent)
+        .expect("could not find inventory for client");
+
+    inventory.readonly = true;
+    inventory.set_slot(20, ItemStack::new(ItemKind::Diamond, 2, None));
+
+    // Process a tick to get past the "on join" logic.
+    app.update();
+    helper.clear_received();
+
+    // Make the client click the slot and pick up the item.
+    let inv_state = app.world_mut().get::<ClientInventoryState>(client).unwrap();
+    let state_id = inv_state.state_id();
+    let window_id = inv_state.window_id();
+
+    helper.send(&ClickSlotC2s {
+        window_id,
+        state_id: VarInt(state_id.0),
+        slot_idx: 20,
+        button: 0,
+        // If the inventory is readonly, this should actually not be possible,
+        // as you cant even select an item (so its on your cursor),
+        // this is also why 2 resyncs are sent, see below.
+        mode: ClickMode::Click,
+        slot_changes: vec![SlotChange {
+            idx: 20,
+            stack: ItemStack::EMPTY,
+        }]
+        .into(),
+        carried_item: ItemStack::new(ItemKind::Diamond, 2, None),
+    });
+
+    app.update();
+
+    let sent_packets = helper.collect_received();
+
+    // because the inventory is readonly, we need to resync the client's inventory.
+    // 2 resync packets are sent, see above.
+    sent_packets.assert_count::<InventoryS2c>(2);
+    sent_packets.assert_count::<ScreenHandlerSlotUpdateS2c>(0);
+
+    // Make assertions
+    let inventory = app
+        .world_mut()
+        .get::<Inventory>(inventory_ent)
+        .expect("could not find inventory");
+    // Inventory is read-only, the item is not being moved
+    assert_eq!(
+        inventory.slot(20),
+        &ItemStack::new(ItemKind::Diamond, 2, None)
+    );
+    let cursor_item = app
+        .world_mut()
+        .get::<CursorItem>(client)
+        .expect("could not find client");
+    // Inventory is read-only, items can not be picked up with the cursor
+    assert_eq!(cursor_item.0, ItemStack::EMPTY);
+}
+
+#[test]
 fn test_should_modify_open_inventory_server_side() {
     let ScenarioSingleClient {
         mut app,
@@ -371,6 +444,262 @@ fn test_should_modify_open_inventory_server_side() {
         &ItemStack::new(ItemKind::IronIngot, 1, None)
     );
 }
+
+// NOT WORKING
+// #[test]
+// fn test_prevent_hotbar_item_click_container_readonly_inventory() {
+//     let ScenarioSingleClient {
+//         mut app,
+//         client,
+//         mut helper,
+//         ..
+//     } = ScenarioSingleClient::new();
+
+//     // Process a tick to get past the "on join" logic.
+//     app.update();
+//     helper.clear_received();
+
+//     // player inventory is not read-only
+//     let mut player_inventory = app
+//         .world_mut()
+//         .get_mut::<Inventory>(client)
+//         .expect("could not find inventory for client");
+
+//     // 36 is the first hotbar slot
+//     player_inventory.set_slot(36, ItemStack::new(ItemKind::Diamond, 1,
+// None));
+
+//     let open_inv_ent = set_up_open_inventory(&mut app, client);
+
+//     let mut open_inventory = app
+//         .world_mut()
+//         .get_mut::<Inventory>(open_inv_ent)
+//         .expect("could not find inventory for client");
+
+//     // Open inventory is read-only
+//     // open_inventory.readonly = true;
+//     open_inventory.set_slot(0, ItemStack::new(ItemKind::IronIngot, 10,
+// None));
+
+//     let inv_state =
+// app.world_mut().get::<ClientInventoryState>(client).unwrap();
+//     let state_id = inv_state.state_id();
+//     let window_id = inv_state.window_id();
+
+//     // The player hovers over the iron ingots in the open inventory, and
+// tries     // to move them to their own (via pressing 1), which should swap
+// the iron     // for the diamonds. However the opened inventory is read-only,
+// so nothing     // should happen.
+//     helper.send(&ClickSlotC2s {
+//         window_id,
+//         state_id: VarInt(state_id.0),
+//         slot_idx: 0,
+//         button: 0, // hotbar slot starting at 0
+//         mode: ClickMode::Hotbar,
+//         slot_changes: vec![
+//             // First SlotChange is the item is the slot in the player's
+// hotbar.             // target slot.
+//             SlotChange {
+//                 idx: 0,
+//                 stack: ItemStack::new(ItemKind::Diamond, 1, None),
+//             },
+//             SlotChange {
+//                 // 54 is the players hotbar slot 1, when the 9x3 inventory is
+// opnened.                 idx: 54,
+//                 stack: ItemStack::new(ItemKind::IronIngot, 10, None),
+//             },
+//             // The second one is the slot in the open inventory, after the
+// ClickSlot action             // source slot.
+//         ]
+//         .into(),
+//         carried_item: ItemStack::EMPTY,
+//     });
+
+//     app.update();
+
+//     let sent_packets = helper.collect_received();
+
+//     // 1 resync for each inventory
+//     sent_packets.assert_count::<InventoryS2c>(2);
+
+//     // Make assertions
+//     let player_inventory = app
+//         .world_mut()
+//         .get::<Inventory>(client)
+//         .expect("could not find client");
+
+//     // Opened inventory is read-only, the items are not swapped.
+//     assert_eq!(player_inventory.slot(36), &ItemStack::new(ItemKind::Diamond,
+// 1, None));
+
+//     let open_inventory = app
+//         .world_mut()
+//         .get::<Inventory>(open_inv_ent)
+//         .expect("could not find inventory");
+
+//     // Opened inventory is read-only, the items are not swapped.
+//     assert_eq!(open_inventory.slot(0), &ItemStack::new(ItemKind::IronIngot,
+// 10, None)); }
+
+// NOT WORKING
+// #[test]
+// fn test_still_allow_hotbar_item_click_in_own_inventory_if_container_readonly_inventory() {
+//     let ScenarioSingleClient {
+//         mut app,
+//         client,
+//         mut helper,
+//         ..
+//     } = ScenarioSingleClient::new();
+
+//     // Process a tick to get past the "on join" logic.
+//     app.update();
+//     helper.clear_received();
+
+//     // player inventory is not read-only
+//     let mut player_inventory = app
+//         .world_mut()
+//         .get_mut::<Inventory>(client)
+//         .expect("could not find inventory for client");
+
+//     // 36 is the first hotbar slot
+//     player_inventory.set_slot(36, ItemStack::new(ItemKind::Diamond, 10,
+// None));
+
+//     let open_inv_ent = set_up_open_inventory(&mut app, client);
+
+//     let mut open_inventory = app
+//         .world_mut()
+//         .get_mut::<Inventory>(open_inv_ent)
+//         .expect("could not find inventory for client");
+
+//     // Open inventory is read-only
+//     open_inventory.readonly = true;
+
+//     let inv_state =
+// app.world_mut().get::<ClientInventoryState>(client).unwrap();
+//     let state_id = inv_state.state_id();
+//     let window_id = inv_state.window_id();
+
+//     // The player's inventory is not readonly, so the player should still be
+//     // able to move items from the hotbar to other parts of the inventory
+// even     // if the other inventory is still open.
+//     helper.send(&ClickSlotC2s {
+//         window_id,
+//         state_id: VarInt(state_id.0),
+//         slot_idx: 27,
+//         button: 0, // hotbar slot starting at 0
+//         mode: ClickMode::Hotbar,
+//         slot_changes: vec![
+//             SlotChange {
+//                 idx: 27,
+//                 stack: ItemStack::new(ItemKind::Diamond, 10, None),
+//             },
+//             SlotChange {
+//                 idx: 54,
+//                 stack: ItemStack::EMPTY,
+//             },
+//         ]
+//         .into(),
+//         carried_item: ItemStack::EMPTY,
+//     });
+
+//     app.update();
+//     // Make assertions
+//     let sent_packets = helper.collect_received();
+//     sent_packets.assert_count::<InventoryS2c>(2);
+
+//     let player_inventory = app
+//         .world_mut()
+//         .get::<Inventory>(client)
+//         .expect("could not find client");
+
+//     // Items swapped successfully, as player item is not read-only
+//     assert_eq!(player_inventory.slot(36), &ItemStack::EMPTY);
+//     assert_eq!(player_inventory.slot(9), &ItemStack::new(ItemKind::Diamond,
+// 1, None)); }
+
+// NOT WORKING
+// #[test]
+// fn test_prevent_shift_item_click_container_readonly_inventory() {
+//     let ScenarioSingleClient {
+//         mut app,
+//         client,
+//         mut helper,
+//         ..
+//     } = ScenarioSingleClient::new();
+
+//     // Process a tick to get past the "on join" logic.
+//     app.update();
+//     helper.clear_received();
+
+//     // player inventory is not read-only
+//     let mut player_inventory = app
+//         .world_mut()
+//         .get_mut::<Inventory>(client)
+//         .expect("could not find inventory for client");
+
+//     player_inventory.set_slot(9, ItemStack::new(ItemKind::Diamond, 64,
+// None));
+
+//     let open_inv_ent = set_up_open_inventory(&mut app, client);
+
+//     let mut open_inventory = app
+//         .world_mut()
+//         .get_mut::<Inventory>(open_inv_ent)
+//         .expect("could not find inventory for client");
+
+//     // Open inventory is read-only
+//     open_inventory.readonly = true;
+
+//     let inv_state =
+// app.world_mut().get::<ClientInventoryState>(client).unwrap();
+//     let state_id = inv_state.state_id();
+//     let window_id = inv_state.window_id();
+
+//     // The player tries to Shift-click transfer the stack of diamonds into
+// the open container     helper.send(&ClickSlotC2s {
+//         window_id,
+//         state_id: VarInt(state_id.0),
+//         slot_idx: 54,
+//         button: 0, // hotbar slot starting at 0
+//         mode: ClickMode::ShiftClick,
+//         slot_changes: vec![
+//             // target
+//             SlotChange {
+//                 idx: 0,
+//                 stack: ItemStack::new(ItemKind::Diamond, 64, None),
+//             },
+//             // source
+//             SlotChange {
+//                 idx: 27,
+//                 stack: ItemStack::EMPTY,
+//             },
+//         ]
+//         .into(),
+//         carried_item: ItemStack::EMPTY,
+//     });
+
+//     app.update();
+
+//     // Make assertions
+//     let sent_packets = helper.collect_received();
+//     sent_packets.assert_count::<InventoryS2c>(2);
+
+//     let player_inventory = app
+//         .world_mut()
+//         .get::<Inventory>(client)
+//         .expect("could not find client");
+
+//     assert_eq!(player_inventory.slot(9), &ItemStack::new(ItemKind::Diamond,
+// 64, None));
+
+//     let open_inventory = app
+//         .world_mut()
+//         .get::<Inventory>(open_inv_ent)
+//         .expect("could not find inventory");
+
+//     assert_eq!(open_inventory.slot(0), &ItemStack::EMPTY);
+// }
 
 #[test]
 fn test_should_sync_entire_open_inventory() {
@@ -641,6 +970,63 @@ mod dropping_items {
     }
 
     #[test]
+    fn prevent_drop_item_player_action_readonly_inventory() {
+        let ScenarioSingleClient {
+            mut app,
+            client,
+            mut helper,
+            ..
+        } = ScenarioSingleClient::new();
+
+        // Process a tick to get past the "on join" logic.
+        app.update();
+        helper.clear_received();
+
+        let mut inventory = app
+            .world_mut()
+            .get_mut::<Inventory>(client)
+            .expect("could not find inventory");
+        inventory.readonly = true;
+        inventory.set_slot(36, ItemStack::new(ItemKind::IronIngot, 3, None));
+
+        helper.send(&PlayerActionC2s {
+            action: PlayerAction::DropItem,
+            position: BlockPos::new(0, 0, 0),
+            direction: Direction::Down,
+            sequence: VarInt(0),
+        });
+
+        app.update();
+
+        // Make assertions
+        let inventory = app
+            .world_mut()
+            .get::<Inventory>(client)
+            .expect("could not find client");
+
+        assert_eq!(
+            inventory.slot(36),
+            // Inventory is read-only, item is not being dropped
+            &ItemStack::new(ItemKind::IronIngot, 3, None)
+        );
+
+        let events = app
+            .world_mut()
+            .get_resource::<Events<DropItemStackEvent>>()
+            .expect("expected drop item stack events");
+
+        let events = events.iter_current_update_events().collect::<Vec<_>>();
+
+        // when the inventory is read-only we do not emit a drop event
+        assert_eq!(events.len(), 0);
+
+        let sent_packets = helper.collect_received();
+
+        // we do need to update the player inventory so we dont desync
+        sent_packets.assert_count::<ScreenHandlerSlotUpdateS2c>(1);
+    }
+
+    #[test]
     fn should_drop_item_stack_player_action() {
         let ScenarioSingleClient {
             mut app,
@@ -691,6 +1077,60 @@ mod dropping_items {
             events[0].stack,
             ItemStack::new(ItemKind::IronIngot, 32, None)
         );
+    }
+
+    #[test]
+    fn prevent_drop_item_stack_player_action_readonly_inventory() {
+        let ScenarioSingleClient {
+            mut app,
+            client,
+            mut helper,
+            ..
+        } = ScenarioSingleClient::new();
+
+        // Process a tick to get past the "on join" logic.
+        app.update();
+        helper.clear_received();
+
+        let mut inventory = app
+            .world_mut()
+            .get_mut::<Inventory>(client)
+            .expect("could not find inventory");
+        inventory.readonly = true;
+        inventory.set_slot(36, ItemStack::new(ItemKind::IronIngot, 32, None));
+
+        helper.send(&PlayerActionC2s {
+            action: PlayerAction::DropAllItems,
+            position: BlockPos::new(0, 0, 0),
+            direction: Direction::Down,
+            sequence: VarInt(0),
+        });
+
+        app.update();
+
+        // Make assertions
+        let held = app
+            .world_mut()
+            .get::<HeldItem>(client)
+            .expect("could not find client");
+        assert_eq!(held.slot(), 36);
+        let inventory = app
+            .world_mut()
+            .get::<Inventory>(client)
+            .expect("could not find inventory");
+        // Inventory is read-only, item is not being dropped
+        assert_eq!(
+            inventory.slot(36),
+            &ItemStack::new(ItemKind::IronIngot, 32, None)
+        );
+        let events = app
+            .world_mut()
+            .get_resource::<Events<DropItemStackEvent>>()
+            .expect("expected drop item stack events");
+        let events = events.iter_current_update_events().collect::<Vec<_>>();
+
+        // when the inventory is read-only we do not emit a drop event
+        assert_eq!(events.len(), 0);
     }
 
     #[test]
@@ -855,6 +1295,73 @@ mod dropping_items {
     }
 
     #[test]
+    fn prevent_drop_item_click_container_with_dropkey_single_readonly_inventory() {
+        let ScenarioSingleClient {
+            mut app,
+            client,
+            mut helper,
+            ..
+        } = ScenarioSingleClient::new();
+
+        // Process a tick to get past the "on join" logic.
+        app.update();
+        helper.clear_received();
+
+        let inv_state = app
+            .world_mut()
+            .get_mut::<ClientInventoryState>(client)
+            .expect("could not find client");
+
+        let state_id = inv_state.state_id().0;
+
+        let mut inventory = app
+            .world_mut()
+            .get_mut::<Inventory>(client)
+            .expect("could not find inventory");
+
+        inventory.readonly = true;
+        inventory.set_slot(40, ItemStack::new(ItemKind::IronIngot, 32, None));
+
+        helper.send(&ClickSlotC2s {
+            window_id: 0,
+            slot_idx: 40,
+            button: 0,
+            mode: ClickMode::DropKey,
+            state_id: VarInt(state_id),
+            slot_changes: vec![SlotChange {
+                idx: 40,
+                stack: ItemStack::new(ItemKind::IronIngot, 31, None),
+            }]
+            .into(),
+            carried_item: ItemStack::EMPTY,
+        });
+
+        app.update();
+
+        // Make assertions
+        let inventory = app
+            .world_mut()
+            .get_mut::<Inventory>(client)
+            .expect("could not find inventory");
+
+        assert_eq!(
+            inventory.slot(40),
+            // Inventory is read-only, item is not being dropped
+            &ItemStack::new(ItemKind::IronIngot, 32, None)
+        );
+
+        let events = app
+            .world_mut()
+            .get_resource::<Events<DropItemStackEvent>>()
+            .expect("expected drop item stack events");
+
+        let events = events.iter_current_update_events().collect::<Vec<_>>();
+
+        // when the inventory is read-only we do not emit a drop event
+        assert_eq!(events.len(), 0);
+    }
+
+    #[test]
     fn should_drop_item_stack_click_container_with_dropkey() {
         let ScenarioSingleClient {
             mut app,
@@ -912,6 +1419,73 @@ mod dropping_items {
             events[0].stack,
             ItemStack::new(ItemKind::IronIngot, 32, None)
         );
+    }
+
+    #[test]
+    fn prevent_drop_item_stack_click_container_with_dropkey_readonly_inventory() {
+        let ScenarioSingleClient {
+            mut app,
+            client,
+            mut helper,
+            ..
+        } = ScenarioSingleClient::new();
+
+        // Process a tick to get past the "on join" logic.
+        app.update();
+        helper.clear_received();
+
+        let inv_state = app
+            .world_mut()
+            .get_mut::<ClientInventoryState>(client)
+            .expect("could not find client");
+
+        let state_id = inv_state.state_id().0;
+
+        let mut inventory = app
+            .world_mut()
+            .get_mut::<Inventory>(client)
+            .expect("could not find inventory");
+
+        inventory.readonly = true;
+        inventory.set_slot(40, ItemStack::new(ItemKind::IronIngot, 32, None));
+
+        helper.send(&ClickSlotC2s {
+            window_id: 0,
+            slot_idx: 40,
+            button: 1, // pressing control
+            mode: ClickMode::DropKey,
+            state_id: VarInt(state_id),
+            slot_changes: vec![SlotChange {
+                idx: 40,
+                stack: ItemStack::EMPTY,
+            }]
+            .into(),
+            carried_item: ItemStack::EMPTY,
+        });
+
+        app.update();
+
+        // Make assertions
+        let inventory = app
+            .world_mut()
+            .get_mut::<Inventory>(client)
+            .expect("could not find inventory");
+
+        assert_eq!(
+            inventory.slot(40),
+            // Inventory is read-only, item is not being dropped
+            &ItemStack::new(ItemKind::IronIngot, 32, None)
+        );
+
+        let events = app
+            .world_mut()
+            .get_resource::<Events<DropItemStackEvent>>()
+            .expect("expected drop item stack events");
+
+        let events = events.iter_current_update_events().collect::<Vec<_>>();
+
+        // when the inventory is read-only we do not emit a drop event
+        assert_eq!(events.len(), 0);
     }
 
     /// The item should be dropped successfully, if the player has an inventory
@@ -998,6 +1572,84 @@ mod dropping_items {
         assert_eq!(
             player_inventory.slot(expected_player_slot_id),
             &ItemStack::new(ItemKind::IronIngot, 31, None)
+        );
+    }
+
+    #[test]
+    fn prevent_drop_item_player_open_inventory_with_dropkey_readonly_inventory() {
+        let ScenarioSingleClient {
+            mut app,
+            client,
+            mut helper,
+            ..
+        } = ScenarioSingleClient::new();
+
+        // Process a tick to get past the "on join" logic.
+        app.update();
+
+        let mut inventory = app
+            .world_mut()
+            .get_mut::<Inventory>(client)
+            .expect("could not find inventory");
+
+        inventory.readonly = true;
+        inventory.set_slot(
+            convert_to_player_slot_id(InventoryKind::Generic9x3, 50),
+            ItemStack::new(ItemKind::IronIngot, 32, None),
+        );
+
+        let _inventory_ent = set_up_open_inventory(&mut app, client);
+
+        app.update();
+
+        helper.clear_received();
+
+        let inv_state = app
+            .world_mut()
+            .get_mut::<ClientInventoryState>(client)
+            .expect("could not find client");
+
+        let state_id = inv_state.state_id().0;
+        let window_id = inv_state.window_id();
+
+        helper.send(&ClickSlotC2s {
+            window_id,
+            state_id: VarInt(state_id),
+            slot_idx: 50, // not pressing control
+            button: 0,
+            mode: ClickMode::DropKey,
+            slot_changes: vec![SlotChange {
+                idx: 50,
+                stack: ItemStack::new(ItemKind::IronIngot, 31, None),
+            }]
+            .into(),
+            carried_item: ItemStack::EMPTY,
+        });
+
+        app.update();
+
+        // Make assertions
+        let events = app
+            .world()
+            .get_resource::<Events<DropItemStackEvent>>()
+            .expect("expected drop item stack events");
+
+        let player_inventory = app
+            .world()
+            .get::<Inventory>(client)
+            .expect("could not find inventory");
+
+        let events = events.iter_current_update_events().collect::<Vec<_>>();
+        // when the inventory is read-only we do not emit a drop event
+        assert_eq!(events.len(), 0);
+
+        // Also make sure that the player inventory was not updated (as it is
+        // read-only).
+        let expected_player_slot_id = convert_to_player_slot_id(InventoryKind::Generic9x3, 50);
+        assert_eq!(
+            player_inventory.slot(expected_player_slot_id),
+            // Inventory is read-only, item is not being dropped
+            &ItemStack::new(ItemKind::IronIngot, 32, None)
         );
     }
 }


### PR DESCRIPTION
# Objective
- ability to make inventories read only (player should be able to click things in the inventory and still emit a click event, this can be useful for creating inventory menus. 
- closes  #427
- related #307 #355 
# Solution

- adds a public ``readonly: bool`` field to the ``Inventory`` component, that will make any interactions with this item impossible (includes: moving, shift moving, hotbar moving, dropping) if a player inventory is readonly, then the player will also not be able to drop items (even when not in the inventory), so the drop event will not be emitted (this could be changed if requested)
- when implementing this i discovered a bug where a player is not able to put a item from a open inventory in the offhand (by hitting F) that will cause a desync. On the client the item will be in the offhand, but if you try to interact with that it dissapears. (unrelated to this PR and will not be fixed in this PR)


