### PR TITLE
support for raw frames in PacketEncoder

### DIFF
--- a/crates/valence_protocol/src/decode.rs
+++ b/crates/valence_protocol/src/decode.rs
@@ -15,13 +15,13 @@ type Cipher = cfb8::Decryptor<aes::Aes128>;
 
 #[derive(Default)]
 pub struct PacketDecoder {
-    buf: BytesMut,
+    pub buf: BytesMut,
     #[cfg(feature = "compression")]
-    decompress_buf: BytesMut,
+    pub decompress_buf: BytesMut,
     #[cfg(feature = "compression")]
-    threshold: CompressionThreshold,
+    pub threshold: CompressionThreshold,
     #[cfg(feature = "encryption")]
-    cipher: Option<Cipher>,
+    pub cipher: Option<Cipher>,
 }
 
 impl PacketDecoder {

--- a/crates/valence_protocol/src/encode.rs
+++ b/crates/valence_protocol/src/encode.rs
@@ -18,13 +18,13 @@ type Cipher = cfb8::Encryptor<aes::Aes128>;
 
 #[derive(Default)]
 pub struct PacketEncoder {
-    buf: BytesMut,
+    pub buf: BytesMut,
     #[cfg(feature = "compression")]
-    compress_buf: Vec<u8>,
+    pub compress_buf: Vec<u8>,
     #[cfg(feature = "compression")]
-    threshold: CompressionThreshold,
+    pub threshold: CompressionThreshold,
     #[cfg(feature = "encryption")]
-    cipher: Option<Cipher>,
+    pub cipher: Option<Cipher>,
 }
 
 impl PacketEncoder {
@@ -42,83 +42,83 @@ impl PacketEncoder {
     ///     adding a data length varint after the packet length, if compression is enabled
     ///     compressing the packet, if compression is enabled
     pub fn enframe_from(&mut self, from: usize) -> anyhow::Result<()> {
-		let data_len = self.buf.len() - from;
+        let data_len = self.buf.len() - from;
 
-		#[cfg(feature = "compression")]
-		if self.threshold.0 >= 0 {
-			use std::io::Read;
+        #[cfg(feature = "compression")]
+        if self.threshold.0 >= 0 {
+            use std::io::Read;
 
-			use flate2::bufread::ZlibEncoder;
-			use flate2::Compression;
+            use flate2::bufread::ZlibEncoder;
+            use flate2::Compression;
 
-			if data_len > self.threshold.0 as usize {
-				let mut z = ZlibEncoder::new(&self.buf[from..], Compression::new(4));
+            if data_len > self.threshold.0 as usize {
+                let mut z = ZlibEncoder::new(&self.buf[from..], Compression::new(4));
 
-				self.compress_buf.clear();
+                self.compress_buf.clear();
 
-				let data_len_size = VarInt(data_len as i32).written_size();
+                let data_len_size = VarInt(data_len as i32).written_size();
 
-				let packet_len = data_len_size + z.read_to_end(&mut self.compress_buf)?;
+                let packet_len = data_len_size + z.read_to_end(&mut self.compress_buf)?;
 
-				ensure!(
-					packet_len <= MAX_PACKET_SIZE as usize,
-					"packet exceeds maximum length"
-				);
+                ensure!(
+                    packet_len <= MAX_PACKET_SIZE as usize,
+                    "packet exceeds maximum length"
+                );
 
-				drop(z);
+                drop(z);
 
-				self.buf.truncate(from);
+                self.buf.truncate(from);
 
-				let mut writer = (&mut self.buf).writer();
+                let mut writer = (&mut self.buf).writer();
 
-				VarInt(packet_len as i32).encode(&mut writer)?;
-				VarInt(data_len as i32).encode(&mut writer)?;
-				self.buf.extend_from_slice(&self.compress_buf);
-			} else {
-				let data_len_size = 1;
-				let packet_len = data_len_size + data_len;
+                VarInt(packet_len as i32).encode(&mut writer)?;
+                VarInt(data_len as i32).encode(&mut writer)?;
+                self.buf.extend_from_slice(&self.compress_buf);
+            } else {
+                let data_len_size = 1;
+                let packet_len = data_len_size + data_len;
 
-				ensure!(
-					packet_len <= MAX_PACKET_SIZE as usize,
-					"packet exceeds maximum length"
-				);
+                ensure!(
+                    packet_len <= MAX_PACKET_SIZE as usize,
+                    "packet exceeds maximum length"
+                );
 
-				let packet_len_size = VarInt(packet_len as i32).written_size();
+                let packet_len_size = VarInt(packet_len as i32).written_size();
 
-				let data_prefix_len = packet_len_size + data_len_size;
+                let data_prefix_len = packet_len_size + data_len_size;
 
-				self.buf.put_bytes(0, data_prefix_len);
-				self.buf
-					.copy_within(from..from + data_len, from + data_prefix_len);
+                self.buf.put_bytes(0, data_prefix_len);
+                self.buf
+                    .copy_within(from..from + data_len, from + data_prefix_len);
 
-				let mut front = &mut self.buf[from..];
+                let mut front = &mut self.buf[from..];
 
-				VarInt(packet_len as i32).encode(&mut front)?;
-				// Zero for no compression on this packet.
-				VarInt(0).encode(front)?;
-			}
+                VarInt(packet_len as i32).encode(&mut front)?;
+                // Zero for no compression on this packet.
+                VarInt(0).encode(front)?;
+            }
 
-			return Ok(());
-		}
+            return Ok(());
+        }
 
-		let packet_len = data_len;
+        let packet_len = data_len;
 
-		ensure!(
-			packet_len <= MAX_PACKET_SIZE as usize,
-			"packet exceeds maximum length"
-		);
+        ensure!(
+            packet_len <= MAX_PACKET_SIZE as usize,
+            "packet exceeds maximum length"
+        );
 
-		let packet_len_size = VarInt(packet_len as i32).written_size();
+        let packet_len_size = VarInt(packet_len as i32).written_size();
 
-		self.buf.put_bytes(0, packet_len_size);
-		self.buf
-			.copy_within(from..from + data_len, from + packet_len_size);
+        self.buf.put_bytes(0, packet_len_size);
+        self.buf
+            .copy_within(from..from + data_len, from + packet_len_size);
 
-		let front = &mut self.buf[from..];
-		VarInt(packet_len as i32).encode(front)?;
+        let front = &mut self.buf[from..];
+        VarInt(packet_len as i32).encode(front)?;
 
-		Ok(())
-	}
+        Ok(())
+    }
 
     pub fn prepend_frame<P>(&mut self, frame: &[u8]) -> anyhow::Result<()>
     where
@@ -161,24 +161,24 @@ impl PacketEncoder {
 
         Ok(())
     }
-	
-	pub fn append_frame(&mut self, frame: &[u8]) -> anyhow::Result<()> {
-	    let start_len = self.buf.len();
+    
+    pub fn append_frame(&mut self, frame: &[u8]) -> anyhow::Result<()> {
+        let start_len = self.buf.len();
         self.append_bytes(frame);
-	    self.enframe_from(start_len)?;
-	    Ok(())
-	}
-	
-	#[allow(clippy::needless_borrows_for_generic_args)]
-	pub fn append_packet<P>(&mut self, pkt: &P) -> anyhow::Result<()>
-	where
-		P: Packet + Encode,
-	{
-		let start_len = self.buf.len();
-		pkt.encode_with_id((&mut self.buf).writer())?;
-		self.enframe_from(start_len)?;
-		Ok(())
-	}
+        self.enframe_from(start_len)?;
+        Ok(())
+    }
+    
+    #[allow(clippy::needless_borrows_for_generic_args)]
+    pub fn append_packet<P>(&mut self, pkt: &P) -> anyhow::Result<()>
+    where
+        P: Packet + Encode,
+    {
+        let start_len = self.buf.len();
+        pkt.encode_with_id((&mut self.buf).writer())?;
+        self.enframe_from(start_len)?;
+        Ok(())
+    }
 
     /// Takes all the packets written so far and encrypts them if encryption is
     /// enabled.

--- a/crates/valence_protocol/src/encode.rs
+++ b/crates/valence_protocol/src/encode.rs
@@ -41,7 +41,7 @@ impl PacketEncoder {
     ///     adding a packet length varint to the start of the frame
     ///     adding a data length varint after the packet length, if compression is enabled
     ///     compressing the packet, if compression is enabled
-    fn enframe_from(&mut self, from: usize) -> anyhow::Result<()> {
+    pub fn enframe_from(&mut self, from: usize) -> anyhow::Result<()> {
 		let data_len = self.buf.len() - from;
 
 		#[cfg(feature = "compression")]

--- a/crates/valence_protocol/src/encode.rs
+++ b/crates/valence_protocol/src/encode.rs
@@ -37,6 +37,110 @@ impl PacketEncoder {
         self.buf.extend_from_slice(bytes)
     }
 
+    /// frames the bytes in a range from `from` to the end of the buffer, framing is:
+    ///     adding a packet length varint to the start of the frame
+    ///     adding a data length varint after the packet length, if compression is enabled
+    ///     compressing the packet, if compression is enabled
+    fn enframe_from(&mut self, from: usize) -> anyhow::Result<()> {
+		let data_len = self.buf.len() - from;
+
+		#[cfg(feature = "compression")]
+		if self.threshold.0 >= 0 {
+			use std::io::Read;
+
+			use flate2::bufread::ZlibEncoder;
+			use flate2::Compression;
+
+			if data_len > self.threshold.0 as usize {
+				let mut z = ZlibEncoder::new(&self.buf[from..], Compression::new(4));
+
+				self.compress_buf.clear();
+
+				let data_len_size = VarInt(data_len as i32).written_size();
+
+				let packet_len = data_len_size + z.read_to_end(&mut self.compress_buf)?;
+
+				ensure!(
+					packet_len <= MAX_PACKET_SIZE as usize,
+					"packet exceeds maximum length"
+				);
+
+				drop(z);
+
+				self.buf.truncate(from);
+
+				let mut writer = (&mut self.buf).writer();
+
+				VarInt(packet_len as i32).encode(&mut writer)?;
+				VarInt(data_len as i32).encode(&mut writer)?;
+				self.buf.extend_from_slice(&self.compress_buf);
+			} else {
+				let data_len_size = 1;
+				let packet_len = data_len_size + data_len;
+
+				ensure!(
+					packet_len <= MAX_PACKET_SIZE as usize,
+					"packet exceeds maximum length"
+				);
+
+				let packet_len_size = VarInt(packet_len as i32).written_size();
+
+				let data_prefix_len = packet_len_size + data_len_size;
+
+				self.buf.put_bytes(0, data_prefix_len);
+				self.buf
+					.copy_within(from..from + data_len, from + data_prefix_len);
+
+				let mut front = &mut self.buf[from..];
+
+				VarInt(packet_len as i32).encode(&mut front)?;
+				// Zero for no compression on this packet.
+				VarInt(0).encode(front)?;
+			}
+
+			return Ok(());
+		}
+
+		let packet_len = data_len;
+
+		ensure!(
+			packet_len <= MAX_PACKET_SIZE as usize,
+			"packet exceeds maximum length"
+		);
+
+		let packet_len_size = VarInt(packet_len as i32).written_size();
+
+		self.buf.put_bytes(0, packet_len_size);
+		self.buf
+			.copy_within(from..from + data_len, from + packet_len_size);
+
+		let front = &mut self.buf[from..];
+		VarInt(packet_len as i32).encode(front)?;
+
+		Ok(())
+	}
+
+    pub fn prepend_frame<P>(&mut self, frame: &[u8]) -> anyhow::Result<()>
+    where
+        P: Packet + Encode,
+    {
+        let start_len = self.buf.len();
+        self.append_frame(frame)?;
+
+        let end_len = self.buf.len();
+        let total_packet_len = end_len - start_len;
+
+        // 1) Move everything back by the length of the packet.
+        // 2) Move the packet to the new space at the front.
+        // 3) Truncate the old packet away.
+        self.buf.put_bytes(0, total_packet_len);
+        self.buf.copy_within(..end_len, total_packet_len);
+        self.buf.copy_within(total_packet_len + start_len.., 0);
+        self.buf.truncate(end_len);
+
+        Ok(())
+    }
+
     pub fn prepend_packet<P>(&mut self, pkt: &P) -> anyhow::Result<()>
     where
         P: Packet + Encode,
@@ -57,93 +161,24 @@ impl PacketEncoder {
 
         Ok(())
     }
-
-    #[allow(clippy::needless_borrows_for_generic_args)]
-    pub fn append_packet<P>(&mut self, pkt: &P) -> anyhow::Result<()>
-    where
-        P: Packet + Encode,
-    {
-        let start_len = self.buf.len();
-
-        pkt.encode_with_id((&mut self.buf).writer())?;
-
-        let data_len = self.buf.len() - start_len;
-
-        #[cfg(feature = "compression")]
-        if self.threshold.0 >= 0 {
-            use std::io::Read;
-
-            use flate2::bufread::ZlibEncoder;
-            use flate2::Compression;
-
-            if data_len > self.threshold.0 as usize {
-                let mut z = ZlibEncoder::new(&self.buf[start_len..], Compression::new(4));
-
-                self.compress_buf.clear();
-
-                let data_len_size = VarInt(data_len as i32).written_size();
-
-                let packet_len = data_len_size + z.read_to_end(&mut self.compress_buf)?;
-
-                ensure!(
-                    packet_len <= MAX_PACKET_SIZE as usize,
-                    "packet exceeds maximum length"
-                );
-
-                drop(z);
-
-                self.buf.truncate(start_len);
-
-                let mut writer = (&mut self.buf).writer();
-
-                VarInt(packet_len as i32).encode(&mut writer)?;
-                VarInt(data_len as i32).encode(&mut writer)?;
-                self.buf.extend_from_slice(&self.compress_buf);
-            } else {
-                let data_len_size = 1;
-                let packet_len = data_len_size + data_len;
-
-                ensure!(
-                    packet_len <= MAX_PACKET_SIZE as usize,
-                    "packet exceeds maximum length"
-                );
-
-                let packet_len_size = VarInt(packet_len as i32).written_size();
-
-                let data_prefix_len = packet_len_size + data_len_size;
-
-                self.buf.put_bytes(0, data_prefix_len);
-                self.buf
-                    .copy_within(start_len..start_len + data_len, start_len + data_prefix_len);
-
-                let mut front = &mut self.buf[start_len..];
-
-                VarInt(packet_len as i32).encode(&mut front)?;
-                // Zero for no compression on this packet.
-                VarInt(0).encode(front)?;
-            }
-
-            return Ok(());
-        }
-
-        let packet_len = data_len;
-
-        ensure!(
-            packet_len <= MAX_PACKET_SIZE as usize,
-            "packet exceeds maximum length"
-        );
-
-        let packet_len_size = VarInt(packet_len as i32).written_size();
-
-        self.buf.put_bytes(0, packet_len_size);
-        self.buf
-            .copy_within(start_len..start_len + data_len, start_len + packet_len_size);
-
-        let front = &mut self.buf[start_len..];
-        VarInt(packet_len as i32).encode(front)?;
-
-        Ok(())
-    }
+	
+	pub fn append_frame(&mut self, frame: &[u8]) -> anyhow::Result<()> {
+	    let start_len = self.buf.len();
+        self.append_bytes(frame);
+	    self.enframe_from(start_len)?;
+	    Ok(())
+	}
+	
+	#[allow(clippy::needless_borrows_for_generic_args)]
+	pub fn append_packet<P>(&mut self, pkt: &P) -> anyhow::Result<()>
+	where
+		P: Packet + Encode,
+	{
+		let start_len = self.buf.len();
+		pkt.encode_with_id((&mut self.buf).writer())?;
+		self.enframe_from(start_len)?;
+		Ok(())
+	}
 
     /// Takes all the packets written so far and encrypts them if encryption is
     /// enabled.


### PR DESCRIPTION
# Objective

its not possible to push a frame to the `PacketEncoder` if its not `Packet + Encode`, this means that if i have a raw frame i can't push it because its not deserialized, so i cant use `PacketEncoder` to compress/encrypt my raw packets

# Solution

i added `enframe_from` method, which enframes a rightmost portion of the buffer which includes adding a packet length varint, a data length varint and compressing, this was already done internally by the `append_packet` method but now its a method so we can re-use this logic, and of course `append_frame` and `prepend_frame` methods
