### PR TITLE
handle clicks outside inventory and non modifying clicks

### DIFF
--- a/crates/valence_inventory/src/lib.rs
+++ b/crates/valence_inventory/src/lib.rs
@@ -883,7 +883,7 @@ fn handle_click_slot(
             continue;
         }
 
-        if pkt.slot_idx < 0 && pkt.mode == ClickMode::Click {
+        if pkt.slot_idx == -999 && pkt.mode == ClickMode::Click {
             // The client is dropping the cursor item by clicking outside the window.
 
             let stack = std::mem::take(&mut cursor_item.0);
@@ -924,6 +924,10 @@ fn handle_click_slot(
                         carried_item: Cow::Borrowed(&cursor_item.0),
                     });
 
+                    continue;
+                }
+                if pkt.slot_idx == -999 {
+                    // The player was just clicking outside the inventories without holding an item
                     continue;
                 }
 
@@ -1014,7 +1018,10 @@ fn handle_click_slot(
                     });
                     continue;
                 }
-
+                if pkt.slot_idx == -999 {
+                    // The player was just clicking outside the inventories without holding an item
+                    continue;
+                }
                 let stack = client_inv.slot(pkt.slot_idx as u16);
 
                 if !stack.is_empty() {

--- a/crates/valence_inventory/src/validate.rs
+++ b/crates/valence_inventory/src/validate.rs
@@ -1,4 +1,4 @@
-use valence_server::protocol::anyhow::{self, bail, ensure}
+use valence_server::protocol::anyhow::{self, bail, ensure};
 use valence_server::protocol::packets::play::click_slot_c2s::ClickMode;
 use valence_server::protocol::packets::play::ClickSlotC2s;
 

--- a/crates/valence_inventory/src/validate.rs
+++ b/crates/valence_inventory/src/validate.rs
@@ -1,4 +1,4 @@
-use valence_server::protocol::anyhow::{self, bail, ensure};
+use valence_server::protocol::anyhow::{self, bail, ensure}
 use valence_server::protocol::packets::play::click_slot_c2s::ClickMode;
 use valence_server::protocol::packets::play::ClickSlotC2s;
 
@@ -877,7 +877,7 @@ mod tests {
             .expect("packet should be valid");
     }
     #[test]
-    fn allow_clicking_outside_inventory_when_not_holding_anything_sucess() {
+    fn allow_clicking_outside_inventory_when_not_holding_anything_success() {
         let player_inventory = Inventory::new(InventoryKind::Player);
         let cursor_item = CursorItem(ItemStack::new(ItemKind::Air, 0, None));
 
@@ -896,7 +896,7 @@ mod tests {
             .expect("packet should be valid");
     }
     #[test]
-    fn allow_clicking_outside_inventory_when_holding_somthing_sucess() {
+    fn allow_clicking_outside_inventory_when_holding_something_success() {
         let player_inventory = Inventory::new(InventoryKind::Player);
         let cursor_item = CursorItem(ItemStack::new(ItemKind::Air, 0, None));
 


### PR DESCRIPTION
# Objective

Fixes some re-syncs because the validation did not accept the now specific cases (all of the affected modifications where cases where the user did not modify the inventory)

Cases like:
- user clicks without an item on the cursor outside the inventory
- user clicks on the margin area without an item held
- user clicks on an empty slot when not holding anything 
- user uses hotbar keybinds on an empty slot to an empty hotbar slot

This causes unneccery re-syncs to the client and also unneccery logs indicating some illegal client packets, while these packets are totaly fine

# Solution

adjusted packet validation logic to allow these cases, but also check for "conservation of mass" when these special magic slot ids shows up
modified the handling code to basically ignore these changes, (I guess there is room for improvement here, as some event would probably be nice to publish in these cases?)

