### PR TITLE
Fix Publish Website Workflow

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -54,7 +54,7 @@ jobs:
             echo "::warning title=Invalid file permissions automatically fixed::$line"
           done
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./website/public
 


### PR DESCRIPTION
# Objective

Fix the build error in the Publish Website workflow.

The error message:
`Missing download info for actions/upload-artifact@v3`

# Solution

Update the `upload-pages-artifact` version from `v2` to `v3`