### PR TITLE
Broadcast equipment interaction

### DIFF
--- a/crates/valence_equipment/src/interaction_broadcast.rs
+++ b/crates/valence_equipment/src/interaction_broadcast.rs
@@ -1,0 +1,37 @@
+use valence_inventory::PlayerAction;
+use valence_server::{entity::living::LivingFlags, event_loop::PacketEvent, interact_item::InteractItemEvent, protocol::packets::play::PlayerActionC2s};
+
+use super::*;
+
+/// This component will broadcast item interactions (e.g. drawing a bow, eating food) to other players by setting the "using_item" LivingFlag.
+#[derive(Debug, Default, Clone, Component)]
+pub struct EquipmentInteractionBroadcast;
+
+// Sets "using_item" flag to true when the client starts interacting with an item.
+pub(crate) fn start_interaction(
+    mut clients: Query<&mut LivingFlags, (With<Client>, With<EquipmentInteractionBroadcast>)>,
+    mut events: EventReader<InteractItemEvent>,
+) {
+    for event in events.read() {
+        if let Ok(mut flags) = clients.get_mut(event.client) {
+            flags.set_using_item(true);
+        }
+    }
+}
+
+
+// Sets "using_item" flag to false when the client stops interacting with an item.
+pub(crate) fn stop_interaction(
+    mut clients: Query<&mut LivingFlags, (With<Client>, With<EquipmentInteractionBroadcast>)>,
+    mut packets: EventReader<PacketEvent>,
+) {
+    for packet in packets.read() {
+        if let Some(pkt) = packet.decode::<PlayerActionC2s>() {
+            if pkt.action == PlayerAction::ReleaseUseItem {
+                if let Ok(mut flags) = clients.get_mut(packet.client) {
+                    flags.set_using_item(false);
+                }
+            }
+        }
+    }
+}

--- a/crates/valence_equipment/src/interaction_broadcast.rs
+++ b/crates/valence_equipment/src/interaction_broadcast.rs
@@ -1,5 +1,3 @@
-use std::i8;
-
 use valence_inventory::{HeldItem, Inventory, PlayerAction};
 use valence_server::entity::living::LivingFlags;
 use valence_server::event_loop::PacketEvent;
@@ -10,11 +8,11 @@ use valence_server::ItemKind;
 use super::*;
 
 /// This component will broadcast item interactions (e.g. drawing a bow, eating
-/// food) to other players by setting the "using_item" LivingFlag.
+/// food) to other players using `LivingFlags::set_using_item`.
 #[derive(Debug, Default, Clone, Component)]
 pub struct EquipmentInteractionBroadcast;
 
-// Sets "using_item" flag to true when the client starts interacting with an
+// Sets flag to true when the client starts interacting with an
 // item.
 pub(crate) fn start_interaction(
     mut clients: Query<
@@ -39,7 +37,7 @@ pub(crate) fn start_interaction(
     }
 }
 
-// Sets "using_item" flag to false when the client stops interacting with an
+// Sets flag to false when the client stops interacting with an
 // item.
 pub(crate) fn stop_interaction(
     mut clients: Query<&mut LivingFlags, (With<Client>, With<EquipmentInteractionBroadcast>)>,

--- a/crates/valence_equipment/src/interaction_broadcast.rs
+++ b/crates/valence_equipment/src/interaction_broadcast.rs
@@ -1,13 +1,18 @@
 use valence_inventory::PlayerAction;
-use valence_server::{entity::living::LivingFlags, event_loop::PacketEvent, interact_item::InteractItemEvent, protocol::packets::play::PlayerActionC2s};
+use valence_server::entity::living::LivingFlags;
+use valence_server::event_loop::PacketEvent;
+use valence_server::interact_item::InteractItemEvent;
+use valence_server::protocol::packets::play::PlayerActionC2s;
 
 use super::*;
 
-/// This component will broadcast item interactions (e.g. drawing a bow, eating food) to other players by setting the "using_item" LivingFlag.
+/// This component will broadcast item interactions (e.g. drawing a bow, eating
+/// food) to other players by setting the "using_item" LivingFlag.
 #[derive(Debug, Default, Clone, Component)]
 pub struct EquipmentInteractionBroadcast;
 
-// Sets "using_item" flag to true when the client starts interacting with an item.
+// Sets "using_item" flag to true when the client starts interacting with an
+// item.
 pub(crate) fn start_interaction(
     mut clients: Query<&mut LivingFlags, (With<Client>, With<EquipmentInteractionBroadcast>)>,
     mut events: EventReader<InteractItemEvent>,
@@ -19,8 +24,8 @@ pub(crate) fn start_interaction(
     }
 }
 
-
-// Sets "using_item" flag to false when the client stops interacting with an item.
+// Sets "using_item" flag to false when the client stops interacting with an
+// item.
 pub(crate) fn stop_interaction(
     mut clients: Query<&mut LivingFlags, (With<Client>, With<EquipmentInteractionBroadcast>)>,
     mut packets: EventReader<PacketEvent>,

--- a/crates/valence_equipment/src/lib.rs
+++ b/crates/valence_equipment/src/lib.rs
@@ -2,6 +2,8 @@
 
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
+mod interaction_broadcast;
+pub use interaction_broadcast::EquipmentInteractionBroadcast;
 mod inventory_sync;
 pub use inventory_sync::EquipmentInventorySync;
 use valence_server::client::{Client, FlushPacketsSet, LoadEntityForClientEvent};
@@ -20,6 +22,8 @@ impl Plugin for EquipmentPlugin {
             PreUpdate,
             (
                 on_entity_init,
+                interaction_broadcast::start_interaction,
+                interaction_broadcast::stop_interaction,
                 inventory_sync::on_attach_inventory_sync,
                 inventory_sync::equipment_inventory_sync,
                 inventory_sync::equipment_held_item_sync_from_client,

--- a/examples/equipment.rs
+++ b/examples/equipment.rs
@@ -97,7 +97,9 @@ fn init_clients(
         inv.set_slot(36, ItemStack::new(ItemKind::Bow, 1, None));
         inv.set_slot(37, ItemStack::new(ItemKind::GoldenApple, 1, None));
 
-        commands.entity(player).insert((EquipmentInventorySync, EquipmentInteractionBroadcast));
+        commands
+            .entity(player)
+            .insert((EquipmentInventorySync, EquipmentInteractionBroadcast));
     }
 }
 

--- a/examples/equipment.rs
+++ b/examples/equipment.rs
@@ -95,7 +95,10 @@ fn init_clients(
         visible_entity_layers.0.insert(layer);
         *game_mode = GameMode::Survival;
         inv.set_slot(36, ItemStack::new(ItemKind::Bow, 1, None));
-        inv.set_slot(37, ItemStack::new(ItemKind::GoldenApple, 1, None));
+        inv.set_slot(37, ItemStack::new(ItemKind::Crossbow, 1, None));
+        inv.set_slot(38, ItemStack::new(ItemKind::GoldenApple, 1, None));
+        inv.set_slot(44, ItemStack::new(ItemKind::Arrow, 1, None));
+        inv.set_slot(45, ItemStack::new(ItemKind::FireworkRocket, 1, None));
 
         commands
             .entity(player)

--- a/examples/equipment.rs
+++ b/examples/equipment.rs
@@ -6,7 +6,7 @@ use rand::Rng;
 use valence::entity::armor_stand::ArmorStandEntityBundle;
 use valence::entity::zombie::ZombieEntityBundle;
 use valence::prelude::*;
-use valence_equipment::EquipmentInventorySync;
+use valence_equipment::{EquipmentInteractionBroadcast, EquipmentInventorySync};
 
 pub fn main() {
     App::new()
@@ -71,6 +71,7 @@ fn init_clients(
             &mut VisibleChunkLayer,
             &mut VisibleEntityLayers,
             &mut GameMode,
+            &mut Inventory,
         ),
         Added<Client>,
     >,
@@ -83,6 +84,7 @@ fn init_clients(
         mut visible_chunk_layer,
         mut visible_entity_layers,
         mut game_mode,
+        mut inv,
     ) in &mut clients
     {
         let layer = layers.single();
@@ -92,12 +94,14 @@ fn init_clients(
         visible_chunk_layer.0 = layer;
         visible_entity_layers.0.insert(layer);
         *game_mode = GameMode::Survival;
+        inv.set_slot(36, ItemStack::new(ItemKind::Bow, 1, None));
+        inv.set_slot(37, ItemStack::new(ItemKind::GoldenApple, 1, None));
 
-        commands.entity(player).insert(EquipmentInventorySync);
+        commands.entity(player).insert((EquipmentInventorySync, EquipmentInteractionBroadcast));
     }
 }
 
-fn randomize_equipment(mut query: Query<&mut Equipment>, server: Res<Server>) {
+fn randomize_equipment(mut query: Query<&mut Equipment, Without<Client>>, server: Res<Server>) {
     let ticks = server.current_tick() as u32;
     // every second
     if ticks % server.tick_rate() != 0 {


### PR DESCRIPTION
# Objective

To broadcast players' item interactions to other players as part of `EquipmentPlugin`

# Solution

When a player has the `EquipmentInteractionBroadcast` component:
- Set the "use_item" LivingFlag to true whenever an `InteractItemEvent` is received
- Set the flag false when a `PlayerActionC2s` packet with a `PlayerAction::ReleaseUseItem` action is received