### PR TITLE
implement (de)serialize for ``ItemStack`` and ``ItemKind``

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ divan.workspace = true
 flume.workspace = true
 noise.workspace = true     # For the terrain example.
 tracing.workspace = true
+serde_json.workspace = true # For serialization tests.
 
 [dev-dependencies.reqwest]
 workspace = true

--- a/crates/valence_generated/Cargo.toml
+++ b/crates/valence_generated/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 valence_math.workspace = true
 valence_ident.workspace = true
 uuid.workspace = true
+serde = { workspace = true, features = ["derive"] }
 
 [build-dependencies]
 anyhow.workspace = true

--- a/crates/valence_generated/build/item.rs
+++ b/crates/valence_generated/build/item.rs
@@ -173,9 +173,6 @@ pub(crate) fn build() -> anyhow::Result<TokenStream> {
         .collect::<TokenStream>();
 
     Ok(quote! {
-        use serde::{Deserialize, Deserializer, Serialize, Serializer};
-        use serde::de::{self, Unexpected};
-
         /// Represents an item from the game
         #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Default)]
         #[repr(u16)]
@@ -196,23 +193,23 @@ pub(crate) fn build() -> anyhow::Result<TokenStream> {
             pub snack: bool,
         }
 
-        impl Serialize for ItemKind {
+        impl serde::Serialize for ItemKind {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
-                S: Serializer,
+                S: serde::Serializer,
             {
                 serializer.serialize_str(self.to_str())
             }
         }
 
-        impl<'de> Deserialize<'de> for ItemKind {
+        impl<'de> serde::Deserialize<'de> for ItemKind {
             fn deserialize<D>(deserializer: D) -> Result<ItemKind, D::Error>
             where
-                D: Deserializer<'de>,
+                D: serde::Deserializer<'de>,
             {
-                let s: &str = Deserialize::deserialize(deserializer)?;
+                let s: &str = serde::Deserialize::deserialize(deserializer)?;
                 ItemKind::from_str(s).ok_or_else(|| {
-                    de::Error::invalid_value(Unexpected::Str(s), &"the snake case item name, like \"white_wool\"")
+                    serde::de::Error::invalid_value(serde::de::Unexpected::Str(s), &"the snake case item name, like \"white_wool\"")
                 })
             }
         }

--- a/crates/valence_protocol/src/item.rs
+++ b/crates/valence_protocol/src/item.rs
@@ -1,12 +1,13 @@
 use std::io::Write;
 
+use serde::{Deserialize, Serialize};
 pub use valence_generated::item::ItemKind;
 use valence_nbt::Compound;
 
 use crate::{Decode, Encode};
 
 /// A stack of items in an inventory.
-#[derive(Clone, PartialEq, Debug, Default)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug, Default)]
 pub struct ItemStack {
     pub item: ItemKind,
     pub count: i8,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -7,5 +7,6 @@ mod layer;
 mod player_list;
 mod potions;
 mod scoreboard;
+mod serialization;
 mod weather;
 mod world_border;

--- a/src/tests/serialization.rs
+++ b/src/tests/serialization.rs
@@ -1,0 +1,35 @@
+use crate::ItemKind;
+
+#[test]
+fn test_serialize_item_kind() {
+    let item = ItemKind::WhiteWool;
+    let serialized = serde_json::to_string(&item).unwrap();
+    assert_eq!(serialized, "\"white_wool\"");
+
+    let item = ItemKind::GoldenSword;
+    let serialized = serde_json::to_string(&item).unwrap();
+    assert_eq!(serialized, "\"golden_sword\"");
+
+    let item = ItemKind::NetheriteAxe;
+    let serialized = serde_json::to_string(&item).unwrap();
+    assert_eq!(serialized, "\"netherite_axe\"");
+
+    let item = ItemKind::WaxedWeatheredCutCopperStairs;
+    let serialized = serde_json::to_string(&item).unwrap();
+    assert_eq!(serialized, "\"waxed_weathered_cut_copper_stairs\"");
+}
+
+#[test]
+fn test_deserialize_item_kind() {
+    let id = "\"diamond_shovel\"";
+    let deserialized: ItemKind = serde_json::from_str(id).unwrap();
+    assert_eq!(deserialized, ItemKind::DiamondShovel);
+
+    let id = "\"minecart\"";
+    let deserialized: ItemKind = serde_json::from_str(id).unwrap();
+    assert_eq!(deserialized, ItemKind::Minecart);
+
+    let id = "\"vindicator_spawn_egg\"";
+    let deserialized: ItemKind = serde_json::from_str(id).unwrap();
+    assert_eq!(deserialized, ItemKind::VindicatorSpawnEgg);
+}


### PR DESCRIPTION
# Objective
- Make it possible to serialize/deserialize ItemStacks without having to implement custom logic
# Solution
- implement ``serde::Serialize`` and ``serde::Deserialize``, ItemKinds will be serialized to their snake case name: e.g `white_wool`
