### PR TITLE
Update lru version to 0.16.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ image = "0.25.2"
 indexmap = "2.5.0"
 itertools = "0.13.0"
 java_string = { path = "crates/java_string", version = "0.1.2" }
-lru = "0.12.4"
+lru = "0.16.3"
 noise = "0.9.0"
 num = "0.4.3"
 num-bigint = "0.4.6"


### PR DESCRIPTION
# Objective

Fixes the `GHSA-rhfx-m35p-ff5j` vulnerability

# Solution

Updated the `lru` version to `0.16.3`
