### PR TITLE
Fix empty scopes in command macros and make scopes affect alternate enum paths

### DIFF
--- a/crates/valence_command_macros/src/lib.rs
+++ b/crates/valence_command_macros/src/lib.rs
@@ -224,7 +224,7 @@ fn process_paths_enum(
                 CommandArg::Literal(lit) => {
                     inner_expansion = quote! {
                         #inner_expansion.literal(#lit)
-
+                                .with_scopes(vec![#(#outer_scopes),*])
                     };
                     if executables && i == path.len() - 1 {
                         inner_expansion = quote! {

--- a/crates/valence_command_macros/src/lib.rs
+++ b/crates/valence_command_macros/src/lib.rs
@@ -432,9 +432,11 @@ fn process_paths_struct(
                     }
 
                     if path_first {
-                        inner_expansion = quote! {
-                            #inner_expansion.with_scopes(vec![#(#outer_scopes),*])
-                        };
+                        if !outer_scopes.is_empty() {
+                            inner_expansion = quote! {
+                                #inner_expansion.with_scopes(vec![#(#outer_scopes),*])
+                            }
+                        }
                         path_first = false;
                     }
                 }
@@ -593,10 +595,11 @@ fn process_paths_struct(
                     }
 
                     if path_first {
-                        inner_expansion = quote! {
-                            #inner_expansion
-                                .with_scopes(vec![#(#outer_scopes),*])
-                        };
+                        if !outer_scopes.is_empty() {
+                            inner_expansion = quote! {
+                                #inner_expansion.with_scopes(vec![#(#outer_scopes),*])
+                            };
+                        }
                         path_first = false;
                     }
                 }

--- a/crates/valence_command_macros/src/lib.rs
+++ b/crates/valence_command_macros/src/lib.rs
@@ -53,7 +53,7 @@ fn command(input: DeriveInput) -> Result<TokenStream> {
                         &fields,
                         variant_ident.clone(),
                         true,
-                        outer_scopes
+                        outer_scopes.clone(),
                     );
                     quote! { #processed; }
                 });
@@ -67,6 +67,7 @@ fn command(input: DeriveInput) -> Result<TokenStream> {
                     format_ident!("{}Root", input_name), // this is more of placeholder
                     // (should never be used)
                     false,
+                    outer_scopes.clone(),
                 ); // this will error if the base path has args
                 let mut expanded_main_command = quote! {
                     let command_root_node = #processed
@@ -93,6 +94,7 @@ fn command(input: DeriveInput) -> Result<TokenStream> {
                         &Fields::Unit,
                         format_ident!("{}Root", input_name),
                         false,
+                        outer_scopes.clone(),
                     );
 
                     alias_expansion = quote! {

--- a/crates/valence_command_macros/src/lib.rs
+++ b/crates/valence_command_macros/src/lib.rs
@@ -469,10 +469,7 @@ fn process_paths_struct(
                         };
                     }
 
-
                     if path_first {
-
-
                         if !outer_scopes.is_empty() {
                             inner_expansion = quote! {
                                 #inner_expansion.with_scopes(vec![#(#outer_scopes),*])

--- a/crates/valence_command_macros/src/lib.rs
+++ b/crates/valence_command_macros/src/lib.rs
@@ -53,6 +53,7 @@ fn command(input: DeriveInput) -> Result<TokenStream> {
                         &fields,
                         variant_ident.clone(),
                         true,
+                        outer_scopes
                     );
                     quote! { #processed; }
                 });
@@ -183,6 +184,7 @@ fn process_paths_enum(
     fields: &Fields,
     variant_ident: Ident,
     executables: bool,
+    outer_scopes: Vec<String>,
 ) -> proc_macro2::TokenStream {
     let mut inner_expansion = quote! {};
     let mut first = true;

--- a/crates/valence_command_macros/src/lib.rs
+++ b/crates/valence_command_macros/src/lib.rs
@@ -228,8 +228,12 @@ fn process_paths_enum(
                 CommandArg::Literal(lit) => {
                     inner_expansion = quote! {
                         #inner_expansion.literal(#lit)
-                                .with_scopes(vec![#(#outer_scopes),*])
                     };
+                    if !outer_scopes.is_empty() {
+                        inner_expansion = quote! {
+                            #inner_expansion.with_scopes(vec![#(#outer_scopes),*])
+                        }
+                    }
                     if executables && i == path.len() - 1 {
                         inner_expansion = quote! {
                             #inner_expansion
@@ -429,8 +433,7 @@ fn process_paths_struct(
 
                     if path_first {
                         inner_expansion = quote! {
-                            #inner_expansion
-                                .with_scopes(vec![#(#outer_scopes),*])
+                            #inner_expansion.with_scopes(vec![#(#outer_scopes),*])
                         };
                         path_first = false;
                     }
@@ -464,11 +467,15 @@ fn process_paths_struct(
                         };
                     }
 
+
                     if path_first {
-                        inner_expansion = quote! {
-                            #inner_expansion
-                                .with_scopes(vec![#(#outer_scopes),*])
-                        };
+
+
+                        if !outer_scopes.is_empty() {
+                            inner_expansion = quote! {
+                                #inner_expansion.with_scopes(vec![#(#outer_scopes),*])
+                            };
+                        }
                         path_first = false;
                     }
                 }


### PR DESCRIPTION
Fix empty scopes in command macros and make scopes effect alternate enum paths.