### PR TITLE
Pin Rust version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
         with:
-          toolchain: "nightly"
+          toolchain: "1.89.0"
           components: "rustfmt"
 
       - name: Copy playground
@@ -127,7 +127,7 @@ jobs:
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
         with:
-          toolchain: "nightly"
+          toolchain: "1.89.0"
           components: "miri"
 
       - name: Run tests
@@ -217,7 +217,7 @@ jobs:
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
         with:
-          toolchain: "nightly"
+          toolchain: "1.89.0"
 
       - name: Install cargo-udeps
         uses: baptiste0928/cargo-install@v2.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
         with:
-          toolchain: "nightly-2025-05-18"
+          toolchain: "1.87.0"
           components: "rustfmt"
 
       - name: Copy playground
@@ -127,7 +127,7 @@ jobs:
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
         with:
-          toolchain: "nightly-2025-05-18"
+          toolchain: "1.87.0"
           components: "miri"
 
       - name: Run tests
@@ -217,7 +217,7 @@ jobs:
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
         with:
-          toolchain: "nightly-2025-05-18"
+          toolchain: "nightly"
 
       - name: Install cargo-udeps
         uses: baptiste0928/cargo-install@v2.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
         with:
-          toolchain: "1.89.0"
+          toolchain: "nightly-2025-05-18"
           components: "rustfmt"
 
       - name: Copy playground
@@ -127,7 +127,7 @@ jobs:
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
         with:
-          toolchain: "1.89.0"
+          toolchain: "nightly-2025-05-18"
           components: "miri"
 
       - name: Run tests
@@ -217,7 +217,7 @@ jobs:
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
         with:
-          toolchain: "1.89.0"
+          toolchain: "nightly-2025-05-18"
 
       - name: Install cargo-udeps
         uses: baptiste0928/cargo-install@v2.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
         with:
-          toolchain: "1.87.0"
+          toolchain: "nightly"
           components: "miri"
 
       - name: Run tests


### PR DESCRIPTION
# Objective

Specify the Rust toolchain version in the CI workflows so that unrelated issues don't pop up in PRs.

# Solution

Replace all instances of `toolchain: "nightly"` with `toolchain: "1.89.0"`