### PR TITLE
update flake to support the egui packet inspector

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,24 +8,38 @@
       flake = false;
     };
   };
-
   outputs = { self, nixpkgs, flake-utils, rust-overlay, ... }:
   flake-utils.lib.eachSystem
     [ "x86_64-linux" "aarch64-linux" ]
     (system:
     let
-      overlays = [ (import rust-overlay) ];
+      overlays = [ (import rust-overlay)  ];
       pkgs = import nixpkgs {
         inherit system overlays;
       };
+
+      rust = pkgs.rust-bin.selectLatestNightlyWith (toolchain: toolchain.default);
+
+      appNativeBuildInputs = with pkgs; [
+          # required for the packet inspector on nix
+          pkg-config
+      ];
+      appBuildInputs = with pkgs; [
+          rust rust-analyzer
+          # dependencies for the packet inspector
+          udev alsa-lib vulkan-loader wayland
+          xorg.libX11 xorg.libXcursor xorg.libXi xorg.libXrandr
+          libxkbcommon wayland
+      ];
     in 
     rec
     {
-      devShell = pkgs.mkShell {
-        buildInputs = with pkgs; [
-          (rust-bin.selectLatestNightlyWith (toolchain: toolchain.default))
-          rust-analyzer
-        ];
-      };
+        devShell = pkgs.mkShell {
+            nativeBuildInputs = appNativeBuildInputs;
+            buildInputs = appBuildInputs;    
+            shellHook = ''
+                export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${pkgs.lib.makeLibraryPath appBuildInputs}"
+            '';
+        };
     });
 }


### PR DESCRIPTION
# Objective
When trying to use the packet inspector I noticed that it could not be ran on nix, the `nix develop` simply does not include the required libraries.
# Solution

I added dependencies listed for bevy window applications to work: https://github.com/bevyengine/bevy/blob/main/docs/linux_dependencies.md#nix and cleaned up the flake a bit while I was at it. 


