### PR TITLE
Fix stresser compilation issue

### DIFF
--- a/crates/java_string/src/slice.rs
+++ b/crates/java_string/src/slice.rs
@@ -2190,12 +2190,14 @@ unsafe impl JavaStrSliceIndex for RangeFrom<usize> {
 
     #[inline]
     unsafe fn get_unchecked(self, slice: *const JavaStr) -> *const JavaStr {
+        #[allow(clippy::needless_borrow)]
         let len = unsafe { (&(*(slice as *const [u8]))).len() };
         unsafe { (self.start..len).get_unchecked(slice) }
     }
 
     #[inline]
     unsafe fn get_unchecked_mut(self, slice: *mut JavaStr) -> *mut JavaStr {
+        #[allow(clippy::needless_borrow)]
         let len = unsafe { (&(*(slice as *mut [u8]))).len() };
         unsafe { (self.start..len).get_unchecked_mut(slice) }
     }

--- a/crates/java_string/src/slice.rs
+++ b/crates/java_string/src/slice.rs
@@ -2190,13 +2190,13 @@ unsafe impl JavaStrSliceIndex for RangeFrom<usize> {
 
     #[inline]
     unsafe fn get_unchecked(self, slice: *const JavaStr) -> *const JavaStr {
-        let len = unsafe { (*(slice as *const [u8])).len() };
+        let len = unsafe { (&(*(slice as *const [u8]))).len() };
         unsafe { (self.start..len).get_unchecked(slice) }
     }
 
     #[inline]
     unsafe fn get_unchecked_mut(self, slice: *mut JavaStr) -> *mut JavaStr {
-        let len = unsafe { (*(slice as *mut [u8])).len() };
+        let len = unsafe { (&(*(slice as *mut [u8]))).len() };
         unsafe { (self.start..len).get_unchecked_mut(slice) }
     }
 }

--- a/crates/valence_network/src/lib.rs
+++ b/crates/valence_network/src/lib.rs
@@ -421,7 +421,7 @@ pub trait NetworkCallbacks: Send + Sync + 'static {
     ///
     /// TODO
     ///
-    /// [`Client`]: valence::client::Client
+    /// [`Client`]: valence_server::client::Client
     async fn login(
         &self,
         shared: &SharedNetworkState,

--- a/tools/stresser/Cargo.toml
+++ b/tools/stresser/Cargo.toml
@@ -17,4 +17,4 @@ anyhow.workspace = true
 clap.workspace = true
 tokio.workspace = true
 uuid = { workspace = true, features = ["v4"] }
-valence_protocol.workspace = true
+valence_protocol = { workspace = true, features = ["compression"] }


### PR DESCRIPTION
# Objective

Make the stresser compile properly again.
Current you get this error when you attempt to compile:
```
error[E0599]: no method named `set_compression` found for struct `PacketDecoder` in the current scope
  --> tools/stresser/src/stresser.rs:89:25
   |
89 |                     dec.set_compression(CompressionThreshold(threshold));
   |                         ^^^^^^^^^^^^^^^ method not found in `PacketDecoder`

error[E0599]: no method named `set_compression` found for struct `PacketEncoder` in the current scope
  --> tools/stresser/src/stresser.rs:90:25
   |
90 |                     enc.set_compression(CompressionThreshold(threshold));
   |                         ^^^^^^^^^^^^^^^ method not found in `PacketEncoder`
```

# Solution

Enable the `compression` feature in `valence_protocol` in the stresser `Cargo.toml` file.