### PR TITLE
remove multilingual field

### DIFF
--- a/website/book.toml
+++ b/website/book.toml
@@ -1,6 +1,5 @@
 [book]
 language = "en"
-multilingual = false
 src = "book"
 title = "Valence Documentation"
 


### PR DESCRIPTION
# Objective

- mdbook removed the multilingual field in [v0.5.0](https://github.com/rust-lang/mdBook/blob/master/CHANGELOG.md#mdbook-050), meaning that websites with it in their `book.toml` will fail to build

# Solution

- simply removed it, simple enough change that it got to build

(also fyi as per #701, seems like the domain https://valence.rs got taken over, so existing link on the project no longer works, encountered this issue because i was trying to build the book myself)
