### PR TITLE
ignore client nbt for hotbar click

### DIFF
--- a/crates/valence_inventory/src/validate.rs
+++ b/crates/valence_inventory/src/validate.rs
@@ -291,13 +291,17 @@ pub(super) fn validate_click_slot_packet(
                     window.slot(packet.slot_changes[0].idx as u16),
                     window.slot(packet.slot_changes[1].idx as u16),
                 ];
+                // There are some cases where the client will add NBT data that did not
+                // previously exist.
                 ensure!(
                     old_slots
                         .iter()
-                        .any(|s| *s == &packet.slot_changes[0].stack)
+                        .any(|s| s.item == packet.slot_changes[0].stack.item
+                            && s.count == packet.slot_changes[0].stack.count)
                         && old_slots
                             .iter()
-                            .any(|s| *s == &packet.slot_changes[1].stack),
+                            .any(|s| s.item == packet.slot_changes[1].stack.item
+                                && s.count == packet.slot_changes[1].stack.count),
                     "swapped items must match"
                 );
             }


### PR DESCRIPTION
Client NBT can be different from whats on the server (e.g when you have armor on you and you move it, the client will add the Damage value). For ``ClickMode::ShiftClicking``/``ClickMode::Click`` this is already handled https://github.com/valence-rs/valence/blob/76fb18f185913a9279862a3084787b2afeb514f2/crates/valence_inventory/src/validate.rs#L198.

Now its also handled for `ClickMode::Hotbar`



